### PR TITLE
[ORA-226] fix(auth): correct HTTP status codes — 201/409/401

### DIFF
--- a/auth-service/app/routes/auth_routes.py
+++ b/auth-service/app/routes/auth_routes.py
@@ -1,25 +1,24 @@
 import asyncio
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel
-from typing import Optional
 
-from app.core.dependencies import (
-    get_service_account_repository,
-    get_user_repository,
-    verify_internal_service,
-)
-from app.core.jwt_handler import create_service_account_token, verify_access_token
+from app.core.dependencies import (get_service_account_repository,
+                                   get_user_repository,
+                                   verify_internal_service)
+from app.core.jwt_handler import (create_service_account_token,
+                                  verify_access_token)
 from app.core.rate_limiter import enforce_key_prefix_rate_limit, limiter
 from app.schema import auth_schemas
 from app.services.auth_service import AuthService
 
-
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
 router = APIRouter()
 
-@router.post("/register/", response_model=auth_schemas.Token)
+
+@router.post("/register/", response_model=auth_schemas.Token, status_code=201)
 @limiter.limit("5/minute")
 async def register_user(user: auth_schemas.UserCreateWithEmail, request: Request):
     repository = await get_user_repository(request)
@@ -28,31 +27,44 @@ async def register_user(user: auth_schemas.UserCreateWithEmail, request: Request
     token_schema = await auth_service.create_user(user=user)
     return token_schema
 
+
 @router.post("/login/", response_model=auth_schemas.Token)
 @limiter.limit("10/minute")
 async def login_user(form_data: auth_schemas.UserLogin, request: Request):
     repository = await get_user_repository(request)
     auth_service = AuthService(repository)
-    token_schema = await auth_service.authenticate_user(email=form_data.email, password=form_data.password)
+    token_schema = await auth_service.authenticate_user(
+        email=form_data.email, password=form_data.password
+    )
     if not token_schema:
-        raise HTTPException(status_code=400, detail="Incorrect email/username or password")
+        raise HTTPException(
+            status_code=401, detail="Incorrect email/username or password"
+        )
     return token_schema
 
 
 @router.post("/refresh/", response_model=auth_schemas.Token)
 @limiter.limit("20/minute")
-async def refresh_token(refresh_token: auth_schemas.RefreshTokenRequest, request: Request):
+async def refresh_token(
+    refresh_token: auth_schemas.RefreshTokenRequest, request: Request
+):
     repository = await get_user_repository(request)
     auth_service = AuthService(repository)
 
     token_schema = await auth_service.verify_refresh_token(refresh_token.refresh_token)
     if not token_schema:
-        raise HTTPException(status_code=400, detail="Refresh Token is invalid or expired")
+        raise HTTPException(
+            status_code=400, detail="Refresh Token is invalid or expired"
+        )
     return token_schema
-    
+
 
 @router.post("/verify-email/")
-async def verify_email(email_verification_request: auth_schemas.EmailVerificationRequest, request: Request, token: str = Depends(oauth2_scheme)):
+async def verify_email(
+    email_verification_request: auth_schemas.EmailVerificationRequest,
+    request: Request,
+    token: str = Depends(oauth2_scheme),
+):
     print("Received token:", token)
     repository = await get_user_repository(request)
     auth_service = AuthService(repository)
@@ -60,10 +72,12 @@ async def verify_email(email_verification_request: auth_schemas.EmailVerificatio
     code = email_verification_request.code
     print("Verification code:", code)
     return await auth_service.verify_user_email(token, code)
-    
+
 
 @router.post("/resend-email-verification/")
-async def resend_email_verification(request: Request, token: str = Depends(oauth2_scheme)):
+async def resend_email_verification(
+    request: Request, token: str = Depends(oauth2_scheme)
+):
     repository = await get_user_repository(request)
     auth_service = AuthService(repository)
 
@@ -72,35 +86,54 @@ async def resend_email_verification(request: Request, token: str = Depends(oauth
 
 @router.post("/forgot-password/")
 @limiter.limit("5/minute")
-async def forgot_password(forget_password_req: auth_schemas.ForgotPasswordRequest, request: Request):
+async def forgot_password(
+    forget_password_req: auth_schemas.ForgotPasswordRequest, request: Request
+):
     repository = await get_user_repository(request)
     auth_service = AuthService(repository)
 
     return await auth_service.send_password_reset_email(email=forget_password_req.email)
 
+
 @router.post("/reset-password/")
 @limiter.limit("5/minute")
-async def reset_password(token: str, reset_password_req: auth_schemas.ResetPasswordRequest, request: Request):
+async def reset_password(
+    token: str, reset_password_req: auth_schemas.ResetPasswordRequest, request: Request
+):
     repository = await get_user_repository(request)
     auth_service = AuthService(repository)
 
-    return await auth_service.reset_password(token=token, new_password=reset_password_req.new_password)
+    return await auth_service.reset_password(
+        token=token, new_password=reset_password_req.new_password
+    )
+
 
 @router.post("/change-password/")
-async def change_password(change_password_req: auth_schemas.ChangePasswordRequest, request: Request, token: str = Depends(oauth2_scheme)):
+async def change_password(
+    change_password_req: auth_schemas.ChangePasswordRequest,
+    request: Request,
+    token: str = Depends(oauth2_scheme),
+):
     repository = await get_user_repository(request)
     auth_service = AuthService(repository)
 
     payload = await auth_service.verify_access_token(token)
     user_id = payload.get("sub")
     if user_id is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
 
     db_user = await repository.get_user_by_id(user_id)
     if not db_user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
 
-    return await auth_service.change_password(user=db_user, new_password=change_password_req.new_password)
+    return await auth_service.change_password(
+        user=db_user, new_password=change_password_req.new_password
+    )
+
 
 @router.get("/validate")
 async def validate_token(request: Request, token: str = Depends(oauth2_scheme)):
@@ -110,12 +143,17 @@ async def validate_token(request: Request, token: str = Depends(oauth2_scheme)):
     payload = await auth_service.verify_access_token(token)
     user_id = payload.get("sub")
     if user_id is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
 
     db_user = await repository.get_user_by_id(user_id)
     if not db_user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
     return payload
+
 
 @router.get("/me")
 async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)):
@@ -125,7 +163,9 @@ async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)
     sub = payload.get("sub")
 
     if not sub:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
 
     if principal_type == "service_account":
         # Verify the SA still has an active key (revocation check)
@@ -150,7 +190,9 @@ async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)
 
     db_user = await repository.get_user_by_id(sub)
     if not db_user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
 
     return {
         "id": str(db_user.id),
@@ -163,6 +205,7 @@ async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)
 
 
 # ── Service Account Endpoints ──────────────────────────────────────────────
