### PR TITLE
chore(infra): Docker multi-agent isolation — compose + runbook + cleanup [ORA-265]

### DIFF
--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -1,0 +1,54 @@
+# docker-compose.agent.yml
+#
+# Override file for running Oraclous services in agent/CI environments where
+# multiple Compose stacks may run concurrently on the same Docker host.
+#
+# Usage (ALWAYS with COMPOSE_PROJECT_NAME and IMAGE_TAG):
+#
+#   export COMPOSE_PROJECT_NAME=oraclous-ORA-XXX
+#   export IMAGE_TAG=my-branch-$(git rev-parse --short HEAD)
+#   docker compose -f docker-compose.yml -f docker-compose.agent.yml up --build -d
+#
+# Dynamic port assignment ("0:PORT") lets the OS pick a free host port,
+# preventing port collisions when multiple stacks are live simultaneously.
+# Use `docker compose port <service> <container_port>` to find the assigned port.
+
+services:
+  oraclous-core-service:
+    ports:
+      - "0:8000"
+
+  auth-service:
+    ports:
+      - "0:8000"
+
+  credential-broker-service:
+    ports:
+      - "0:8000"
+
+  knowledge-graph-builder:
+    ports:
+      - "0:8000"
+
+  knowledge-graph-mcp:
+    ports:
+      - "0:8004"
+
+  neo4j:
+    ports:
+      - "0:7474"
+      - "0:7687"
+
+  redis:
+    ports:
+      - "0:6379"
+
+  postgres:
+    ports:
+      - "0:5432"
+
+  jaeger:
+    ports:
+      - "0:16686"
+      - "0:4317"
+      - "0:4318"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   oraclous-core-service:
     build: ./oraclous-core-service
+    image: oraclous-core-service:${IMAGE_TAG:-dev}
     ports:
       - "8001:8000"
     env_file:
@@ -14,6 +15,7 @@ services:
     build:
       context: ./auth-service
       dockerfile: Dockerfile.dev
+    image: oraclous-auth-service:${IMAGE_TAG:-dev}
     ports:
       - "8000:8000"
     env_file:
@@ -27,6 +29,7 @@ services:
     build:
       context: ./credential-broker-service
       dockerfile: Dockerfile
+    image: oraclous-credential-broker:${IMAGE_TAG:-dev}
     ports:
       - "8002:8000"
     env_file:
@@ -41,7 +44,6 @@ services:
 
   neo4j:
     image: neo4j:5.23-community
-    container_name: neo4j_llm_graph
     restart: unless-stopped
     ports:
       - "7474:7474"
@@ -73,7 +75,7 @@ services:
     build:
       context: ./knowledge-graph-builder
       dockerfile: Dockerfile
-    container_name: knowledge-graph-worker
+    image: oraclous-kg-builder:${IMAGE_TAG:-dev}
     restart: unless-stopped
     command: celery -A app.services.background_jobs.celery_app worker --loglevel=info
     env_file:
@@ -101,7 +103,7 @@ services:
     build:
       context: ./knowledge-graph-builder
       dockerfile: Dockerfile
-    container_name: knowledge-graph-builder
+    image: oraclous-kg-builder:${IMAGE_TAG:-dev}
     restart: unless-stopped
     ports:
       - "8003:8000"
@@ -134,7 +136,7 @@ services:
     build:
       context: ./knowledge-graph-builder
       dockerfile: Dockerfile
-    container_name: knowledge-graph-mcp
+    image: oraclous-kg-builder:${IMAGE_TAG:-dev}
     restart: unless-stopped
     command: python -m app.mcp.server
     ports:
@@ -170,7 +172,6 @@ services:
 
   jaeger:
     image: jaegertracing/all-in-one:1.58
-    container_name: jaeger
     restart: unless-stopped
     ports:
       - "16686:16686"   # Jaeger UI
@@ -189,7 +190,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: redis_cache
     restart: unless-stopped
     ports:
       - "6379:6379"

