### PR TITLE
fix(endpoints): remove response_class=Response / add response_model=None on 204 DELETE routes (ORA-235, ORA-242)

### DIFF
--- a/knowledge-base/operations/deployment-validation-report-2026-04-08.md
+++ b/knowledge-base/operations/deployment-validation-report-2026-04-08.md
@@ -1,0 +1,163 @@
+# Deployment Validation Report — Full-Stack (All Phases)
+
+**Date:** 2026-04-08
+**Task:** [ORA-96](/ORA/issues/ORA-96) — Full-Stack Deployment Validation
+**Engineer:** DevOps SRE Specialist
+**Prerequisites verified:** ORA-93 ✅ ORA-94 ✅ ORA-95 ✅
+
+---
+
+## 1. Build Summary
+
+```
+docker compose build
+```
+
+All 6 application images built successfully with no errors:
+
+| Image | Result |
+|---|---|
+| auth-service | ✅ Built |
+| credential-broker-service | ✅ Built |
+| knowledge-graph-builder | ✅ Built |
+| knowledge-graph-mcp | ✅ Built |
+| knowledge-graph-worker | ✅ Built |
+| oraclous-core-service | ✅ Built |
+
+---
+
+## 2. Service Startup Status
+
+```
+docker compose up -d
+```
+
+| Service | Status | Port | Notes |
+|---|---|---|---|
+| **neo4j** | ✅ Healthy | 7474, 7687 | v5.23.0 Community |
+| **postgres** | ✅ Healthy | 5432 | |
+| **redis** | ✅ Healthy | 6379 | |
+| **jaeger** | ✅ Healthy | 16686, 4317, 4318 | OTLP UI running |
+| **knowledge-graph-builder** | ✅ Healthy | 8003 | All dependencies connected |
+| **knowledge-graph-worker** | ✅ Running | — | All 8 tasks registered, connected to Redis |
+| **oraclous-core-service** | ✅ Running | 8001 | Uvicorn up |
+| **credential-broker-service** | ✅ Running | 8002 | `/health` → 200 healthy |
+| **auth-service** | ⚠️ Degraded | 8000 | Starts but passlib/bcrypt error on auth ops |
+| **knowledge-graph-mcp** | ❌ CrashLoop | 8004 | `FastMCP.run()` API incompatibility |
+
+---
+
+## 3. Smoke Test Results
+
+### Infrastructure
+| Check | Result |
+|---|---|
+| Neo4j reachable + version confirmed | ✅ v5.23.0 |
+| PostgreSQL healthy | ✅ |
+| Redis healthy | ✅ |
+| Jaeger UI accessible at :16686 | ✅ |
+
+### Knowledge Graph Builder (Port 8003)
+| Endpoint | HTTP Status | Result |
+|---|---|---|
+| `GET /api/v1/health` | 200 | ✅ healthy, neo4j+postgres connected |
+| `GET /api/v1/graphs` (no auth) | 403 | ✅ Multi-tenant auth enforced |
+| `GET /api/v1/api/v1/schema/health` | 200 | ✅ |
+| `GET /` root | 200 | ✅ service running |
+
+### Auth Service (Port 8000)
+| Endpoint | HTTP Status | Result |
+|---|---|---|
+| `GET /` | 200 | ✅ "API service is running" |
+| `POST /register/` | 500 | ❌ passlib/bcrypt ValueError — see Bug #1 |
+
+### Core Service (Port 8001)
+| Endpoint | HTTP Status | Result |
+|---|---|---|
+| `GET /` | 404 | ℹ️ No root handler (expected) |
+| Uvicorn up | — | ✅ Service accepting connections |
+
+### Credential Broker (Port 8002)
+| Endpoint | HTTP Status | Result |
+|---|---|---|
+| `GET /health` | 200 | ✅ healthy |
+
+### MCP Server (Port 8004)
+| Check | Result |
+|---|---|
+| Container starts | ❌ CrashLoop — see Bug #2 |
+
+---
+
+## 4. Multi-Tenant Isolation Validation
+
+- All graph endpoints require authentication (403 without token) ✅
+- Graph-scoped routes (`/api/v1/graphs/{graph_id}/*`) require valid auth token ✅
+- No unauthenticated data access confirmed at API boundary ✅
+
+---
+
+## 5. OpenTelemetry Status
+
+- `OTEL_ENABLED` is **not set** in `knowledge-graph-builder/.env` → defaults to `false`
+- OTel instrumentation is present and opt-in (by design per ORA-47)
+- Jaeger is running and reachable
+- To enable tracing: set `OTEL_ENABLED=true` and `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317` in `.env`
+
+---
+
+## 6. Phase Feature Accessibility
+
+| Feature Area | Accessible | Notes |
+|---|---|---|
+| Graph CRUD (`/api/v1/graphs`) | ✅ (auth required) | |
+| Ingestion pipeline | ✅ (auth required) | |
+| Chat / GraphRAG | ✅ (auth required) | |
+| Community detection | ✅ (auth required) | |
+| Temporal queries | ✅ (auth required) | |
+| Snapshots / rollback | ✅ (auth required) | |
+| Ontology management | ✅ (auth required) | |
+| Memory consolidation | ✅ (auth required) | |
+| Federation / vector search | ✅ (auth required) | |
+| Service accounts / ReBAC | ✅ (auth required) | |
+| MCP server | ❌ CrashLoop | Bug #2 — FastMCP API |
+| Auth registration / login | ❌ 500 | Bug #1 — passlib/bcrypt |
+
+---
+
+## 7. Bugs Found
+
+### Bug #1 — Auth Service: passlib/bcrypt ValueError on registration
+- **Severity:** High (blocks all authentication flows)
+- **Error:** `ValueError: password cannot be longer than 72 bytes` in `passlib/handlers/bcrypt.py`
+- **Root cause:** Same as tracked in ORA-182 — passlib/bcrypt compatibility issue
+- **Status:** Already tracked in ORA-182/ORA-184
+
+### Bug #2 — MCP Server CrashLoop: FastMCP.run() API incompatibility
+- **Severity:** High (MCP server completely unavailable)
+- **Error:** `TypeError: FastMCP.run() got an unexpected keyword argument 'host'`
+- **Location:** `app/mcp/server.py:763` — `mcp.run(transport="sse", host=host, port=port)`
+- **Root cause:** MCP library version updated, `host` and `port` args no longer accepted by `FastMCP.run()`
+- **Status:** New bug — requires Backend Engineering Lead triage
+
+### Note — Double-prefix routes
+- Routes like `/api/v1/api/v1/chat` appear in OpenAPI spec (should be `/api/v1/chat`)
+- Likely a router prefix registration issue — flag for Backend Engineering Lead review
+
+---
+
+## 8. Conclusion
+
+**Overall: PARTIAL PASS**
+
+- Infrastructure layer (Neo4j, PostgreSQL, Redis, Jaeger): ✅ Fully operational
+- Core API (knowledge-graph-builder): ✅ Healthy, all routes accessible with auth
+- Worker (Celery): ✅ Running with all tasks registered
+- Auth service: ❌ Degraded (passlib/bcrypt — tracked in ORA-182)
+- MCP server: ❌ CrashLoop (new bug filed)
+
+The platform is deployable with the exception of auth registration (ORA-182 fix pending) and MCP (new bug). All Phase 2–4 features are accessible via the knowledge-graph-builder API once authentication is resolved.
+
+---
+
+*Report generated by DevOps SRE Specialist — ORA-96*

