### PR TITLE
test(retriever): ORA-176 regression tests for vector search embed_query contract

### DIFF
--- a/knowledge-base/qa/evaluation-reports/ORA-185-smoke-test-ora-171-multimodal-depends-fix.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-185-smoke-test-ora-171-multimodal-depends-fix.md
@@ -1,0 +1,93 @@
+---
+title: "ORA-185 — Smoke Test: ORA-171 Multimodal verify_graph_access Bug Fix"
+author: QA Evaluation Engineer
+date: 2026-04-08
+status: passed
+source: fix/phase-1/lead-backend/ora-171-multimodal-depends-fix
+target: ORA-171 — multimodal endpoint calls verify_graph_access directly
+---
+
+# ORA-185 — Smoke Test Report: ORA-171 Multimodal `verify_graph_access` Bug Fix
+
+## Summary
+
+**Result: PASSED** ✅
+
+All acceptance criteria met. The fix converts direct `verify_graph_access()` calls to `Depends(verify_graph_write_access)` in both multimodal endpoints, enabling FastAPI's dependency injection to function correctly in tests.
+
+## Branch Validated
+
+`fix/phase-1/lead-backend/ora-171-multimodal-depends-fix`
+Commit: `abc9bf6 fix(multimodal): convert direct verify_graph_access calls to Depends`
+
+## Checklist
+
+| # | Check | Result |
+|---|---|---|
+| 1 | Integration tests: 11/11 pass | ✅ PASS |
+| 2 | Was 2/11 before fix, now 11/11 | ✅ CONFIRMED |
+| 3 | No unit test regressions introduced | ✅ NO REGRESSION |
+| 4 | Cross-tenant isolation: 403 returned correctly | ✅ PASS |
+| 5 | CI green on branch | ⚠️ CI INFRASTRUCTURE BLOCKED (see below) |
+
+## Integration Test Results
+
+```
+tests/integration/test_multimodal_api.py::test_ingest_document_pdf_success        PASSED
+tests/integration/test_multimodal_api.py::test_ingest_image_png_success           PASSED
+tests/integration/test_multimodal_api.py::test_ingest_document_too_large          PASSED
+tests/integration/test_multimodal_api.py::test_ingest_image_too_large             PASSED
+tests/integration/test_multimodal_api.py::test_ingest_document_invalid_mime       PASSED
+tests/integration/test_multimodal_api.py::test_ingest_image_invalid_mime          PASSED
+tests/integration/test_multimodal_api.py::test_ingest_document_missing_upload_dir PASSED
+tests/integration/test_multimodal_api.py::test_ingest_document_neo4j_unavailable  PASSED
+tests/integration/test_multimodal_api.py::test_ingest_image_neo4j_unavailable     PASSED
+tests/integration/test_multimodal_api.py::test_ingest_document_cross_tenant_denied PASSED
+tests/integration/test_multimodal_api.py::test_ingest_image_cross_tenant_denied   PASSED
+
+11 passed in 0.79s
+```
+
+Command: `cd knowledge-graph-builder && PYTHONPATH=. pytest tests/integration/test_multimodal_api.py -m integration -v`
+
+## Unit Test Regression Check
+
+- **Branch (ORA-171 fix):** 673 passed, 33 failed
+- **`develop` baseline:** 673 passed, 33 failed
+- **Delta: 0 regressions**
+
+The 33 pre-existing failures are tracked separately and are NOT caused by this fix. Known failing suites:
+- `test_ora138_smoke.py` — temporal filter logic (pre-existing, ORA-138 related)
+- `test_service_accounts.py` — coroutine attribute errors (pre-existing)
+- `test_rate_limiting.py` — IP isolation test (pre-existing)
+- `test_pipeline_service.py` — approx() usage issue (pre-existing)
+
+## Cross-Tenant Isolation Verification
+
+`test_ingest_document_cross_tenant_denied` and `test_ingest_image_cross_tenant_denied` both return **HTTP 403** as expected when a user attempts to ingest into a graph owned by another user. The `Depends(verify_graph_write_access)` injection correctly routes through the DI override in tests.
+
+## Root Cause — What Was Fixed
+
+**Before (broken):**
+```python
+# multimodal.py — direct function call, bypasses DI overrides
+await verify_graph_access(str(graph_id), "write", user_id)
+```
+
+**After (fixed):**
+```python
+# multimodal.py — injected via Depends, DI overrides work correctly
+async def ingest_document(
+    ...
+    _access: str = Depends(verify_graph_write_access),
+    ...
+):
+```
+
+## CI Status
+
+GitHub Actions CI runs are failing across **all** branches due to 192 ruff lint errors (tracked in `fix/ci/lead-backend/ruff-lint-errors`). This is a CI infrastructure issue unrelated to ORA-171. Local test execution confirms the fix is correct.
+
+## Verdict
+
+**QA GATE: PASSED** — the ORA-171 fix is correct and may be merged to `develop`. The CI infrastructure blocker (ruff lint) should be resolved independently.

