### PR TITLE
fix(federation): ORA-217 — fix invalid CALL {} UNION ALL CALL {} Cypher for Neo4j 5.23+

### DIFF
--- a/knowledge-base/qa/evaluation-reports/ORA-108-federation-403-smoke-test.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-108-federation-403-smoke-test.md
@@ -1,0 +1,121 @@
+---
+title: "QA Smoke Test Report — ORA-108: Federation 403 Fix (ORA-102)"
+author: "QA Evaluation Engineer"
+date: "2026-04-09"
+status: "complete"
+source: "ORA-102 — g.owner_user_id fix in federation_service.py"
+target: "POST /api/v1/graphs/federate/query"
+branch_tested: "develop (commit ed08ea6, post 67bd406 fix)"
+---
+
+# QA Smoke Test Report — ORA-108
+
+**Task:** [ORA-108](/ORA/issues/ORA-108) — Smoke test for ORA-102 federation 403 fix
+**Parent bug:** [ORA-102](/ORA/issues/ORA-102)
+**Test date:** 2026-04-09
+**Branch tested:** `develop` (includes commit `67bd406` — `fix(federation): read g.owner_user_id instead of g.user_id`)
+**Environment:** Docker Compose stack (auth-service:8000, knowledge-graph-builder:8003, neo4j:7687)
+
+---
+
+## Unit Test Verification — PASSED (2/2)
+
+Both named regression tests from the task description pass:
+
+| Test | Result |
+|---|---|
+| `test_validate_uses_owner_user_id_not_user_id` | ✅ PASSED |
+| `test_validate_matches_system_namespace` | ✅ PASSED |
+
+Run inside container: `pytest tests/unit/test_federation_service.py::test_validate_uses_owner_user_id_not_user_id tests/unit/test_federation_service.py::test_validate_matches_system_namespace` — **2 passed in 0.02s**
+
+---
+
+## ORA-102 Fix Verification — CONFIRMED
+
+**What the fix changed:**
+- `MATCH (g:Graph)` → `MATCH (g:Graph {namespace: "__system__"})`
+- `g.user_id AS user_id` → `g.owner_user_id AS user_id`
+
+**Why:** `g.user_id` is always `None` on ReBAC-managed Graph nodes (rebac_service stores ownership in `g.owner_user_id`). The stale property caused every user-path federated query to fail the ownership check and raise 403.
+
+**Evidence of fix working:** Same-user federatable query no longer receives 403. It now passes validation and proceeds to the entity search phase (where a separate secondary bug produces a 500 — see Bug Filing below). The key behavioral change is confirmed: **the false 403 is gone**.
+
+---
+
+## Live API Smoke Test Results
+
+Test graphs created directly in Neo4j (graph creation API blocked by secondary infrastructure bug — see below):
+
+| Graph ID | Owner | federatable | namespace |
+|---|---|---|---|
+| `qa-smoke-graph-a` | user1 | `true` | `__system__` |
+| `qa-smoke-graph-b` | user1 | `true` | `__system__` |
+| `qa-smoke-graph-c` | user1 | `false` | `__system__` |
+| `qa-smoke-graph-d-user2` | user2 | `true` | `__system__` |
+
+### Step 2-3: Same-user federatable query
+- **Request:** `POST /api/v1/api/v1/graphs/federate/query` with `graph_ids: [qa-smoke-graph-a, qa-smoke-graph-b]`
+- **Expected:** 200 OK
+- **Actual:** 500 Internal Server Error
+- **Root cause:** Validation passed (ORA-102 fix confirmed), but `_execute_entity_union` uses unsupported Cypher `CALL {} UNION ALL CALL {}` syntax — Neo4j 5.23 error: `"Query cannot conclude with CALL"`. **This is a separate bug (ORA-212), not ORA-102.**
+- **QA interpretation:** The ORA-102 fix is confirmed working (no false 403). The 500 is unrelated to the auth fix.
+
+### Step 4: Entities from both graphs in results
+- **Status:** Blocked by Step 2-3 Cypher bug (ORA-212)
+
+### Step 5: Cross-tenant isolation — ✅ PASSED
+- **Request:** user1 queries `[qa-smoke-graph-a, qa-smoke-graph-d-user2]`
+- **Expected:** 403 Forbidden
+- **Actual:** `403` — `"Access denied — no accessible graphs in federation request"`
+- **Result:** ✅ Cross-tenant block preserved
+
+### Step 6: Non-federatable graph rejection — ✅ PASSED
+- **Request:** user1 queries `[qa-smoke-graph-a, qa-smoke-graph-c]` (graph-c has `federatable=false`)
+- **Expected:** 400 Bad Request
+- **Actual:** `400` — `"One or more requested graphs are not enabled for federation"`
+- **Result:** ✅ Non-federatable rejection preserved
+
+---
+
+## QA Gate Summary
+
+| Gate | Result | Notes |
+|---|---|---|
+| Named regression tests (2/2) | ✅ PASS | `test_validate_uses_owner_user_id_not_user_id` + `test_validate_matches_system_namespace` |
+| False 403 eliminated | ✅ PASS | Same-user federatable query passes validation |
+| Cross-tenant block (Step 5) | ✅ PASS | Returns 403 as required |
+| Non-federatable rejection (Step 6) | ✅ PASS | Returns 400 as required |
+| Full 200 OK with entities (Steps 3-4) | ⚠️ BLOCKED | Blocked by ORA-212 (Cypher UNION ALL syntax bug, separate from ORA-102) |
+
+**ORA-102 fix verdict: APPROVED** — the authentication/authorization fix is correct and all regression guards pass. The entity retrieval 500 is a separate pre-existing issue.
+
+---
+
+## Bugs Filed
+
+### ORA-212 (P1) — Federation entity search: invalid Cypher UNION ALL syntax
+- `_execute_entity_union` generates `CALL {} UNION ALL CALL {}` which is not valid in Neo4j 5.23
+- Error: `Query cannot conclude with CALL (must be a RETURN clause...)`
+- Blocks full federation entity retrieval but does NOT affect auth validation
+- **Assigned to:** Backend Engineering Lead for triage
+
+### ORA-XXX (P2) — `sync_driver` not initialized at startup
+- `main.py` lifespan only calls `connect_async()` — `connect_sync()` is never called
+- All endpoints using `sync_driver` (graph creation, etc.) return 503 on fresh container start
+- `POST /api/v1/graphs` returns `503 "Neo4j connection not available"` until a Celery job triggers `connect_sync()`
+- **Assigned to:** Backend Engineering Lead for triage
+
+### Build hygiene observation
+- The oraclous-data-studio repo was on `fix/phase-4/sr-backend/ora-106-sa-integration-tests` when Docker build ran
+- The ORA-102 fix only exists on `develop`
+- First build produced an image WITHOUT the fix — required branch switch to `develop` before rebuild
+- **Recommendation:** CI/CD should always build from `develop`; add branch guard to build scripts
+
+---
+
+## Infrastructure Notes
+
+- Rebuilt knowledge-graph-builder image from `develop` branch (commit `ed08ea6`)
+- auth-service was already rebuilt (27 min prior) with passlib/bcrypt fix (ORA-181)
+- All core services healthy at test time: neo4j ✅, postgres ✅, redis ✅, auth-service ✅