--- a/knowledge-base/qa/evaluation-reports/ORA-169-community-staleness-abs-delta-smoke-test.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-169-community-staleness-abs-delta-smoke-test.md
@@ -1,0 +1,89 @@
+---
+title: "QA Smoke Test Report — ORA-137 Community Staleness Absolute Delta Fix"
+author: "QA Evaluation Engineer"
+date: "2026-04-09"
+status: "pass"
+source: "ORA-169"
+target: "fix(background_jobs): ORA-137 — use abs() for community staleness delta"
+branch: "fix/phase1/graph-dev/ora-137-community-staleness-absolute-delta"
+merged_to: "develop"
+pr: "https://github.com/Jahankohan/oraclous-backend/pull/4"
+---
+
+# QA Smoke Test Report — ORA-137 Community Staleness Absolute Delta Fix
+
+## Summary
+
+**Result: PASS** — All 4 acceptance criteria met. No regressions detected.
+
+| Test Area | Result | Tests |
+|---|---|---|
+| Regression fix (negative delta) | ✅ PASS | `test_negative_delta_above_threshold_marks_stale` |
+| Growth path (positive delta) | ✅ PASS | `test_positive_delta_above_threshold_marks_stale` |
+| Below-threshold no-op | ✅ PASS | `test_delta_below_threshold_not_stale` |
+| Zero-baseline guard | ✅ PASS | `test_zero_entity_count_at_detection_no_zero_division_error` |
+| Full community detection suite | ✅ PASS | 24/24 tests |
+| background_jobs unit suite | ✅ PASS | 24/24 tests |
+
+## Fix Verification
+
+**File:** `knowledge-graph-builder/app/services/background_jobs.py:750`
+
+Before (buggy):
+```python
+staleness = new_delta / row[0]
+```
+
+After (fix):
+```python
+staleness = abs(new_delta) / max(row[0], 1)
+```
+
+The root cause was that when `entity_delta_since_detection` is negative (entities deleted), `new_delta` becomes negative, and without `abs()` the staleness ratio was also negative — never exceeding the 0.10 threshold. Communities were therefore never marked stale after entity deletions. The fix applies `abs()` to ensure both positive (growth) and negative (deletion) deltas trigger staleness correctly.
+
+The `max(row[0], 1)` guard provides defence-in-depth against `ZeroDivisionError` when `entity_count_at_detection = 0`, though the outer condition `if row and row[0] and row[0] > 0` already prevents this path.
+
+## Test Execution
+
+**Command:**
+```
+python3 -m pytest tests/unit/test_community_detection.py::TestMaybeTriggerCommunityDetectionStaleness -v
+```
+
+**Output:**
+```
+collected 4 items
+
+TestMaybeTriggerCommunityDetectionStaleness::test_negative_delta_above_threshold_marks_stale PASSED
+TestMaybeTriggerCommunityDetectionStaleness::test_positive_delta_above_threshold_marks_stale PASSED
+TestMaybeTriggerCommunityDetectionStaleness::test_delta_below_threshold_not_stale            PASSED
+TestMaybeTriggerCommunityDetectionStaleness::test_zero_entity_count_at_detection_no_zero_division_error PASSED
+
+4 passed in 0.24s
+```
+
+**Regression suite (full community detection):**
+```
+python3 -m pytest tests/unit/test_community_detection.py -v
+24 passed in 0.12s
+```
+
+**Regression suite (background_jobs):**
+```
+python3 -m pytest tests/unit/test_background_jobs.py -v
+24 passed in 0.11s
+```
+
+## Acceptance Criteria — Verification
+
+| Criterion | Status | Evidence |
+|---|---|---|
+| After deleting entities below baseline, subsequent ingest marks communities stale | ✅ | `test_negative_delta_above_threshold_marks_stale` passes |
+| After adding entities above baseline (>10%), communities marked stale | ✅ | `test_positive_delta_above_threshold_marks_stale` passes |
+| Small changes (<10%) in either direction do NOT mark communities stale | ✅ | `test_delta_below_threshold_not_stale` passes |
+| Zero baseline guard — no ZeroDivisionError | ✅ | `test_zero_entity_count_at_detection_no_zero_division_error` passes |
+
+## Notes
+
+- Unit test collection was previously blocked by SQLAlchemy double-registration (ORA-111). This did not affect the current test run — all tests collected and passed cleanly.
+- Manual end-to-end verification (ingest → delete → ingest cycle against a running instance) was not performed as services are not deployed locally. Unit tests fully cover the staleness logic path with I/O mocked.

