### PR TITLE
fix(docker): replace knowledge-graph-worker healthcheck with celery inspect ping [ORA-164]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,12 @@ services:
     command: celery -A app.services.background_jobs.celery_app worker --loglevel=info
     env_file:
       - ./knowledge-graph-builder/.env
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A app.services.background_jobs.celery_app inspect ping -d celery@$$HOSTNAME || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       neo4j:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Fixes the `knowledge-graph-worker` container being permanently `unhealthy` due to the Dockerfile healthcheck curling `localhost:8000/api/v1/health` — an HTTP endpoint that does not exist on Celery workers.

## Root Cause

The `knowledge-graph-worker` service shares the same `Dockerfile` as `knowledge-graph-builder`. The shared Dockerfile healthcheck targets the FastAPI HTTP server. Celery workers have no HTTP server, so every health probe fails.

## Fix

Added a `healthcheck` override in `docker-compose.yml` under the `knowledge-graph-worker` service:

```yaml
healthcheck:
  test: ["CMD-SHELL", "celery -A app.services.background_jobs.celery_app inspect ping -d celery@$$HOSTNAME || exit 1"]
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 30s
```

`$$HOSTNAME` uses double-dollar to prevent docker-compose variable interpolation.

## Impact

- Worker container will correctly report `healthy` once Celery is ready
- Eliminates false-positive monitoring alerts
- Unblocks future `condition: service_healthy` dependencies on the worker

## References

- Discovered in ORA-96 full-stack deployment validation
- Related task: ORA-164

## Test Plan

- [ ] `docker-compose up knowledge-graph-worker` → container transitions to `healthy`
- [ ] Worker logs show `celery@... ready` before healthcheck passes
- [ ] No regression on `knowledge-graph-builder` healthcheck (still uses HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)