### PR TITLE
fix(mcp): add /health endpoint and docker-compose healthcheck (ORA-262)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,12 @@ services:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8004
       - ORACLOUS_BASE_URL=http://knowledge-graph-builder:8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8004/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     depends_on:
       knowledge-graph-builder:
         condition: service_healthy

--- a/knowledge-graph-builder/app/mcp/server.py
+++ b/knowledge-graph-builder/app/mcp/server.py
@@ -39,6 +39,8 @@ from pathlib import Path
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 # ---------------------------------------------------------------------------
 # Ensure the knowledge-graph-builder package root is on sys.path so that
@@ -154,6 +156,16 @@ mcp = FastMCP(
     ),
     lifespan=_lifespan,
 )
+
+# ---------------------------------------------------------------------------
+# Health check — used by Docker HEALTHCHECK and load-balancer probes
+# ---------------------------------------------------------------------------
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
 
 # ===========================================================================
 # 1 – Graph Management

--- a/knowledge-graph-builder/tests/unit/test_lifespan_sync_driver.py
+++ b/knowledge-graph-builder/tests/unit/test_lifespan_sync_driver.py
@@ -22,12 +22,23 @@ async def test_lifespan_calls_connect_sync(monkeypatch):
     # Stub modules that are unavailable in unit-test context.
     # Use monkeypatch.setitem so sys.modules is restored after test teardown,
     # preventing these stubs from polluting other tests (e.g. test_rate_limiting).
-    for mod_name in ["app.api.v1.router", "app.core.rate_limiter"]:
+    for mod_name in [
+        "app.api.v1.router",
+        "app.core.rate_limiter",
+        "app.services.memory_service",
+        "app.services.database_connector_service",
+    ]:
         stub = types.ModuleType(mod_name)
         if mod_name == "app.api.v1.router":
             stub.api_router = MagicMock()
         elif mod_name == "app.core.rate_limiter":
             stub.limiter = MagicMock()
+        elif mod_name == "app.services.memory_service":
+            stub.ensure_memory_indexes = AsyncMock()
+        elif mod_name == "app.services.database_connector_service":
+            mock_db_connector = MagicMock()
+            mock_db_connector.ensure_constraints = AsyncMock()
+            stub.database_connector_service = mock_db_connector
         monkeypatch.setitem(sys.modules, mod_name, stub)
 
     # Stub slowapi only when not already installed.

--- a/knowledge-graph-builder/tests/unit/test_mcp_server.py
+++ b/knowledge-graph-builder/tests/unit/test_mcp_server.py
@@ -537,6 +537,40 @@ class TestGetNeighbors:
 
 
 # ---------------------------------------------------------------------------
+# Health Endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    @pytest.mark.asyncio
+    async def test_health_returns_200_with_ok_status(self):
+        """GET /health must return HTTP 200 with {"status": "ok"}."""
+        import httpx
+
+        app = mcp_module.mcp.sse_app()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_health_content_type_is_json(self):
+        """GET /health must return JSON content-type."""
+        import httpx
+
+        app = mcp_module.mcp.sse_app()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health")
+
+        assert "application/json" in response.headers.get("content-type", "")
+
+
+# ---------------------------------------------------------------------------
 # Lifespan / Shutdown
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `GET /health` to the MCP SSE server via `@mcp.custom_route("/health", methods=["GET"])` returning `{"status": "ok"}` — fixes the root cause of [ORA-258](/ORA/issues/ORA-258) where the shared `Dockerfile` HEALTHCHECK hit port 8000 (FastAPI) but the MCP container only binds port 8004
- Adds an explicit `healthcheck` block to the `knowledge-graph-mcp` service in `docker-compose.yml` targeting `http://localhost:8004/health`
- Adds `TestHealthEndpoint` unit tests (2 tests) verifying HTTP 200 and JSON content-type

## Changes

| File | Change |
|---|---|
| `app/mcp/server.py` | Import `Request`/`JSONResponse` from Starlette; add `@mcp.custom_route("/health")` handler |
| `docker-compose.yml` | Add `healthcheck` block to `knowledge-graph-mcp` service |
| `tests/unit/test_mcp_server.py` | Add `TestHealthEndpoint` class (2 unit tests via ASGI transport) |

## Test plan

- [x] `pytest tests/unit/test_mcp_server.py` — 35/35 passed
- [x] `black`, `isort`, `ruff` — all clean
- [ ] CI: Unit Tests, Lint & Format, Docker Build

## Security Checklist

- No Cypher queries added
- No user input handled — health endpoint takes no parameters
- No info leakage — returns static `{"status": "ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)