### PR TITLE
fix(tests): mock ensure_memory_indexes to eliminate real Neo4j call in CI (ORA-277)

### DIFF
--- a/knowledge-graph-builder/tests/unit/test_lifespan_sync_driver.py
+++ b/knowledge-graph-builder/tests/unit/test_lifespan_sync_driver.py
@@ -107,6 +107,11 @@ async def test_lifespan_calls_connect_sync(monkeypatch):
                 mock_sa_service,
                 create=True,
             ),
+            patch(
+                "app.services.memory_service.ensure_memory_indexes",
+                AsyncMock(),
+                create=True,
+            ),
             patch.object(main_module, "neo4j_client", mock_client),
         ):
             async with lifespan_fn(app_obj):


### PR DESCRIPTION
## Summary

- Adds `AsyncMock` for `app.services.memory_service.ensure_memory_indexes` in `test_lifespan_calls_connect_sync`
- Since ORA-254 merged, the lifespan now calls `ensure_memory_indexes()` which tried connecting to `localhost:7687` in CI — timing out after 131s
- No production code changed; mock is scoped to this single unit test

## Root Cause

ORA-254 added `await ensure_memory_indexes()` to the lifespan startup sequence. The existing unit test mocked every other startup call but not this one, causing a real Neo4j connection attempt in CI.

## Test Results

```
tests/unit/test_lifespan_sync_driver.py::test_lifespan_calls_connect_sync PASSED (0.06s)
tests/unit/test_lifespan_sync_driver.py::test_main_py_calls_connect_sync_after_connect PASSED
```

## Acceptance Criteria Met

- [x] `test_lifespan_calls_connect_sync` passes without live Neo4j
- [x] Mock scoped to unit test only — no production code changes
- [x] All other sync driver tests continue to pass
- [x] Lint & format clean (black, isort, ruff)

Closes ORA-277. Unblocks ORA-275 and ORA-262 PR #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)