--- a/knowledge-graph-builder/app/api/v1/endpoints/connectors.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/connectors.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import get_current_user_id, get_database, verify_graph_access
@@ -131,7 +130,7 @@ async def update_connector(
 @router.delete(
     "/graphs/{graph_id}/connectors/{connector_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    response_class=Response,
+    response_model=None,
     summary="Delete a connector",
 )
 async def delete_connector(

--- a/knowledge-graph-builder/app/api/v1/endpoints/memories.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/memories.py
@@ -13,7 +13,6 @@ Agent Memory API Endpoints
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import Response
 
 from app.api.dependencies import get_current_user_id, verify_graph_access
 from app.core.logging import get_logger
@@ -192,7 +191,7 @@ async def update_memory(
 @router.delete(
     "/graphs/{graph_id}/memories/{memory_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    response_class=Response,
+    response_model=None,
     tags=["memories"],
     summary="Forget a memory (soft or hard delete)",
 )


### PR DESCRIPTION
## Summary

- **memories.py**: replaced `response_class=Response` with `response_model=None` on the DELETE endpoint
- **connectors.py**: replaced `response_class=Response` with `response_model=None` on the DELETE endpoint
- Removed now-unused `from fastapi.responses import Response` imports in both files

FastAPI v0.116 asserts that `status_code=204` routes must not carry a response body. `response_class=Response` was conflicting with this constraint, causing a startup `AssertionError` that prevented the service from starting. Replacing it with the explicit `response_model=None` satisfies FastAPI's requirement cleanly.

Closes ORA-235 and ORA-242.

## Test plan

- [x] Unit tests pass: 679 passed, 7 xfailed (pre-existing `test_database_connector_service` basename conflict is unrelated)
- [x] `black` / `isort` / `ruff` — all clear
- [ ] CI: Unit Tests ✓, Lint & Format ✓, Docker Build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)