### PR TITLE
fix(memory): add ensure_memory_indexes() to lifespan startup [ORA-254]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,12 +153,6 @@ services:
         condition: service_healthy
     volumes:
       - ./knowledge-graph-builder/app:/app/app
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8004/sse"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,12 @@ services:
         condition: service_healthy
     volumes:
       - ./knowledge-graph-builder/app:/app/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8004/sse"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     networks:
       - app-network
 

--- a/knowledge-base/qa/evaluation-reports/ORA-221-federation-entity-search-validation.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-221-federation-entity-search-validation.md
@@ -1,0 +1,119 @@
+---
+title: "QA Validation Report — Federation Entity Search Cypher Fix (ORA-221)"
+author: QA Evaluation Engineer
+date: 2026-04-09
+status: PASSED
+source: commit b139fff4 (merged to develop)
+target: ORA-217 / ORA-221
+---
+
+# QA Validation Report — Federation Entity Search Fix
+
+**Task:** [ORA-221](/ORA/issues/ORA-221)
+**Fix:** [ORA-217](/ORA/issues/ORA-217)
+**Commit:** `b139fff4` (merged to `develop` via PR #14)
+**Date:** 2026-04-09
+**Verdict:** ✅ **PASSED — Fix is correct and all tests green**
+
+---
+
+## Root Cause (ORA-217)
+
+Neo4j 5.23+ rejects Cypher queries where `CALL {}` subqueries are joined at the top level with `UNION ALL`. The old `_execute_entity_union` in `federation_service.py` generated:
+
+```cypher
+CALL {
+  MATCH (e:__Entity__) WHERE e.graph_id = $gid_0 ...
+  RETURN ... LIMIT $limit
+}
+UNION ALL
+CALL {
+  MATCH (e:__Entity__) WHERE e.graph_id = $gid_1 ...
+  RETURN ... LIMIT $limit
+}
+RETURN entity_id, name, type, source_graph_id
+```
+
+This caused `SyntaxError: Query cannot conclude with CALL` on every federated entity search.
+
+---
+
+## Fix Verification
+
+The fix restructures to a single outer CALL wrapping all UNION ALL branches:
+
+```cypher
+CALL {
+  MATCH (e:__Entity__) WHERE e.graph_id = $gid_0 ...
+  RETURN ... LIMIT $limit
+  UNION ALL
+  MATCH (e:__Entity__) WHERE e.graph_id = $gid_1 ...
+  RETURN ... LIMIT $limit
+}
+RETURN entity_id, name, type, source_graph_id
+```
+
+**Code review confirmed:**
+- No per-branch `CALL {}` wrappers ✅
+- Single outer `CALL {}` wrapping all UNION ALL branches ✅
+- `$gid_N AS source_graph_id` → `e.graph_id AS source_graph_id` (safe: WHERE clause enforces equality) ✅
+- Params structure unchanged — `search_term`, `limit`, `gid_N` per graph ✅
+
+---
+
+## Test Results
+
+### Federation Service Unit Tests (ORA-217 regression suite)
+
+```
+tests/unit/test_federation_service.py::test_validate_rejects_cross_tenant_graph              PASSED
+tests/unit/test_federation_service.py::test_validate_rejects_non_federatable_graph           PASSED
+tests/unit/test_federation_service.py::test_validate_rejects_missing_graph                   PASSED
+tests/unit/test_federation_service.py::test_validate_rejects_too_many_graphs                 PASSED
+tests/unit/test_federation_service.py::test_validate_passes_for_all_owned_and_federatable    PASSED
+tests/unit/test_federation_service.py::test_validate_uses_owner_user_id_not_user_id          PASSED
+tests/unit/test_federation_service.py::test_validate_matches_system_namespace                PASSED
+tests/unit/test_federation_service.py::test_entity_union_passes_graph_ids_as_params          PASSED
+tests/unit/test_federation_service.py::test_federated_query_returns_source_attribution       PASSED
+tests/unit/test_federation_service.py::test_same_as_deduplication_produces_link_for_matching PASSED
+tests/unit/test_federation_service.py::test_store_same_as_links_is_awaited                  PASSED
+tests/unit/test_federation_service.py::test_same_as_no_link_for_same_graph                  PASSED
+tests/unit/test_federation_service.py::test_same_as_no_link_for_different_types             PASSED
+tests/unit/test_federation_service.py::test_entity_union_cypher_uses_single_outer_call      PASSED  ← ORA-217
+tests/unit/test_federation_service.py::test_entity_union_cypher_structure_single_call_wrapping PASSED  ← ORA-217
+tests/unit/test_federation_service.py::test_federated_query_request_rejects_duplicate_graph_ids PASSED
+tests/unit/test_federation_service.py::test_federated_query_request_rejects_single_graph    PASSED
+tests/unit/test_federation_service.py::test_federated_query_request_rejects_too_many_graphs PASSED
+
+Result: 18/18 passed
+```
+
+### Full KG-Builder Unit Suite (Regression)
+
+```
+Total: 713 passed, 7 xfailed — 0 failures, 0 regressions
+```
+
+---
+
+## Acceptance Criteria
+
+| Criterion | Status |
+|---|---|
+| Cypher no longer uses per-branch `CALL {}` wrappers | ✅ Confirmed in code |
+| Single outer `CALL {}` wraps all UNION ALL branches | ✅ Confirmed in code |
+| Two ORA-217 regression tests added and passing | ✅ 18/18 tests pass |
+| No regressions in existing federation tests | ✅ All prior 16 tests still pass |
+| Full kg-builder unit suite passes | ✅ 713/713 |
+
+---
+
+## Note on Live Endpoint Testing
+
+Live stack (Docker containers + Neo4j 5.23+) is not running in local QA environment. Unit-level validation confirms the Cypher template is structurally correct per Neo4j 5.23+ requirements. The two new regression tests (`test_entity_union_cypher_uses_single_outer_call`, `test_entity_union_cypher_structure_single_call_wrapping`) provide high confidence the fix resolves ORA-217. Full live smoke test can be performed in staging when Neo4j environment is available.
+
+---
+
+## Decision
+
+**✅ QA APPROVED** — Cypher fix is structurally correct, all 18 federation tests pass, 713/713 unit tests pass with zero regressions. ORA-217 fix is validated.

--- a/knowledge-base/qa/evaluation-reports/ORA-236-memories-delete-204-validation.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-236-memories-delete-204-validation.md
@@ -1,0 +1,85 @@
+---
+title: "ORA-236 QA Validation — memories.py DELETE 204 Fix"
+author: QA Evaluation Engineer
+date: 2026-04-09
+status: passed
+source: ORA-236
+target: ORA-235 (fix), ORA-233 (bug)
+branch: develop (commit 1fa39b9, PR #18)
+---
+
+# ORA-236 QA Validation Report — memories.py DELETE 204 Fix
+
+## Summary
+
+**PASSED** — The `knowledge-graph-builder` service starts cleanly after the fix in ORA-235 and the memories DELETE endpoint returns the correct 204 No Content response.
+
+## Fix Verified
+
+Commit `1fa39b9` on `develop` (PR #18) removed `response_class=Response` and replaced with `response_model=None` on the DELETE 204 endpoint:
+
+```python
+# Before (broken — caused AssertionError at startup):
+@router.delete("/graphs/{graph_id}/memories/{memory_id}", status_code=204, response_class=Response)
+
+# After (fixed):
+@router.delete("/graphs/{graph_id}/memories/{memory_id}", status_code=204, response_model=None)
+```
+
+## Validation Checklist Results
+
+| Check | Result | Detail |
+|---|---|---|
+| Service starts without crash loop | ✅ PASS | `Application startup complete.` in logs |
+| No `AssertionError: Status code 204 must not have a response body` | ✅ PASS | Zero occurrences in docker logs |
+| Health check `GET /api/v1/health` returns 200 | ✅ PASS | `{"status":"healthy",...}` — Neo4j + Postgres healthy |
+| `DELETE /graphs/{id}/memories/{id}` returns 204 No Content | ✅ PASS | HTTP 204 with empty body |
+| `POST /graphs/{id}/memories` (create) still works | ✅ PASS | HTTP 201, memory_id returned |
+| `PATCH /graphs/{id}/memories/{id}` (update) still works | ✅ PASS | HTTP 200, superseded memory returned |
+| `GET /graphs/{id}/memories/search` | ⚠️ 500 | Missing fulltext index `memory_content_idx` (see bug note below) |
+| `GET /graphs/{id}/memories/context` | ⚠️ 500 | Same missing fulltext index (separate issue) |
+
+## Test Evidence
+
+```
+# Service startup
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://0.0.0.0:8000
+
+# Health endpoint
+GET /api/v1/health → 200
+{"status":"healthy","service":"knowledge-graph-builder","version":"1.0.0",...}
+
+# DELETE endpoint (critical fix)
+DELETE /api/v1/api/v1/graphs/c349ffa4-eec8-49f3-a8c8-a25fa4cbc37a/memories/621f7963-262e-4897-8d82-17cd4ac9e917 → 204 (empty body)
+
+# POST (create memory)
+POST /api/v1/api/v1/graphs/{graph_id}/memories → 201
+{"memory_id":"621f7963-...","importance_score":0.4,...}
+
+# PATCH (update memory)
+PATCH /api/v1/api/v1/graphs/{graph_id}/memories/{memory_id} → 200
+{"old_memory_id":"2e699651-...","new_memory_id":"fab52acc-...","superseded_at":"..."}
+```
+
+## Separate Bug Found
+
+**BUG: Missing fulltext index `memory_content_idx`** — `GET /memories/search` and `GET /memories/context` both return 500:
+
+```
+Neo.ClientError.Procedure.ProcedureCallFailed: There is no such fulltext schema index: memory_content_idx
+```
+
+This is unrelated to ORA-235 and was present before the fix. The fulltext index is expected to be created during Neo4j schema initialization but is missing from the current instance. Reported separately to Backend Engineering Lead.
+
+## Environment
+
+- Branch: `develop`
+- Commit: `1fa39b9`
+- Service: `knowledge-graph-builder` (port 8003)
+- Neo4j: `5.23.0 community`
+- Test date: 2026-04-09
+
+## Conclusion
+
+ORA-235 fix is valid. The P0 crash-on-startup bug is resolved. The DELETE 204 endpoint behaves correctly. The service is healthy and ORA-221 (federation Cypher fix QA) is unblocked — the service is accessible.

--- a/knowledge-base/qa/evaluation-reports/ORA-244-auth-status-codes-smoke-test.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-244-auth-status-codes-smoke-test.md
@@ -1,0 +1,112 @@
+---
+title: "QA Smoke Test Report — Auth HTTP Status Codes (ORA-244)"
+author: QA Evaluation Engineer
+date: 2026-04-09
+status: PASSED
+source: fix/phase1/sr-backend/ora-224-auth-status-codes
+target: ORA-226 / PR #16
+---
+
+# QA Smoke Test Report — Auth HTTP Status Code Fixes
+
+**Task:** [ORA-244](/ORA/issues/ORA-244)
+**Parent Fix:** [ORA-226](/ORA/issues/ORA-226)
+**Bug:** [ORA-224](/ORA/issues/ORA-224)
+**Branch:** `fix/phase1/sr-backend/ora-224-auth-status-codes`
+**PR:** [#16](https://github.com/Jahankohan/oraclous-backend/pull/16) → `develop`
+**Date:** 2026-04-09
+**Verdict:** ✅ **PASSED — Clear to merge**
+
+---
+
+## Test Scenarios
+
+| Endpoint | Scenario | Expected | Result |
+|---|---|---|---|
+| `POST /register/` | New user success | **201 Created** | ✅ PASS |
+| `POST /register/` | Duplicate email | **409 Conflict** + `{"detail": "Email already registered"}` | ✅ PASS |
+| `POST /login/` | Wrong credentials | **401 Unauthorized** + `{"detail": "Incorrect email/username or password"}` | ✅ PASS |
+
+---
+
+## Unit Test Results
+
+### New Tests (ORA-226)
+
+```
+tests/unit/test_auth_status_codes.py::test_register_route_declares_201                  PASSED
+tests/unit/test_auth_status_codes.py::test_create_user_duplicate_raises_409              PASSED
+tests/unit/test_auth_status_codes.py::test_authenticate_user_wrong_password_returns_none PASSED
+tests/unit/test_auth_status_codes.py::test_login_route_raises_401_on_bad_credentials     PASSED
+
+Result: 4/4 passed
+```
+
+### Regression Suite (Full Unit Suite)
+
+```
+tests/unit/test_auth_endpoint_rate_limits.py    8/8  passed
+tests/unit/test_auth_status_codes.py            4/4  passed
+tests/unit/test_cors_proxy_security.py          7/7  passed
+tests/unit/test_jwt_sub_migration.py           14/14 passed
+tests/unit/test_rate_limiting.py                8/8  passed
+tests/unit/test_service_account_keys.py         7/7  passed
+
+Total: 48/48 passed — 0 regressions
+```
+
+---
+
+## Code Review Summary
+
+### `auth_routes.py`
+- `/register/` decorator updated: `status_code=201` ✅
+- `/login/` raises `HTTPException(status_code=401)` on `None` return from service ✅ (was `400`)
+- No unintended side effects on other routes
+
+### `auth_service.py`
+- `create_user()` raises `HTTPException(status_code=409, detail="Email already registered")` when user already exists ✅ (was not raising — returned 200)
+- All other service methods unchanged
+
+### `tests/unit/test_auth_status_codes.py`
+- 4 well-scoped unit tests covering all 3 scenarios + service contract
+- Uses mocks correctly; rate limiter bypassed via patch for route-layer test
+- No DB or Redis dependency — fully isolated
+
+---
+
+## CI Reference
+
+| Run | Status |
+|---|---|
+| PR run `24170169791` | ✅ passed |
+| Push run `24170163233` | ✅ passed |
+| Local unit run (2026-04-09) | ✅ 48/48 |
+
+---
+
+## Security Check
+
+- No internal error details leaked in 409 / 401 response bodies
+- Error messages use generic spec-compliant strings
+- No stack traces or DB info in error responses
+
+---
+
+## Acceptance Criteria Checklist
+
+- [x] `POST /register/` success returns 201
+- [x] `POST /register/` duplicate returns 409 `{"detail": "Email already registered"}`
+- [x] `POST /login/` wrong credentials returns 401 `{"detail": "Incorrect email/username or password"}`
+- [x] Unit tests (4 new) confirmed passing locally
+- [x] No regressions in existing auth flows (48/48 pass)
+- [x] Response body detail strings match spec
+- [x] Security: no internal error leakage
+
+---
+
+## Decision
+
+**✅ QA APPROVED** — All acceptance criteria met. PR #16 is clear to merge to `develop`.
+
+Backend Lead Developer may proceed with merge.

--- a/knowledge-base/qa/evaluation-reports/ORA-250-validation-ora-249-mcp-healthcheck-sse-fix.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-250-validation-ora-249-mcp-healthcheck-sse-fix.md
@@ -1,0 +1,162 @@
+---
+title: "ORA-250 QA Validation — knowledge-graph-mcp SSE Healthcheck Fix (ORA-249)"
+author: QA Evaluation Engineer
+date: 2026-04-09
+status: pass-with-note
+source: ORA-250
+target: ORA-249 (fix/phase1/devops-sre/ora-248-mcp-healthcheck-sse)
+---
+
+# QA Validation Report — ORA-250
+
+## Summary
+
+**Result: PASS (code-verified + live command test)** — fix is correct and will resolve the unhealthy status once PR #19 is merged and the container is recreated. The running stack still uses the old config (pre-merge), so the live container currently shows `unhealthy`.
+
+---
+
+## Context
+
+| Item | Value |
+|---|---|
+| Fix branch | `fix/phase1/devops-sre/ora-248-mcp-healthcheck-sse` |
+| PR | https://github.com/Jahankohan/oraclous-backend/pull/19 (→ `develop`) |
+| Commit | `596b19f` |
+| Parent bug | ORA-248 — healthcheck curl times out on SSE stream |
+| Prior port fix | ORA-228 — wrong port 8000 vs 8004 |
+| Validated on | 2026-04-09, Docker 28.2.2, Docker Compose v2.36.2 |
+
+---
+
+## Validation Steps Executed
+
+### 1. Code Review — PASS
+
+Diff between `origin/develop` and fix branch on `docker-compose.yml`:
+
+**Before (broken):**
+```yaml
+# No healthcheck block in docker-compose.yml for knowledge-graph-mcp
+# Container falls back to Dockerfile HEALTHCHECK targeting :8000
+# Previously ORA-228 added: test: ["CMD", "curl", "-f", "http://localhost:8004/sse"]
+```
+
+**After (fixed):**
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "bash -c 'curl -sf --max-time 3 http://localhost:8004/sse; code=$?; [ $code -eq 0 ] || [ $code -eq 28 ]'"]
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 15s
+```
+
+Fix analysis:
+- `CMD-SHELL` form required for bash scripting ✅
+- `--max-time 3` forces curl to exit after 3s (before 10s Docker timeout kills it) ✅
+- Exit code 28 = CURLE_OPERATION_TIMEDOUT (HTTP 200 received, stream held open) — accepted as success ✅
+- `timeout: 10s` > `--max-time 3` — curl self-exits before Docker kills it ✅
+- Exit code 7 (connection refused) is NOT accepted — genuine failures still fail ✅
+
+### 2. curl Availability Check — PASS
+
+Dockerfile explicitly installs curl:
+```dockerfile
+RUN apt-get update && apt-get install -y curl gcc libigraph-dev
+```
+`knowledge-graph-mcp` uses the same Dockerfile as `knowledge-graph-builder` — curl is available.
+
+### 3. SSE Endpoint Live Test — PASS
+
+```
+$ curl -s --max-time 3 http://localhost:8004/sse
+event: endpoint
+data: /messages/?session_id=f962d31c07644ea78661e182d6d098e5
+EXIT:28
+```
+SSE stream at `/sse` returns HTTP 200 + event data immediately, holds connection open as expected. Exit code 28 is correct.
+
+### 4. New Healthcheck Command Live Test — PASS
+
+Executed the exact fix command **inside the running container**:
+```
+$ docker exec knowledge-graph-mcp bash -c \
+  'curl -sf --max-time 3 http://localhost:8004/sse; code=$?; \
+   echo "CURL_EXIT_CODE:$code"; \
+   [ $code -eq 0 ] || [ $code -eq 28 ]; \
+   echo "HEALTHCHECK_RESULT:$?"'
+
+event: endpoint
+data: /messages/?session_id=3d970c4f76934bd28080e2d1d4103877
+
+CURL_EXIT_CODE:28
+HEALTHCHECK_RESULT:0
+```
+
+**The healthcheck command exits 0 — Docker will mark the container as `healthy`.** ✅
+
+### 5. Downstream Impact Check — PASS
+
+No services in `docker-compose.yml` depend on `knowledge-graph-mcp` with `condition: service_healthy`:
+```
+# service_healthy dependencies found:
+postgres    ← used by auth-service, others
+neo4j       ← used by knowledge-graph-builder, knowledge-graph-mcp
+redis       ← used by knowledge-graph-builder, knowledge-graph-worker
+knowledge-graph-builder ← used by knowledge-graph-mcp
+
+knowledge-graph-mcp ← NOT used by any service as service_healthy dependency
+```
+No downstream cascade failures. ✅
+
+### 6. Running Container Health Status
+
+```json
+{
+  "Status": "unhealthy",
+  "FailingStreak": 29,
+  "Log": [{"ExitCode": -1, "Output": "Health check exceeded timeout (10s)..."}]
+}
+```
+
+**Expected** — the running container was started from a branch that does NOT have the fix merged. The old `CMD curl -f http://localhost:8004/sse` healthcheck times out at 10s with ExitCode=-1.
+
+Running container healthcheck config (old):
+```json
+{"Test": ["CMD", "curl", "-f", "http://localhost:8004/sse"], "Timeout": 10s}
+```
+
+---
+
+## Pass Criteria Results
+
+| Criterion | Result | Evidence |
+|---|---|---|
+| Fix uses CMD-SHELL accepting exit code 28 | ✅ PASS | Code diff verified |
+| curl available in container image | ✅ PASS | Dockerfile line 5 |
+| SSE endpoint returns HTTP 200 | ✅ PASS | `curl --max-time 3` → event:endpoint data |
+| New healthcheck command exits 0 inside container | ✅ PASS | `HEALTHCHECK_RESULT:0` |
+| No services blocked by mcp `service_healthy` | ✅ PASS | docker-compose.yml grep |
+| Container shows `healthy` live | ⚠️ BLOCKED | PR #19 not yet merged; container still running old config |
+| No `ExitCode=-1` after fix deployed | ⚠️ PENDING | Will clear on container recreate post-merge |
+
+---
+
+## Finding: Pre-Deployment State
+
+The fix is on PR #19 (not yet merged to `develop`). The running `knowledge-graph-mcp` container was built from a branch where the docker-compose.yml has `CMD curl -f http://localhost:8004/sse` (ORA-228 fix, no timeout), which fails as expected.
+
+**Required action to reach full live PASS:**
+1. Merge PR #19 to `develop`
+2. `git pull origin develop` in workspace
+3. `docker compose up -d --force-recreate knowledge-graph-mcp`
+4. Wait 15s (start_period) + 30s (first interval)
+5. `docker compose ps` → should show `healthy`
+
+---
+
+## Conclusion
+
+**Code verification: PASS.** The fix is correct, well-scoped, and has been validated by live execution of the healthcheck command inside the running container. No regressions introduced. PR #19 may be merged to `develop`.
+
+Full live container health status (`healthy`) will be confirmed after deployment.

--- a/knowledge-graph-builder/app/main.py
+++ b/knowledge-graph-builder/app/main.py
@@ -67,6 +67,11 @@ async def lifespan(app: FastAPI):
 
         await service_account_service.initialize_schema(neo4j_client.async_driver)
 
+        # Ensure Memory API Neo4j indexes (idempotent, IF NOT EXISTS)
+        from app.services.memory_service import ensure_memory_indexes
+
+        await ensure_memory_indexes()
+
         logger.info("All services initialized successfully")
     except Exception as e:
         logger.error(f"Failed to initialize services: {e}")

--- a/knowledge-graph-builder/app/services/memory_service.py
+++ b/knowledge-graph-builder/app/services/memory_service.py
@@ -810,5 +810,39 @@ class MemoryService:
         )
 
 
+async def ensure_memory_indexes() -> None:
+    """
+    Create Neo4j indexes required for the Agent Memory API. Idempotent.
+    Called once at application startup (do NOT call neo4j_client.connect/close here).
+    """
+    index_queries = [
+        # 1. Vector index — semantic similarity search on Memory nodes
+        """
+        CREATE VECTOR INDEX memory_embedding_idx IF NOT EXISTS
+        FOR (m:Memory) ON m.embedding
+        OPTIONS {indexConfig: {
+          `vector.dimensions`: 3072,
+          `vector.similarity_function`: 'cosine'
+        }}
+        """,
+        # 2. Fulltext index — keyword recall across memory content
+        "CREATE FULLTEXT INDEX memory_content_idx IF NOT EXISTS FOR (m:Memory) ON EACH [m.content]",
+        # 3. Composite lookup — graph-scoped queries by scope/type/validity
+        "CREATE INDEX memory_graph_scope_idx IF NOT EXISTS FOR (m:Memory) ON (m.graph_id, m.scope, m.memory_type, m.valid_to)",
+        # 4. Deduplication — content hash within graph
+        "CREATE INDEX memory_content_hash_idx IF NOT EXISTS FOR (m:Memory) ON (m.graph_id, m.content_hash)",
+    ]
+    for q in index_queries:
+        try:
+            await neo4j_client.execute_write_query(q)
+        except Exception as e:
+            logger.warning(f"Memory index creation skipped: {e}")
+
+    indexes = await neo4j_client.execute_query(
+        "SHOW INDEXES WHERE labelsOrTypes = ['Memory']", {}
+    )
+    logger.info(f"Memory indexes present: {len(indexes)}")
+
+
 # Global service instance
 memory_service = MemoryService()

--- a/knowledge-graph-builder/tests/unit/test_memory_service.py
+++ b/knowledge-graph-builder/tests/unit/test_memory_service.py
@@ -386,3 +386,60 @@ class TestMemoryRetriever:
 
         assert len(results) == 1
         assert results[0]["memory_id"] == "m1"
+
+
+# ============================================================
+# ensure_memory_indexes
+# ============================================================
+
+
+class TestEnsureMemoryIndexes:
+    @pytest.mark.unit
+    async def test_calls_all_four_index_queries(self):
+        from app.services.memory_service import ensure_memory_indexes
+
+        write_mock = AsyncMock()
+        query_mock = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "app.services.memory_service.neo4j_client.execute_write_query",
+                write_mock,
+            ),
+            patch(
+                "app.services.memory_service.neo4j_client.execute_query",
+                query_mock,
+            ),
+        ):
+            await ensure_memory_indexes()
+
+        assert write_mock.call_count == 4
+        called_queries = [call.args[0] for call in write_mock.call_args_list]
+        assert any("memory_embedding_idx" in q for q in called_queries)
+        assert any("memory_content_idx" in q for q in called_queries)
+        assert any("memory_graph_scope_idx" in q for q in called_queries)
+        assert any("memory_content_hash_idx" in q for q in called_queries)
+
+    @pytest.mark.unit
+    async def test_continues_on_index_creation_error(self):
+        """A failing index query should be swallowed (IF NOT EXISTS race) and remaining indexes created."""
+        from app.services.memory_service import ensure_memory_indexes
+
+        write_mock = AsyncMock(
+            side_effect=[Exception("already exists"), None, None, None]
+        )
+        query_mock = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "app.services.memory_service.neo4j_client.execute_write_query",
+                write_mock,
+            ),
+            patch(
+                "app.services.memory_service.neo4j_client.execute_query",
+                query_mock,
+            ),
+        ):
+            await ensure_memory_indexes()  # must not raise
+
+        assert write_mock.call_count == 4


### PR DESCRIPTION
## Summary

- Fixes [ORA-254](/ORA/issues/ORA-254): `GET /memories/search` and `GET /memories/context` returned HTTP 500 because the `memory_content_idx` fulltext index was never created at startup
- Adds `ensure_memory_indexes()` to `memory_service.py` — creates 4 Memory Neo4j indexes using `IF NOT EXISTS` (idempotent)
- Calls it in `main.py` lifespan after `service_account_service.initialize_schema()`, consistent with all other service schema initializations
- Unit tests verify all 4 queries are called and errors are swallowed gracefully

## Files Changed

| File | Change |
|---|---|
| `app/services/memory_service.py` | Added `ensure_memory_indexes()` function |
| `app/main.py` | Added startup call in lifespan |
| `tests/unit/test_memory_service.py` | Added `TestEnsureMemoryIndexes` class (2 tests) |

## Security Checklist
- [x] No user input in index creation queries
- [x] No multi-tenancy concern (system indexes are global)
- [x] No info leakage

## How to Verify

1. Start the service without pre-existing Memory indexes
2. Confirm `GET /api/v1/memories/search` returns results (not 500)
3. Check logs for `Memory indexes present: 4`

Agent: Backend Developer Senior
Task: ORA-255
Phase: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)