--- a/knowledge-graph-builder/app/services/federation_service.py
+++ b/knowledge-graph-builder/app/services/federation_service.py
@@ -268,30 +268,31 @@ class FederationService:
     ) -> list[dict[str, Any]]:
         """Build a UNION ALL Cypher query across all graph_ids and execute async.
 
-        Each CALL subquery is scoped to one graph_id, hitting the per-graph index.
+        Each UNION branch is scoped to one graph_id, hitting the per-graph index.
+        All branches are wrapped in a single outer CALL to satisfy Neo4j 5.23+
+        syntax: queries must not conclude with a CALL subquery (ORA-217 fix).
         """
         params: dict[str, Any] = {"search_term": search_term, "limit": max_per_graph}
 
-        subqueries: list[str] = []
+        branches: list[str] = []
         for i, gid in enumerate(graph_ids):
             param_key = f"gid_{i}"
             params[param_key] = gid
-            subqueries.append(
-                f"CALL {{\n"
+            branches.append(
                 f"  MATCH (e:__Entity__)\n"
                 f"  WHERE e.graph_id = ${param_key}\n"
                 f"    AND toLower(e.name) CONTAINS toLower($search_term)\n"
                 f"  RETURN elementId(e) AS entity_id,\n"
                 f"         e.name AS name,\n"
                 f"         coalesce(e.type, labels(e)[-1]) AS type,\n"
-                f"         ${param_key} AS source_graph_id\n"
-                f"  LIMIT $limit\n"
-                f"}}"
+                f"         e.graph_id AS source_graph_id\n"
+                f"  LIMIT $limit"
             )
 
+        union_body = "\n  UNION ALL\n".join(branches)
         cypher = (
-            "\nUNION ALL\n".join(subqueries)
-            + "\nRETURN entity_id, name, type, source_graph_id"
+            f"CALL {{\n{union_body}\n}}\n"
+            "RETURN entity_id, name, type, source_graph_id"
         )
 
         async with self._driver.session(database=self._database) as session:

--- a/knowledge-graph-builder/tests/unit/test_federation_service.py
+++ b/knowledge-graph-builder/tests/unit/test_federation_service.py
@@ -442,6 +442,86 @@ async def test_same_as_no_link_for_different_types():
     assert links == []
 
 
+# ─── ORA-217 regression: valid CALL { UNION ALL } syntax ─────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_entity_union_cypher_uses_single_outer_call():
+    """ORA-217 regression: generated Cypher must NOT use CALL {} UNION ALL CALL {}.
+
+    Neo4j 5.23+ rejects queries that conclude with a CALL subquery.
+    The fix wraps all UNION ALL branches in a single outer CALL block.
+    """
+    import inspect
+
+    source = inspect.getsource(FederationService._execute_entity_union)
+    # The old (broken) pattern had each branch wrapped as its own CALL
+    # joined at the top level: CALL{} UNION ALL CALL{}
+    # The fixed pattern has one outer CALL containing all branches.
+    # Verify the branch-building loop does NOT produce per-branch CALL wrappers.
+    assert (
+        'f"CALL {\\n"' not in source and "f'CALL {\\n'" not in source
+    ), "ORA-217 regression: branches must NOT be individually wrapped in CALL"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_entity_union_cypher_structure_single_call_wrapping():
+    """ORA-217: _execute_entity_union must emit CALL { <union branches> } RETURN."""
+    graph_ids = ["graph-x", "graph-y", "graph-z"]
+
+    captured_cypher: list[str] = []
+    captured_params: list[dict] = []
+
+    mock_result = AsyncMock()
+    mock_result.data = AsyncMock(return_value=[])
+
+    mock_session = MagicMock()
+
+    async def capture_run(cypher, params=None):
+        captured_cypher.append(cypher)
+        captured_params.append(params or {})
+        return mock_result
+
+    mock_session.run = capture_run
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    driver = MagicMock()
+    driver.session.return_value = mock_session
+
+    svc = FederationService(async_driver=driver)
+    await svc._execute_entity_union(
+        graph_ids=graph_ids, search_term="test", max_per_graph=10
+    )
+
+    assert len(captured_cypher) == 1, "Expected exactly one Cypher execution"
+    cypher = captured_cypher[0]
+
+    # Must start with a single outer CALL block
+    assert cypher.startswith("CALL {"), f"Cypher must start with 'CALL {{': {cypher!r}"
+
+    # Must have UNION ALL inside (not at the top level)
+    call_start = cypher.index("CALL {")
+    call_close = cypher.rindex("}")
+    inner_body = cypher[call_start + len("CALL {") : call_close]
+    assert (
+        "UNION ALL" in inner_body
+    ), f"UNION ALL must be inside the outer CALL block: {cypher!r}"
+
+    # Outer RETURN must follow the closing brace
+    tail = cypher[call_close + 1 :].strip()
+    assert tail.startswith(
+        "RETURN"
+    ), f"Query must conclude with RETURN after CALL block: {cypher!r}"
+
+    # All graph_id params parameterized
+    params = captured_params[0]
+    for i in range(len(graph_ids)):
+        assert f"gid_{i}" in params, f"Missing param gid_{i}"
+
+
 # ─── Pydantic schema validation tests ────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **Root cause:** `_execute_entity_union` generated top-level `CALL {} UNION ALL CALL {}` Cypher which Neo4j 5.23 rejects with `SyntaxError: Query cannot conclude with CALL`
- **Fix:** Restructure to wrap all UNION ALL branches inside a single outer `CALL { ... }` block — the valid Neo4j 5.23+ pattern
- **Also:** Replaced `$gid_N AS source_graph_id` with `e.graph_id AS source_graph_id` (safe: enforced by WHERE clause) to keep column names uniform across all UNION branches

## Before (broken)
```cypher
CALL { MATCH (e:__Entity__) WHERE e.graph_id = $gid_0 ... RETURN ... LIMIT $limit }
UNION ALL
CALL { MATCH (e:__Entity__) WHERE e.graph_id = $gid_1 ... RETURN ... LIMIT $limit }
RETURN entity_id, name, type, source_graph_id
```

## After (fixed)
```cypher
CALL {
  MATCH (e:__Entity__) WHERE e.graph_id = $gid_0 ... RETURN ... LIMIT $limit
  UNION ALL
  MATCH (e:__Entity__) WHERE e.graph_id = $gid_1 ... RETURN ... LIMIT $limit
}
RETURN entity_id, name, type, source_graph_id
```

## Changes

| File | Change |
|---|---|
| `app/services/federation_service.py` | Restructured `_execute_entity_union` to use single outer CALL |
| `tests/unit/test_federation_service.py` | Added 2 ORA-217 regression tests |

## Security Checklist
- [x] All Cypher queries parameterized (gid_0..N, search_term, limit)
- [x] graph_id filter on every query (WHERE e.graph_id = $gid_N per branch)
- [x] No GDS projections (N/A)
- [x] No info leakage in error responses

## Test plan
- [x] All 18 unit tests pass (`pytest tests/unit/test_federation_service.py`)
- [x] black, isort, ruff all clean
- [x] `test_entity_union_cypher_uses_single_outer_call` — verifies no per-branch CALL wrapping
- [x] `test_entity_union_cypher_structure_single_call_wrapping` — verifies emitted Cypher starts with `CALL {`, has UNION ALL inside the block, and concludes with `RETURN`
- [ ] Integration test against real Neo4j 5.23 (requires live Neo4j)

Closes [ORA-217](/ORA/issues/ORA-217). Unblocks Steps 3-4 of [ORA-108](/ORA/issues/ORA-108) smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)