### PR TITLE
fix(graph_node_service): MERGE shadow node in update_graph() — ORA-290

### DIFF
--- a/knowledge-graph-builder/app/services/graph_node_service.py
+++ b/knowledge-graph-builder/app/services/graph_node_service.py
@@ -278,10 +278,11 @@ class GraphNodeService:
 
         if federatable is not None:
             # Sync shadow node atomically so federation_service reads the updated flag.
-            # OPTIONAL MATCH is a no-op when the shadow node does not yet exist.
+            # MERGE ensures the shadow node is created if it does not yet exist.
+            # Only SET shadow.federatable — never overwrite owner_user_id, graph_name, etc.
             query = f"""
         MATCH (g:Graph {{graph_id: $graph_id, user_id: $user_id}})
-        OPTIONAL MATCH (shadow:Graph {{graph_id: $graph_id, namespace: "__system__"}})
+        MERGE (shadow:Graph {{graph_id: $graph_id, namespace: "__system__"}})
         SET {set_clause}, shadow.federatable = $federatable
         RETURN g {{
             .graph_id,

--- a/knowledge-graph-builder/tests/unit/test_graph_node_service.py
+++ b/knowledge-graph-builder/tests/unit/test_graph_node_service.py
@@ -405,8 +405,8 @@ class TestUpdateGraph:
 
     @pytest.mark.unit
     def test_update_graph_federatable_syncs_shadow_node(self):
-        """When federatable is updated, the Cypher must also SET shadow.federatable
-        so that federation_service reads the correct flag from the ReBAC shadow node.
+        """When federatable is updated, the Cypher must MERGE the shadow node and
+        SET shadow.federatable so that federation_service reads the correct flag.
         """
         mock_driver, mock_session, mock_result, _ = _make_driver()
         mock_result.single.return_value = None  # return value doesn't matter here
@@ -420,12 +420,66 @@ class TestUpdateGraph:
 
         assert (
             'namespace: "__system__"' in query
-        ), "Shadow node OPTIONAL MATCH missing from query when federatable is updated"
+        ), "Shadow node MERGE missing from query when federatable is updated"
+        assert (
+            "MERGE" in query
+        ), "MERGE must be used for shadow node (not OPTIONAL MATCH) to create if absent"
         assert (
             "shadow.federatable" in query
         ), "SET shadow.federatable missing from query when federatable is updated"
         assert params.get("federatable") is True
         assert params.get("graph_id") == "g-1"
+
+    @pytest.mark.unit
+    def test_update_graph_shadow_merge_bootstrap_path(self):
+        """Bootstrap path: when no shadow node exists, MERGE must create it.
+
+        Verified by asserting MERGE (not OPTIONAL MATCH) appears in the query,
+        meaning a missing shadow node will be created rather than silently skipped.
+        """
+        mock_driver, mock_session, mock_result, _ = _make_driver()
+        mock_result.single.return_value = None
+
+        svc = GraphNodeService(mock_driver)
+        svc.update_graph("g-new", "user-1", federatable=True)
+
+        call_args = mock_session.run.call_args
+        query: str = call_args[0][0] if call_args[0] else ""
+        params: dict = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
+
+        assert (
+            "MERGE" in query
+        ), "Shadow node must use MERGE so it is created when absent"
+        assert (
+            "OPTIONAL MATCH" not in query
+        ), "OPTIONAL MATCH must not be used for shadow node"
+        assert 'namespace: "__system__"' in query
+        assert params.get("graph_id") == "g-new"
+        assert params.get("federatable") is True
+
+    @pytest.mark.unit
+    def test_update_graph_shadow_merge_update_path_preserves_other_props(self):
+        """Update path: shadow MERGE must only SET federatable — not overwrite other props.
+
+        Verified by asserting the SET clause targets shadow.federatable specifically
+        and does not use SET shadow = {…} (which would wipe owner_user_id, graph_name, etc.).
+        """
+        mock_driver, mock_session, mock_result, _ = _make_driver()
+        mock_result.single.return_value = None
+
+        svc = GraphNodeService(mock_driver)
+        svc.update_graph("g-existing", "user-1", federatable=False)
+
+        call_args = mock_session.run.call_args
+        query: str = call_args[0][0] if call_args[0] else ""
+        params: dict = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
+
+        assert "shadow.federatable" in query, "Must SET shadow.federatable specifically"
+        # Ensure we're not doing a destructive SET shadow = {...} that wipes all properties
+        assert (
+            "SET shadow = " not in query
+        ), "Must not overwrite all shadow node properties"
+        assert params.get("federatable") is False
 
     @pytest.mark.unit
     def test_update_graph_no_shadow_sync_when_federatable_not_provided(self):


### PR DESCRIPTION
## Summary

Fixes the silent no-op in `graph_node_service.update_graph()` when `federatable` is set but the ReBAC shadow node does not yet exist (root issue: [ORA-287](/ORA/issues/ORA-287), impl task: [ORA-290](/ORA/issues/ORA-290)).

- **Root cause:** `OPTIONAL MATCH` on a non-existent shadow node returns `null`; `SET null.federatable` is silently discarded by Neo4j — so `PUT /graphs/{id}` with `federatable: true` on a freshly-created graph never wrote the flag to the shadow node.
- **Fix:** Replace `OPTIONAL MATCH` with `MERGE` so the shadow node is created if absent. Only `shadow.federatable` is SET — `owner_user_id`, `graph_name`, and other existing shadow properties are preserved.

## Files Changed

| File | Change |
|---|---|
| `knowledge-graph-builder/app/services/graph_node_service.py` | `OPTIONAL MATCH` → `MERGE` for shadow node in `update_graph()` |
| `knowledge-graph-builder/tests/unit/test_graph_node_service.py` | Updated MERGE assertion comment; added 2 new unit tests |

## Tests Added

| Test | Coverage |
|---|---|
| `test_update_graph_shadow_merge_bootstrap_path` | Bootstrap: MERGE creates shadow node when absent, `OPTIONAL MATCH` absent |
| `test_update_graph_shadow_merge_update_path_preserves_other_props` | Update: only `shadow.federatable` is SET, no destructive overwrite |

All 714 unit tests pass. Lint (black/isort/ruff) clean.

## Cypher Security Checklist

- [x] All Cypher queries parameterized (no f-string interpolation of user input)
- [x] `graph_id` filter on every query (multi-tenancy gate)
- [x] No GDS projections (not applicable)
- [x] No info leakage in error responses

## How to Verify

```bash
pytest -m unit tests/unit/test_graph_node_service.py::TestUpdateGraph -v
# Expect: 7 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)