--- a/knowledge-graph-builder/tests/unit/test_vector_search_regression.py
+++ b/knowledge-graph-builder/tests/unit/test_vector_search_regression.py
@@ -1,0 +1,123 @@
+"""
+Regression tests for ORA-103: vector search embed_query call contract.
+
+Verifies that the vector search service:
+1. Calls embed_query with the user's query_text argument (not a modified value)
+2. Passes the resulting vector to the Neo4j query (not None or empty)
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.retriever_service import RetrievalService
+
+GRAPH_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
+QUERY_TEXT = "what are the key concepts in this knowledge graph?"
+EXPECTED_VECTOR = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+
+class _FakeVectorRetriever:
+    """
+    Test double for neo4j_graphrag VectorRetriever.
+
+    Faithfully simulates the critical behaviour of the real class:
+      - calls embedder.embed_query(query_text) when query_text is provided
+      - passes the resulting vector to driver.execute_query as query_vector
+
+    This lets unit tests assert on embed_query + Neo4j call without requiring
+    a live Neo4j connection or a real neo4j.Driver instance.
+    """
+
+    VERIFY_NEO4J_VERSION = False
+
+    def __init__(
+        self, driver, index_name, embedder=None, return_properties=None, **kwargs
+    ):
+        self.driver = driver
+        self.index_name = index_name
+        self.embedder = embedder
+        self.return_properties = return_properties or []
+
+    def get_search_results(self, query_text=None, query_vector=None, top_k=5, **kwargs):
+        if query_text is not None and self.embedder is not None:
+            query_vector = self.embedder.embed_query(query_text)
+        self.driver.execute_query(
+            "CALL db.index.vector.queryNodes($index, $k, $vector) YIELD node, score",
+            {"query_vector": query_vector, "index": self.index_name, "k": top_k},
+        )
+        return MagicMock(items=[])
+
+
+class TestVectorSearchRegressionORA103:
+    """Regression tests for ORA-103: vector search embed_query contract."""
+
+    @pytest.fixture
+    def mock_embedder(self):
+        embedder = MagicMock()
+        embedder.embed_query.return_value = EXPECTED_VECTOR
+        return embedder
+
+    @pytest.fixture
+    def mock_driver(self):
+        return MagicMock()
+
+    @pytest.mark.unit
+    async def test_vector_search_calls_embed_query_with_query_text(
+        self, mock_embedder, mock_driver
+    ):
+        """Verify similarity_search_entities calls embed_query with the query_text argument.
+
+        Regression for ORA-103: ensures embed_query receives the user's actual query
+        text, not an empty string, None, or any pre-transformed value.
+        """
+        with (
+            patch(
+                "app.components.multi_tenant_components.VectorRetriever",
+                _FakeVectorRetriever,
+            ),
+            patch(
+                "neo4j_graphrag.retrievers.base.get_version",
+                return_value=((5, 23, 0), False, False),
+            ),
+        ):
+            service = RetrievalService(driver=mock_driver, embedder=mock_embedder)
+            await service.similarity_search_entities(QUERY_TEXT, GRAPH_ID)
+
+        mock_embedder.embed_query.assert_called_once_with(QUERY_TEXT)
+
+    @pytest.mark.unit
+    async def test_vector_search_passes_real_vector_to_neo4j(
+        self, mock_embedder, mock_driver
+    ):
+        """Verify the embedded vector is passed to the Neo4j query, not None or empty.
+
+        Regression for ORA-103: ensures the vector returned by embed_query is actually
+        forwarded to the Neo4j vector index query rather than being discarded.
+        """
+        with (
+            patch(
+                "app.components.multi_tenant_components.VectorRetriever",
+                _FakeVectorRetriever,
+            ),
+            patch(
+                "neo4j_graphrag.retrievers.base.get_version",
+                return_value=((5, 23, 0), False, False),
+            ),
+        ):
+            service = RetrievalService(driver=mock_driver, embedder=mock_embedder)
+            await service.similarity_search_entities(QUERY_TEXT, GRAPH_ID)
+
+        assert mock_driver.execute_query.called, "No Neo4j execute_query call was made"
+
+        # The EXPECTED_VECTOR must appear as query_vector in at least one call
+        vector_found = any(
+            isinstance(call_args.args[1], dict)
+            and call_args.args[1].get("query_vector") == EXPECTED_VECTOR
+            for call_args in mock_driver.execute_query.call_args_list
+        )
+        assert vector_found, (
+            f"Expected query_vector={EXPECTED_VECTOR} was not passed to Neo4j. "
+            f"Actual execute_query calls: {mock_driver.execute_query.call_args_list}"
+        )


### PR DESCRIPTION
## Summary

- Adds two regression tests that were specified as acceptance criteria on ORA-103 and ORA-157 but never written
- `test_vector_search_calls_embed_query_with_query_text` — verifies `RetrievalService.similarity_search_entities` passes the user's query text directly to `embedder.embed_query`
- `test_vector_search_passes_real_vector_to_neo4j` — verifies the vector from `embed_query` is forwarded to Neo4j as `query_vector` (not discarded)

## Test Design

Uses `_FakeVectorRetriever` (a lightweight test double) to simulate the `embed_query → execute_query` contract of the real `VectorRetriever` without requiring a live Neo4j connection or a real `neo4j.Driver` instance (which has Pydantic validation). Both tests have `@pytest.mark.unit` and run in ~10ms.

## Test plan

- [x] Both tests collected by `pytest tests/unit/test_vector_search_regression.py --collect-only`
- [x] Both tests pass: `pytest tests/unit/test_vector_search_regression.py -v`
- [x] No new collection errors: `pytest tests/unit/ -q --tb=no` (630 pass, pre-existing failures unchanged)
- [x] `black`, `isort`, `ruff` clean

## References

- Closes [ORA-176](/ORA/issues/ORA-176)
- Regression for [ORA-103](/ORA/issues/ORA-103)
- Surface gap found in [ORA-158](/ORA/issues/ORA-158)

🤖 Generated with [Claude Code](https://claude.com/claude-code)