--- a/knowledge-base/operations/docker-agent-coordination.md
+++ b/knowledge-base/operations/docker-agent-coordination.md
@@ -1,0 +1,152 @@
+# Docker Multi-Agent Isolation Protocol
+
+**Status:** Active — Approved via ORA-267 (2026-04-11)
+**Scope:** All backend agents, all CI/CD workflows, all PR reviews
+**Owner:** DevOps SRE Specialist (ORA-265)
+
+---
+
+## Problem
+
+Multiple agents running Docker simultaneously on the same host share the default Compose project namespace (`oraclous`). Without isolation, agents can:
+
+- Overwrite each other's containers, networks, and volumes
+- Produce false-positive or false-negative test results by sharing runtime state
+- Contaminate each other's images via the `:latest` tag (overwritten mid-run)
+
+---
+
+## Required Protocol
+
+### Layer 1 — Compose Project Isolation
+
+All `docker compose` calls **MUST** include a unique project name tied to the issue identifier. Never run bare `docker compose` without `COMPOSE_PROJECT_NAME`.
+
+```bash
+export COMPOSE_PROJECT_NAME=oraclous-ORA-XXX   # e.g. oraclous-ORA-265
+docker compose up --build -d
+```
+
+Docker Compose uses this value to prefix all container names, network names, and volume names. This is the primary isolation boundary — stacks from different agents cannot touch each other's resources.
+
+### Layer 2 — Image Tag Isolation
+
+All local image builds **MUST** use a deterministic tag derived from the current branch and commit SHA. Never build or push `:latest`.
+
+```bash
+export IMAGE_TAG="$(git rev-parse --abbrev-ref HEAD | tr '/' '-')-$(git rev-parse --short HEAD)"
+# e.g. feature-phase1-devops-ora-265-docker-agent-isolation-a3f8c12
+docker compose build
+```
+
+The `docker-compose.yml` uses `${IMAGE_TAG:-dev}` on every locally-built service `image:` field. Without `IMAGE_TAG` set, it falls back to `dev` (safe for solo local development, not for multi-agent environments).
+
+**Reza's key principle:** Each image must point only to changes on the same branch — no collisions across branches running locally.
+
+### Layer 3 — Dynamic Port Allocation
+
+When running multiple stacks concurrently on the same host, use the `docker-compose.agent.yml` override to replace all fixed host ports with `"0:PORT"` (OS-assigned ephemeral port):
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.agent.yml \
+  up --build -d
+```
+
+Find the assigned port for a service after startup:
+
+```bash
+docker compose port knowledge-graph-builder 8000
+# => 0.0.0.0:52341
+```
+
+---
+
+## Full Agent Startup Sequence
+
+Before running **any** `docker compose` command on this repo, set both required variables:
+
+```bash
+# 1. Set project isolation (mandatory)
+export COMPOSE_PROJECT_NAME=oraclous-ORA-XXX
+
+# 2. Set image tag (mandatory in multi-agent environments)
+export IMAGE_TAG="$(git rev-parse --abbrev-ref HEAD | tr '/' '-')-$(git rev-parse --short HEAD)"
+
+# 3. Start stack (add -f docker-compose.agent.yml if port conflicts are possible)
+docker compose -f docker-compose.yml -f docker-compose.agent.yml up --build -d
+
+# 4. Verify health
+docker compose ps
+```
+
+---
+
+## Example `.env.agent` Template
+
+Create this file at the repo root before running Compose. Do not commit it.
+
+```dotenv
+# .env.agent — copy this, fill in your issue ID, do NOT commit
+COMPOSE_PROJECT_NAME=oraclous-ORA-XXX
+IMAGE_TAG=feature-branch-slug-$(git rev-parse --short HEAD)
+```
+
+Then start with:
+
+```bash
+set -a && source .env.agent && set +a
+docker compose -f docker-compose.yml -f docker-compose.agent.yml up --build -d
+```
+
+---
+
+## Automated Cleanup (Script-Enforced)
+
+When branch work is complete, run the cleanup script to tear down the isolated stack and remove tagged images. Cleanup is **mandatory** before abandoning or merging a branch.
+
+```bash
+./scripts/agent-docker-cleanup.sh ORA-XXX
+```
+
+What the script does:
+
+1. Derives `COMPOSE_PROJECT_NAME=oraclous-ORA-XXX` from the issue identifier
+2. Runs `docker compose -p oraclous-ORA-XXX down --volumes --remove-orphans`
+3. Removes locally-built images tagged with this issue's branch slug
+
+Dry-run mode (preview without executing):
+
+```bash
+./scripts/agent-docker-cleanup.sh ORA-XXX --dry-run
+```
+
+**Do not skip cleanup.** Orphaned stacks accumulate disk usage, dangling networks, and stale volumes that interfere with future runs.
+
+---
+
+## PR Review Checklist (Mandatory)
+
+The Backend Lead Developer **MUST reject** any PR where:
+
+- [ ] An agent ran `docker compose` without `COMPOSE_PROJECT_NAME=oraclous-{ORA-XXX}`
+- [ ] An agent built or referenced a `:latest` image tag
+- [ ] Task descriptions or CI logs show bare `docker compose up` calls
+- [ ] The cleanup script was not run before branch merge
+
+Add this question to every PR review:
+
+> **Docker isolation protocol followed?** (`COMPOSE_PROJECT_NAME` + `IMAGE_TAG` set? Cleanup script run?)
+
+---
+
+## Rationale
+
+Approved by Reza (ORA-267). Without isolation, concurrent agent workstreams interfere with each other's Docker environments, leading to non-reproducible failures and contaminated test results.
+
+Explicit `container_name:` fields were removed from `docker-compose.yml` to allow `COMPOSE_PROJECT_NAME` to take effect. Hardcoded container names bypass project namespacing and cause `docker: Error response from daemon: Conflict` errors when two stacks are live.
+
+---
+
+*Created by DevOps SRE Specialist — [ORA-265](/ORA/issues/ORA-265). Protocol designed in [ORA-264](/ORA/issues/ORA-264).*

--- a/scripts/agent-docker-cleanup.sh
+++ b/scripts/agent-docker-cleanup.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# agent-docker-cleanup.sh
+#
+# Tears down the Compose stack for a given Oraclous issue/agent workstream.
+# Run this after your branch work is complete or the Docker environment is no
+# longer needed.
+#
+# Usage:
+#   ./scripts/agent-docker-cleanup.sh ORA-265
+#   ./scripts/agent-docker-cleanup.sh ORA-265 --dry-run
+#
+# The script uses the issue identifier to derive COMPOSE_PROJECT_NAME so that
+# only containers/networks/volumes belonging to that stack are removed —
+# other concurrently-running agent stacks are not affected.
+
+set -euo pipefail
+
+ISSUE_ID="${1:-}"
+DRY_RUN="${2:-}"
+
+if [[ -z "$ISSUE_ID" ]]; then
+  echo "Usage: $0 <issue-identifier> [--dry-run]" >&2
+  echo "  e.g. $0 ORA-265" >&2
+  exit 1
+fi
+
+# Normalise to lowercase for Docker project name compatibility
+PROJECT_NAME="oraclous-$(echo "$ISSUE_ID" | tr '[:upper:]' '[:lower:]')"
+
+echo "=> Compose project: $PROJECT_NAME"
+
+if [[ "$DRY_RUN" == "--dry-run" ]]; then
+  echo "[dry-run] Would run: docker compose -p $PROJECT_NAME down --volumes --remove-orphans"
+  exit 0
+fi
+
+# Change to repo root (script may be called from any working directory)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=> Tearing down $PROJECT_NAME ..."
+docker compose -p "$PROJECT_NAME" down --volumes --remove-orphans
+
+echo "=> Removing tagged images for this stack (IMAGE_TAG prefix: ${ISSUE_ID,,}) ..."
+# Remove any locally-built images that carry this issue's tag prefix to free disk space.
+docker images --format '{{.Repository}}:{{.Tag}}' \
+  | grep ":.*$(echo "$ISSUE_ID" | tr '[:upper:]' '[:lower:]')" \
+  | xargs -r docker rmi --force || true
+
+echo "=> Cleanup complete for $PROJECT_NAME"


### PR DESCRIPTION
## Summary

- **`docker-compose.yml`** — adds `image: <service>:${IMAGE_TAG:-dev}` to all locally-built services; removes hardcoded `container_name:` fields so `COMPOSE_PROJECT_NAME` namespacing works correctly across concurrent agent stacks
- **`docker-compose.agent.yml`** — new override with `"0:PORT"` dynamic port mappings for multi-agent environments (prevents host port collisions)
- **`scripts/agent-docker-cleanup.sh`** — automated teardown script (`docker compose -p oraclous-ORA-XXX down --volumes --remove-orphans` + image removal); supports `--dry-run`
- **`knowledge-base/operations/docker-agent-coordination.md`** — full runbook: 3-layer protocol (COMPOSE_PROJECT_NAME + IMAGE_TAG + dynamic ports), startup sequence, `.env.agent` template, cleanup instructions, PR review checklist

## Motivation

Implements the Docker multi-agent isolation protocol approved by Reza in [ORA-267](/ORA/issues/ORA-267). Without this, concurrent agent workstreams share container names, image tags, and host ports — causing non-reproducible failures and test contamination.

## Test plan

- [ ] `docker compose config` passes (no YAML errors) on both `docker-compose.yml` and with the `-f docker-compose.agent.yml` override
- [ ] Start two stacks concurrently with different `COMPOSE_PROJECT_NAME` values — confirm no port or container-name conflicts
- [ ] `./scripts/agent-docker-cleanup.sh ORA-265 --dry-run` prints expected command without executing
- [ ] `./scripts/agent-docker-cleanup.sh ORA-265` tears down only the ORA-265 stack, leaving others untouched

## Related

- Parent: [ORA-264](/ORA/issues/ORA-264) — Multiple Agents using Docker
- Protocol approval: [ORA-267](/ORA/issues/ORA-267)
- Blocked CORS task: [ORA-154](/ORA/issues/ORA-154) (separate, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)