+
 
 class ServiceTokenRequest(BaseModel):
     api_key: str
@@ -203,14 +246,17 @@ async def exchange_service_token(
     #
     # Retrieve stored metadata from the key record via SA lookup
     from sqlalchemy.future import select
+
     from app.models.service_account_model import AgentServiceAccountKey
 
     async with sa_repository.Session() as session:
         result = await session.execute(
-            select(AgentServiceAccountKey).where(
+            select(AgentServiceAccountKey)
+            .where(
                 AgentServiceAccountKey.service_account_id == sa_id,
                 AgentServiceAccountKey.status == "active",
-            ).limit(1)
+            )
+            .limit(1)
         )
         key_record = result.scalars().first()
 
@@ -229,6 +275,7 @@ async def exchange_service_token(
 
 # ── Internal endpoints (service-to-service, requires X-Internal-Key header) ─
 
+
 class CreateKeyRequest(BaseModel):
     service_account_id: str
     created_by_user_id: str
@@ -239,7 +286,7 @@ class CreateKeyRequest(BaseModel):
 
 class CreateKeyResponse(BaseModel):
     key_id: str
-    api_key: str       # raw key — shown only once
+    api_key: str  # raw key — shown only once
     key_prefix: str
 
 
@@ -273,7 +320,9 @@ async def internal_create_sa_key(
 
     # Persist tenant_id and home_graph_id on the key record for token exchange
     from sqlalchemy import update as sa_update
+
     from app.models.service_account_model import AgentServiceAccountKey
+
     async with sa_repository.Session() as session:
         await session.execute(
             sa_update(AgentServiceAccountKey)
@@ -292,7 +341,10 @@ async def internal_create_sa_key(
     )
 
 
-@router.delete("/internal/service-account-keys/{service_account_id}", response_model=RevokeKeysResponse)
+@router.delete(
+    "/internal/service-account-keys/{service_account_id}",
+    response_model=RevokeKeysResponse,
+)
 async def internal_revoke_sa_keys(
     service_account_id: str,
     request: Request,

--- a/auth-service/app/services/auth_service.py
+++ b/auth-service/app/services/auth_service.py
@@ -1,18 +1,21 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
 from fastapi import HTTPException, status
 from passlib.context import CryptContext
-from app.models.user_model import User
-from app.schema import auth_schemas
-from app.core.jwt_handler import create_access_token, verify_access_token, create_refresh_token, verify_refresh_token
-from datetime import datetime, timezone
-from datetime import timedelta
-from typing import Optional
-from app.repositories.user_repository import UserRepository
+
 from app.core.config import settings
-import logging
+from app.core.jwt_handler import (create_access_token, create_refresh_token,
+                                  verify_access_token, verify_refresh_token)
+from app.models.user_model import User
+from app.repositories.user_repository import UserRepository
+from app.schema import auth_schemas
 from app.services.email_service import send_email
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 logging.basicConfig(level=logging.DEBUG)
+
 
 class AuthService:
     def __init__(self, repository: UserRepository):
@@ -22,27 +25,47 @@ class AuthService:
         user = await self.repository.get_user_by_email(email)
         return user
 
-    async def create_user(self, user: auth_schemas.UserCreateWithEmail) -> auth_schemas.Token:
+    async def create_user(
+        self, user: auth_schemas.UserCreateWithEmail
+    ) -> auth_schemas.Token:
         db_user = await self.get_user_by_email(user.email)
         if db_user:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Email already registered"
+            )
         hashed_password = pwd_context.hash(user.password)
-        db_user = await self.repository.create_user_with_email(user.email, hashed_password)
-        
-        verification_code = await self.repository.set_new_verification_code(db_user.email)
+        db_user = await self.repository.create_user_with_email(
+            user.email, hashed_password
+        )
+
+        verification_code = await self.repository.set_new_verification_code(
+            db_user.email
+        )
 
         body = f"Your verification code is: {verification_code}"
         await send_email(db_user.email, "Oraclous Verification Code", body)
 
-        access_token, expires_in = await self.create_access_token(data={"sub": str(db_user.id), "email": db_user.email, "is_superuser": db_user.is_superuser})
-        refresh_token = await self.create_refresh_token(data={"sub": str(db_user.id), "email": db_user.email, "is_superuser": db_user.is_superuser})
+        access_token, expires_in = await self.create_access_token(
+            data={
+                "sub": str(db_user.id),
+                "email": db_user.email,
+                "is_superuser": db_user.is_superuser,
+            }
+        )
+        refresh_token = await self.create_refresh_token(
+            data={
+                "sub": str(db_user.id),
+                "email": db_user.email,
+                "is_superuser": db_user.is_superuser,
+            }
+        )
         token_schema = auth_schemas.Token(
             email=db_user.email,
             is_superuser=db_user.is_superuser,
             access_token=access_token,
             refresh_token=refresh_token,
             expires_in=expires_in,
-            token_type="bearer"
+            token_type="bearer",
         )
         return token_schema
 
@@ -51,24 +74,43 @@ class AuthService:
         if not db_user or not pwd_context.verify(password, db_user.password_hash):
             return None
 
-        access_token, expires_in = await self.create_access_token(data={"sub": str(db_user.id), "email": db_user.email, "is_superuser": db_user.is_superuser})
-        refresh_token = await self.create_refresh_token(data={"sub": str(db_user.id), "email": db_user.email, "is_superuser": db_user.is_superuser})
+        access_token, expires_in = await self.create_access_token(
+            data={
+                "sub": str(db_user.id),
+                "email": db_user.email,
+                "is_superuser": db_user.is_superuser,
+            }
+        )
+        refresh_token = await self.create_refresh_token(
+            data={
+                "sub": str(db_user.id),
+                "email": db_user.email,
+                "is_superuser": db_user.is_superuser,
+            }
+        )
         token_schema = auth_schemas.Token(
             email=db_user.email,
             is_superuser=db_user.is_superuser,
             access_token=access_token,
             refresh_token=refresh_token,
             expires_in=expires_in,
-            token_type="bearer"
+            token_type="bearer",
         )
         return token_schema
-    
+
     async def send_password_reset_email(self, email: str):
         db_user = await self.get_user_by_email(email)
         if not db_user:
             raise None
 
-        reset_token, _ = await self.create_access_token(data={"sub": str(db_user.id), "email": db_user.email, "is_superuser": db_user.is_superuser}, expires_delta=timedelta(minutes=15))
+        reset_token, _ = await self.create_access_token(
+            data={
+                "sub": str(db_user.id),
+                "email": db_user.email,
+                "is_superuser": db_user.is_superuser,
+            },
+            expires_delta=timedelta(minutes=15),
+        )
         reset_link = f"{settings.FRONTEND_URL}/reset-password?token={reset_token}"
         print("Reset link:", reset_link)  # Debugging line
         body = f"Click the following link to reset your password: {reset_link}"
@@ -79,11 +121,15 @@ class AuthService:
         payload = await self.verify_access_token(token)
         user_id = payload.get("sub")
         if user_id is None:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
 
         db_user = await self.repository.get_user_by_id(user_id)
         if not db_user:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+            )
 
         hashed_password = pwd_context.hash(new_password)
         await self.repository.update_password(db_user.email, hashed_password)
@@ -94,28 +140,33 @@ class AuthService:
         await self.repository.update_password(user.email, hashed_password)
         return {"message": "Password changed successfully"}
 
-    async def create_access_token(self, data: dict, expires_delta: Optional[timedelta] = None):
+    async def create_access_token(
+        self, data: dict, expires_delta: Optional[timedelta] = None
+    ):
         return create_access_token(data, expires_delta)
-    
+
     async def resend_verification_email(self, token: str):
         print("Resending verification email with token:", token)
         payload = await self.verify_access_token(token)
 
         user_id = payload.get("sub")
         if user_id is None:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
 
         db_user = await self.repository.get_user_by_id(user_id)
         if not db_user:
             raise HTTPException(status_code=400, detail="User not found")
 
-        verification_code = await self.repository.set_new_verification_code(db_user.email)
+        verification_code = await self.repository.set_new_verification_code(
+            db_user.email
+        )
 
         body = f"Your verification code is: {verification_code}"
         await send_email(db_user.email, "Oraclous Verification Code", body)
         return {"message": "Verification email resent successfully"}
 
-    
     async def verify_user_email(self, token: str, code: int):
         payload = await self.verify_access_token(token)
         print("Payload from token:", payload)
@@ -123,38 +174,57 @@ class AuthService:
         print("User ID from token:", user_id)
 
         if user_id is None:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
 
         db_user = await self.repository.get_user_by_id(user_id)
         if not db_user:
             raise HTTPException(status_code=400, detail="User not found")
-    
-        if db_user.verification_code != code or datetime.now(timezone.utc) > db_user.verification_code_expiry.replace(tzinfo=timezone.utc):
-            raise HTTPException(status_code=400, detail="Invalid or expired verification code")
-    
+
+        if db_user.verification_code != code or datetime.now(
+            timezone.utc
+        ) > db_user.verification_code_expiry.replace(tzinfo=timezone.utc):
+            raise HTTPException(
+                status_code=400, detail="Invalid or expired verification code"
+            )
+
         await self.repository.verify_email(db_user.email, db_user.verification_code)
         return {"message": "Email verified successfully"}
-    
-    
+
     async def verify_access_token(self, token: str):
         return verify_access_token(token=token)
 
-    async def create_refresh_token(self, data: dict, expires_delta: Optional[timedelta] = None):
+    async def create_refresh_token(
+        self, data: dict, expires_delta: Optional[timedelta] = None
+    ):
         return create_refresh_token(data, expires_delta)
 
     async def verify_refresh_token(self, token: str):
         payload = verify_refresh_token(token)
         db_user = await self.repository.get_user_by_id(payload.user_id)
 
-        access_token, expires_in = await self.create_access_token(data={"sub": str(db_user.id), "email": db_user.email, "is_superuser": db_user.is_superuser})
-        refresh_token = await self.create_refresh_token(data={"sub": str(db_user.id), "email": db_user.email, "is_superuser": db_user.is_superuser})
-        
+        access_token, expires_in = await self.create_access_token(
+            data={
+                "sub": str(db_user.id),
+                "email": db_user.email,
+                "is_superuser": db_user.is_superuser,
+            }
+        )
+        refresh_token = await self.create_refresh_token(
+            data={
+                "sub": str(db_user.id),
+                "email": db_user.email,
+                "is_superuser": db_user.is_superuser,
+            }
+        )
+
         token_schema = auth_schemas.Token(
             email=db_user.email,
             is_superuser=db_user.is_superuser,
             access_token=access_token,
             refresh_token=refresh_token,
             expires_in=expires_in,
-            token_type="bearer"
+            token_type="bearer",
         )
         return token_schema

--- a/auth-service/tests/unit/test_auth_status_codes.py
+++ b/auth-service/tests/unit/test_auth_status_codes.py
@@ -1,0 +1,138 @@
+"""Unit tests for correct HTTP status codes on auth endpoints.
+
+Covers three scenarios per ORA-226:
+- POST /register/ success → 201 Created (verified via route decorator)
+- POST /register/ duplicate email → 409 Conflict (verified in service layer)
+- POST /login/ wrong password → 401 Unauthorized (verified in route layer)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+# ---------------------------------------------------------------------------
+# Route decorator: register must declare status_code=201
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_register_route_declares_201():
+    """The /register/ route decorator must declare status_code=201."""
+    from app.routes.auth_routes import router
+
+    register_route = next(
+        (r for r in router.routes if hasattr(r, "path") and r.path == "/register/"),
+        None,
+    )
+    assert register_route is not None, "/register/ route not found"
+    assert (
+        register_route.status_code == 201
+    ), f"Expected 201 but got {register_route.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# AuthService.create_user — 409 on duplicate email
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_user_duplicate_raises_409():
+    """Duplicate email registration must raise HTTPException with 409 Conflict."""
+    from app.services.auth_service import AuthService
+
+    mock_repo = AsyncMock()
+    mock_repo.get_user_by_email.return_value = MagicMock()  # user already exists
+
+    service = AuthService(mock_repo)
+
+    with pytest.raises(HTTPException) as exc_info:
+        from app.schema.auth_schemas import UserCreateWithEmail
+
+        user = UserCreateWithEmail(email="dup@example.com", password="Pass123!")
+        await service.create_user(user=user)
+
+    assert exc_info.value.status_code == status.HTTP_409_CONFLICT
+    assert exc_info.value.detail == "Email already registered"
+
+
+# ---------------------------------------------------------------------------
+# AuthService.authenticate_user — returns None on bad credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authenticate_user_wrong_password_returns_none():
+    """authenticate_user returns None when password verification fails.
+
+    The route then raises 401 — this validates the service contract.
+    """
+    from app.services.auth_service import AuthService
+
+    mock_user = MagicMock()
+    mock_repo = AsyncMock()
+    mock_repo.get_user_by_email.return_value = mock_user
+
+    service = AuthService(mock_repo)
+
+    # Patch pwd_context.verify to simulate wrong password
+    with patch("app.services.auth_service.pwd_context") as mock_pwd:
+        mock_pwd.verify.return_value = False
+        result = await service.authenticate_user(
+            email="user@example.com", password="wrong_password"
+        )
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Route layer — login raises 401 on None return from service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_login_route_raises_401_on_bad_credentials():
+    """The login route must return HTTP 401 when authenticate_user returns None.
+
+    Patches slowapi's _check_request_limit to bypass Redis so the route logic
+    is tested in isolation without an external rate-limit backend.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from slowapi import Limiter
+    from slowapi.errors import RateLimitExceeded
+    from slowapi.util import get_remote_address
+
+    from app.core.rate_limiter import rate_limit_exceeded_handler
+
+    test_limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")
+    app = FastAPI()
+    app.state.limiter = test_limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+
+    from app.routes.auth_routes import router
+
+    app.include_router(router)
+
+    mock_repo = AsyncMock()
+    mock_service = AsyncMock()
+    mock_service.authenticate_user.return_value = None
+
+    # Patch _check_request_limit on the bound limiter to skip Redis entirely
+    with patch(
+        "app.routes.auth_routes.limiter._check_request_limit", return_value=None
+    ), patch(
+        "app.routes.auth_routes.get_user_repository", return_value=mock_repo
+    ), patch(
+        "app.routes.auth_routes.AuthService", return_value=mock_service
+    ):
+        client = TestClient(app, raise_server_exceptions=False)
+        r = client.post(
+            "/login/",
+            json={"email": "u@example.com", "password": "bad"},
+        )
+
+    assert r.status_code == 401
+    assert r.json()["detail"] == "Incorrect email/username or password"


### PR DESCRIPTION
## Summary

Fixes three incorrect HTTP status codes in the auth-service per ORA-226.

| Endpoint | Scenario | Before | After |
|---|---|---|---|
| `POST /register/` | New user success | 200 | **201 Created** |
| `POST /register/` | Duplicate email | 400 | **409 Conflict** |
| `POST /login/` | Wrong password | 400 | **401 Unauthorized** |

## Changes

- `auth-service/app/routes/auth_routes.py` — added `status_code=201` to register decorator; changed login bad-credentials raise to `401`
- `auth-service/app/services/auth_service.py` — changed `HTTP_400_BAD_REQUEST` → `HTTP_409_CONFLICT` for duplicate email
- `auth-service/tests/unit/test_auth_status_codes.py` — 4 new unit tests covering all three scenarios

## Test plan

- [x] `test_register_route_declares_201` — verifies route decorator has `status_code=201`
- [x] `test_create_user_duplicate_raises_409` — verifies service raises `HTTPException(409)`
- [x] `test_authenticate_user_wrong_password_returns_none` — verifies service returns `None` on bad credentials
- [x] `test_login_route_raises_401_on_bad_credentials` — verifies route raises `HTTPException(401)`
- [x] All 4 tests pass; full unit suite green (1 pre-existing `test_bcrypt_hash_verify` failure unrelated to this change)

## Security Checklist

- [x] No info leakage in error responses (detail messages are generic)
- [x] Rate limiting unchanged on both endpoints

Agent: Backend Developer Senior | Task: ORA-226 | Phase: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)