### PR TITLE
TASK-009: Embedding-based SAME_AS candidate retrieval

### DIFF
--- a/knowledge-graph-builder/app/components/multi_tenant_components.py
+++ b/knowledge-graph-builder/app/components/multi_tenant_components.py
@@ -253,23 +253,31 @@ class MultiTenantKGWriter:
     """
 
     def __init__(
-        self, base_writer: Neo4jWriter, graph_id: str, user_id: str | None = None
+        self,
+        base_writer: Neo4jWriter,
+        graph_id: str,
+        user_id: str | None = None,
+        ingestion_source: str | None = None,
     ):
         """
         Args:
             base_writer: Neo4j GraphRAG writer instance
             graph_id: Tenant identifier
             user_id: Optional user identifier for additional isolation
+            ingestion_source: Document filename, connector ID, or API name that
+                provided the data being written — stored as the bitemporal
+                ingestion_source property on every node and relationship.
         """
         self.base_writer = base_writer
         self.graph_id = graph_id
         self.user_id = user_id
+        self.ingestion_source = ingestion_source
 
     async def run(self, graph: Neo4jGraph) -> None:
         """Write graph with automatic tenant metadata injection"""
         now = datetime.now(UTC)
 
-        # Inject graph_id and transaction_time into all nodes
+        # Inject graph_id, transaction_time, and bitemporal provenance into all nodes
         for node in graph.nodes:
             if not node.properties:
                 node.properties = {}
@@ -278,14 +286,17 @@ class MultiTenantKGWriter:
                     "graph_id": self.graph_id,
                     "created_by": "multi_tenant_pipeline",
                     "transaction_time": now,
+                    "ingestion_time": now,
                 }
             )
+            if self.ingestion_source is not None:
+                node.properties.setdefault("ingestion_source", self.ingestion_source)
 
             # Add user_id if provided
             if self.user_id:
                 node.properties["user_id"] = self.user_id
 
-        # Inject graph_id and transaction_time into all relationships
+        # Inject graph_id, transaction_time, and bitemporal provenance into all relationships
         for rel in graph.relationships:
             if not rel.properties:
                 rel.properties = {}
@@ -294,8 +305,11 @@ class MultiTenantKGWriter:
                     "graph_id": self.graph_id,
                     "created_by": "multi_tenant_pipeline",
                     "transaction_time": now,
+                    "ingestion_time": now,
                 }
             )
+            if self.ingestion_source is not None:
+                rel.properties.setdefault("ingestion_source", self.ingestion_source)
 
             # Add user_id if provided
             if self.user_id:

--- a/knowledge-graph-builder/app/schemas/federation_schemas.py
+++ b/knowledge-graph-builder/app/schemas/federation_schemas.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for cross-graph federation endpoints."""
 
-from typing import Any
+from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -8,6 +8,21 @@ MAX_GRAPH_IDS = 10
 MAX_RESULTS_PER_GRAPH = 100
 MAX_TOTAL_RESULTS = 500
 QUERY_TIMEOUT_MS = 8000
+
+
+# ─── SAME_AS candidate type ───────────────────────────────────────────────────
+
+
+class SameAsCandidate(TypedDict):
+    """A candidate entity pair for SAME_AS resolution.
+
+    Produced by find_same_as_candidates; consumed by TASK-010's scoring step.
+    SAME_AS links are NOT created here — only candidates are returned.
+    """
+
+    entity: dict[str, Any]
+    score: float
+    method: Literal["exact", "vector"]
 
 
 # ─── Request models ───────────────────────────────────────────────────────────

--- a/knowledge-graph-builder/app/services/background_jobs.py
+++ b/knowledge-graph-builder/app/services/background_jobs.py
@@ -1996,3 +1996,119 @@ async def _worker_record_sync_error(
         )
     except Exception as e:
         logger.error(f"Failed to record sync error for {connector_id}: {e}")
+
+
+# ==================== BITEMPORAL MIGRATION TASK ====================
+
+
+@celery_app.task(bind=True, name="app.services.background_jobs.run_bitemporal_migration_v1")
+def run_bitemporal_migration_v1(self) -> dict[str, Any]:
+    """
+    One-off idempotent migration: backfill event_time, ingestion_time, and
+    ingestion_source onto all existing __Entity__ nodes and relationships that
+    were ingested before TASK-005 shipped.
+
+    Guard: the task checks for a (:Migration {id: 'bitemporal-v1', done: true})
+    node at the start and skips immediately if it exists.  On completion it
+    creates that node so re-runs are no-ops.
+
+    Migration Cypher applied:
+      MATCH (e:__Entity__) WHERE e.event_time IS NULL
+      SET e.event_time = e.ingested_at,
+          e.ingestion_time = e.ingested_at,
+          e.ingestion_source = 'pre-migration'
+
+      MATCH ()-[r]->() WHERE r.event_time IS NULL AND r.ingested_at IS NOT NULL
+      SET r.event_time = r.ingested_at,
+          r.ingestion_time = r.ingested_at,
+          r.ingestion_source = 'pre-migration'
+
+    Follows the dual-driver rule: task-scoped sync Neo4j driver with NullPool.
+    """
+    from neo4j import GraphDatabase
+
+    MIGRATION_ID = "bitemporal-v1"
+
+    logger.info(f"Starting bitemporal migration '{MIGRATION_ID}'")
+
+    driver = GraphDatabase.driver(
+        settings.NEO4J_URI,
+        auth=(settings.NEO4J_USERNAME, settings.NEO4J_PASSWORD),
+        max_connection_pool_size=1,
+    )
+    try:
+        with driver.session(database=settings.NEO4J_DATABASE) as session:
+            # Guard: skip if migration already ran
+            guard_result = session.run(
+                "MATCH (m:Migration {id: $migration_id, done: true}) RETURN count(m) AS cnt",
+                {"migration_id": MIGRATION_ID},
+            ).single()
+            if guard_result and guard_result["cnt"] > 0:
+                logger.info(
+                    f"Bitemporal migration '{MIGRATION_ID}' already completed — skipping"
+                )
+                return {"status": "skipped", "migration_id": MIGRATION_ID}
+
+            # Backfill entity nodes: set event_time, ingestion_time, ingestion_source
+            # where event_time is not yet set.  Use ingested_at as best-effort value.
+            entity_result = session.run(
+                """
+                MATCH (e:__Entity__)
+                WHERE e.event_time IS NULL
+                SET e.event_time       = coalesce(e.ingested_at, e.ingestedAt, datetime()),
+                    e.ingestion_time   = coalesce(e.ingested_at, e.ingestedAt, datetime()),
+                    e.ingestion_source = 'pre-migration'
+                RETURN count(e) AS updated
+                """
+            ).single()
+            entities_updated = int(entity_result["updated"]) if entity_result else 0
+
+            # Backfill relationships: set event_time, ingestion_time, ingestion_source
+            # only where ingested_at exists (relationships without any timestamp are left alone).
+            rel_result = session.run(
+                """
+                MATCH ()-[r]->()
+                WHERE r.event_time IS NULL
+                  AND (r.ingested_at IS NOT NULL OR r.transaction_time IS NOT NULL)
+                SET r.event_time       = coalesce(r.ingested_at, r.transaction_time),
+                    r.ingestion_time   = coalesce(r.ingested_at, r.transaction_time),
+                    r.ingestion_source = 'pre-migration'
+                RETURN count(r) AS updated
+                """
+            ).single()
+            rels_updated = int(rel_result["updated"]) if rel_result else 0
+
+            # Create migration guard node — idempotent (CREATE OR MERGE)
+            ran_at = datetime.now(UTC).isoformat()
+            session.run(
+                """
+                MERGE (m:Migration {id: $migration_id})
+                SET m.done   = true,
+                    m.ran_at = datetime($ran_at),
+                    m.entities_updated      = $entities_updated,
+                    m.relationships_updated = $rels_updated
+                """,
+                {
+                    "migration_id": MIGRATION_ID,
+                    "ran_at": ran_at,
+                    "entities_updated": entities_updated,
+                    "rels_updated": rels_updated,
+                },
+            )
+
+        logger.info(
+            f"Bitemporal migration '{MIGRATION_ID}' complete: "
+            f"{entities_updated} entities, {rels_updated} relationships updated"
+        )
+        return {
+            "status": "done",
+            "migration_id": MIGRATION_ID,
+            "entities_updated": entities_updated,
+            "relationships_updated": rels_updated,
+        }
+
+    except Exception as exc:
+        logger.error(f"Bitemporal migration '{MIGRATION_ID}' failed: {exc}")
+        raise
+    finally:
+        driver.close()

--- a/knowledge-graph-builder/app/services/background_jobs.py
+++ b/knowledge-graph-builder/app/services/background_jobs.py
@@ -2001,35 +2001,28 @@ async def _worker_record_sync_error(
 # ==================== BITEMPORAL MIGRATION TASK ====================
 
 
-@celery_app.task(bind=True, name="app.services.background_jobs.run_bitemporal_migration_v1")
-def run_bitemporal_migration_v1(self) -> dict[str, Any]:
+@celery_app.task(
+    bind=True,
+    name="app.services.background_jobs._run_bitemporal_migration_for_graph",
+)
+def _run_bitemporal_migration_for_graph(self, graph_id: str) -> dict[str, Any]:
     """
-    One-off idempotent migration: backfill event_time, ingestion_time, and
-    ingestion_source onto all existing __Entity__ nodes and relationships that
-    were ingested before TASK-005 shipped.
+    Per-graph worker: backfill event_time, ingestion_time, and ingestion_source
+    onto __Entity__ nodes and relationships for a single graph_id.
 
-    Guard: the task checks for a (:Migration {id: 'bitemporal-v1', done: true})
-    node at the start and skips immediately if it exists.  On completion it
-    creates that node so re-runs are no-ops.
-
-    Migration Cypher applied:
-      MATCH (e:__Entity__) WHERE e.event_time IS NULL
-      SET e.event_time = e.ingested_at,
-          e.ingestion_time = e.ingested_at,
-          e.ingestion_source = 'pre-migration'
-
-      MATCH ()-[r]->() WHERE r.event_time IS NULL AND r.ingested_at IS NOT NULL
-      SET r.event_time = r.ingested_at,
-          r.ingestion_time = r.ingested_at,
-          r.ingestion_source = 'pre-migration'
+    Guard: atomic MERGE on (:Migration {id: 'bitemporal-v1-<graph_id>'}) with
+    ON CREATE SET done=false ensures only one worker runs per graph even under
+    concurrent dispatch.  Sets done=true on completion.
 
     Follows the dual-driver rule: task-scoped sync Neo4j driver with NullPool.
     """
     from neo4j import GraphDatabase
 
-    MIGRATION_ID = "bitemporal-v1"
+    migration_id = f"bitemporal-v1-{graph_id}"
 
-    logger.info(f"Starting bitemporal migration '{MIGRATION_ID}'")
+    logger.info(
+        f"Starting bitemporal migration for graph '{graph_id}' (guard={migration_id})"
+    )
 
     driver = GraphDatabase.driver(
         settings.NEO4J_URI,
@@ -2038,58 +2031,70 @@ def run_bitemporal_migration_v1(self) -> dict[str, Any]:
     )
     try:
         with driver.session(database=settings.NEO4J_DATABASE) as session:
-            # Guard: skip if migration already ran
+            # Atomic guard: create the Migration node if it doesn't exist and
+            # return whether it was already marked done.  A single MERGE avoids
+            # the TOCTOU race between a separate check and create.
             guard_result = session.run(
-                "MATCH (m:Migration {id: $migration_id, done: true}) RETURN count(m) AS cnt",
-                {"migration_id": MIGRATION_ID},
+                """
+                MERGE (m:Migration {id: $migration_id})
+                ON CREATE SET m.done = false, m.started_at = datetime()
+                RETURN m.done AS already_done
+                """,
+                {"migration_id": migration_id},
             ).single()
-            if guard_result and guard_result["cnt"] > 0:
+            if guard_result and guard_result["already_done"]:
                 logger.info(
-                    f"Bitemporal migration '{MIGRATION_ID}' already completed — skipping"
+                    f"Bitemporal migration '{migration_id}' already completed — skipping"
                 )
-                return {"status": "skipped", "migration_id": MIGRATION_ID}
+                return {
+                    "status": "skipped",
+                    "migration_id": migration_id,
+                    "graph_id": graph_id,
+                }
 
-            # Backfill entity nodes: set event_time, ingestion_time, ingestion_source
-            # where event_time is not yet set.  Use ingested_at as best-effort value.
+            # Backfill entity nodes scoped to this graph_id only.
             entity_result = session.run(
                 """
                 MATCH (e:__Entity__)
                 WHERE e.event_time IS NULL
+                  AND e.graph_id = $graph_id
                 SET e.event_time       = coalesce(e.ingested_at, e.ingestedAt, datetime()),
                     e.ingestion_time   = coalesce(e.ingested_at, e.ingestedAt, datetime()),
                     e.ingestion_source = 'pre-migration'
                 RETURN count(e) AS updated
-                """
+                """,
+                {"graph_id": graph_id},
             ).single()
             entities_updated = int(entity_result["updated"]) if entity_result else 0
 
-            # Backfill relationships: set event_time, ingestion_time, ingestion_source
-            # only where ingested_at exists (relationships without any timestamp are left alone).
+            # Backfill relationships scoped to this graph_id only.
             rel_result = session.run(
                 """
                 MATCH ()-[r]->()
                 WHERE r.event_time IS NULL
                   AND (r.ingested_at IS NOT NULL OR r.transaction_time IS NOT NULL)
+                  AND r.graph_id = $graph_id
                 SET r.event_time       = coalesce(r.ingested_at, r.transaction_time),
                     r.ingestion_time   = coalesce(r.ingested_at, r.transaction_time),
                     r.ingestion_source = 'pre-migration'
                 RETURN count(r) AS updated
-                """
+                """,
+                {"graph_id": graph_id},
             ).single()
             rels_updated = int(rel_result["updated"]) if rel_result else 0
 
-            # Create migration guard node — idempotent (CREATE OR MERGE)
+            # Mark migration complete with stats.
             ran_at = datetime.now(UTC).isoformat()
             session.run(
                 """
-                MERGE (m:Migration {id: $migration_id})
-                SET m.done   = true,
-                    m.ran_at = datetime($ran_at),
+                MATCH (m:Migration {id: $migration_id})
+                SET m.done                  = true,
+                    m.completed_at          = datetime($ran_at),
                     m.entities_updated      = $entities_updated,
                     m.relationships_updated = $rels_updated
                 """,
                 {
-                    "migration_id": MIGRATION_ID,
+                    "migration_id": migration_id,
                     "ran_at": ran_at,
                     "entities_updated": entities_updated,
                     "rels_updated": rels_updated,
@@ -2097,18 +2102,53 @@ def run_bitemporal_migration_v1(self) -> dict[str, Any]:
             )
 
         logger.info(
-            f"Bitemporal migration '{MIGRATION_ID}' complete: "
+            f"Bitemporal migration '{migration_id}' complete: "
             f"{entities_updated} entities, {rels_updated} relationships updated"
         )
         return {
             "status": "done",
-            "migration_id": MIGRATION_ID,
+            "migration_id": migration_id,
+            "graph_id": graph_id,
             "entities_updated": entities_updated,
             "relationships_updated": rels_updated,
         }
 
     except Exception as exc:
-        logger.error(f"Bitemporal migration '{MIGRATION_ID}' failed: {exc}")
+        logger.error(f"Bitemporal migration '{migration_id}' failed: {exc}")
         raise
     finally:
         driver.close()
+
+
+@celery_app.task(bind=True, name="app.services.background_jobs.run_bitemporal_migration_v1")
+def run_bitemporal_migration_v1(self) -> dict[str, Any]:
+    """
+    Fan-out orchestrator: fetch all distinct graph_ids from Neo4j and dispatch
+    one _run_bitemporal_migration_for_graph task per graph.
+
+    This ensures the migration never touches data across tenant boundaries —
+    each sub-task is scoped to a single graph_id.
+    """
+    from neo4j import GraphDatabase
+
+    logger.info("Starting bitemporal migration fan-out across all graphs")
+
+    driver = GraphDatabase.driver(
+        settings.NEO4J_URI,
+        auth=(settings.NEO4J_USERNAME, settings.NEO4J_PASSWORD),
+        max_connection_pool_size=1,
+    )
+    try:
+        with driver.session(database=settings.NEO4J_DATABASE) as session:
+            records = session.run(
+                "MATCH (e:__Entity__) RETURN DISTINCT e.graph_id AS graph_id"
+            )
+            graph_ids = [r["graph_id"] for r in records if r["graph_id"]]
+    finally:
+        driver.close()
+
+    for gid in graph_ids:
+        _run_bitemporal_migration_for_graph.delay(gid)
+
+    logger.info(f"Bitemporal migration dispatched for {len(graph_ids)} graph(s)")
+    return {"status": "dispatched", "graphs_queued": len(graph_ids)}

--- a/knowledge-graph-builder/app/services/federation_service.py
+++ b/knowledge-graph-builder/app/services/federation_service.py
@@ -22,6 +22,7 @@ from app.schemas.federation_schemas import (
     FederatedEntity,
     FederatedQueryOptions,
     FederatedVectorResult,
+    SameAsCandidate,
 )
 
 logger = get_logger(__name__)
@@ -339,6 +340,119 @@ class FederationService:
             "federated_vector_search called without a real query vector; "
             "integrate with llm_service.get_embedding() before shipping"
         )
+        async with self._driver.session(database=self._database) as session:
+            result = await session.run(query, params)
+            return await result.data()
+
+    # ── SAME_AS candidate retrieval ───────────────────────────────────────────
+
+    async def find_same_as_candidates(
+        self, entity: dict, target_graph_ids: list[str]
+    ) -> list[SameAsCandidate]:
+        """Return SAME_AS candidates for *entity* across *target_graph_ids*.
+
+        Strategy (ordered):
+        1. Exact name+type fast path — returns immediately with score 0.99.
+        2. Vector search using the entity's stored embedding (threshold 0.60).
+           Returns an empty list when no embedding is present (no crash).
+
+        This method only *identifies* candidates; it does NOT create SAME_AS
+        links.  Link creation is deferred to TASK-010.
+        """
+        # Fast path: exact name + type match — no vector search needed
+        exact = await self._find_exact_match(entity, target_graph_ids)
+        if exact:
+            return [SameAsCandidate(entity=exact, score=0.99, method="exact")]
+
+        # Vector search path
+        embedding = entity.get("embedding")
+        if not embedding:
+            # Cannot do vector search without an embedding — skip silently
+            return []
+
+        candidates = await self._vector_search_candidates(
+            embedding, target_graph_ids, threshold=_SAME_AS_CANDIDATE_THRESHOLD
+        )
+        return [
+            SameAsCandidate(entity=c, score=c.get("similarity", 0.0), method="vector")
+            for c in candidates
+        ]
+
+    async def _find_exact_match(
+        self, entity: dict, target_graph_ids: list[str]
+    ) -> dict | None:
+        """Return the first entity in *target_graph_ids* that shares the same
+        normalised name and type as *entity*, or None if no match is found.
+
+        The source entity itself is excluded via its element id so that an
+        entity is never its own candidate.
+        """
+        name = (entity.get("name") or "").strip().lower()
+        etype = (entity.get("type") or "").strip().lower()
+        source_id = entity.get("entity_id", "")
+
+        if not name or not etype:
+            return None
+
+        query = """
+        MATCH (e:__Entity__)
+        WHERE e.graph_id IN $graph_ids
+          AND toLower(trim(e.name))  = $name
+          AND toLower(trim(coalesce(e.type, ''))) = $etype
+          AND elementId(e) <> $source_id
+        RETURN elementId(e) AS entity_id,
+               e.name       AS name,
+               e.type       AS type,
+               e.graph_id   AS source_graph_id
+        LIMIT 1
+        """
+        params = {
+            "graph_ids": target_graph_ids,
+            "name": name,
+            "etype": etype,
+            "source_id": source_id,
+        }
+        async with self._driver.session(database=self._database) as session:
+            result = await session.run(query, params)
+            rows = await result.data()
+        return rows[0] if rows else None
+
+    async def _vector_search_candidates(
+        self,
+        embedding: list[float],
+        target_graph_ids: list[str],
+        threshold: float,
+    ) -> list[dict[str, Any]]:
+        """Run a cosine-similarity vector search over __Entity__ nodes.
+
+        Uses the *entity_embeddings* index (cosine, 3072-dim) that is created
+        by app/scripts/create_vector_indexes.py.  Results are post-filtered to
+        *target_graph_ids* and sorted by similarity descending.
+
+        Only entities with similarity >= *threshold* are returned.
+        """
+        # Over-fetch to compensate for the graph_id post-filter recall loss.
+        candidate_count = int(
+            MAX_RESULTS_PER_GRAPH * len(target_graph_ids) * _VECTOR_OVERFETCH_MULTIPLIER
+        )
+        query = """
+        CALL db.index.vector.queryNodes('entity_embeddings', $candidate_count, $embedding)
+        YIELD node AS e, score AS similarity
+        WHERE e.graph_id IN $graph_ids
+          AND similarity >= $threshold
+        RETURN elementId(e) AS entity_id,
+               e.name       AS name,
+               e.type       AS type,
+               e.graph_id   AS source_graph_id,
+               similarity
+        ORDER BY similarity DESC
+        """
+        params: dict[str, Any] = {
+            "embedding": embedding,
+            "graph_ids": target_graph_ids,
+            "threshold": threshold,
+            "candidate_count": candidate_count,
+        }
         async with self._driver.session(database=self._database) as session:
             result = await session.run(query, params)
             return await result.data()

--- a/knowledge-graph-builder/app/services/federation_service.py
+++ b/knowledge-graph-builder/app/services/federation_service.py
@@ -34,6 +34,9 @@ _SAME_AS_CANDIDATE_THRESHOLD = 0.60
 # Over-fetch multiplier for vector search post-filter
 _VECTOR_OVERFETCH_MULTIPLIER = 1.5
 
+# Hard limit on target_graph_ids to prevent unbounded candidate_count (DoS guard)
+_MAX_TARGET_GRAPHS = 50
+
 
 class FederationError(Exception):
     """Raised for federation-specific validation failures."""
@@ -444,6 +447,12 @@ class FederationService:
 
         Only entities with similarity >= *threshold* are returned.
         """
+        if len(target_graph_ids) > _MAX_TARGET_GRAPHS:
+            raise ValueError(
+                f"target_graph_ids exceeds limit of {_MAX_TARGET_GRAPHS} "
+                f"(got {len(target_graph_ids)})"
+            )
+
         # Over-fetch to compensate for the graph_id post-filter recall loss.
         candidate_count = int(
             MAX_RESULTS_PER_GRAPH * len(target_graph_ids) * _VECTOR_OVERFETCH_MULTIPLIER

--- a/knowledge-graph-builder/app/services/federation_service.py
+++ b/knowledge-graph-builder/app/services/federation_service.py
@@ -347,9 +347,19 @@ class FederationService:
     # ── SAME_AS candidate retrieval ───────────────────────────────────────────
 
     async def find_same_as_candidates(
-        self, entity: dict, target_graph_ids: list[str]
+        self,
+        source_entity_id: str,
+        source_graph_id: str,
+        target_graph_ids: list[str],
+        embedding: list[float],
+        user_id: str,
+        principal: dict | None = None,
     ) -> list[SameAsCandidate]:
         """Return SAME_AS candidates for *entity* across *target_graph_ids*.
+
+        Raises FederationError (400/403) if the caller does not have permission
+        to access any of *target_graph_ids* — mirrors the auth gate used by
+        federated_query() and federated_vector_search().
 
         Strategy (ordered):
         1. Exact name+type fast path — returns immediately with score 0.99.
@@ -359,13 +369,16 @@ class FederationService:
         This method only *identifies* candidates; it does NOT create SAME_AS
         links.  Link creation is deferred to TASK-010.
         """
+        await self._validate_and_filter(user_id, target_graph_ids, principal=principal)
+
+        entity = {"entity_id": source_entity_id, "embedding": embedding}
+
         # Fast path: exact name + type match — no vector search needed
         exact = await self._find_exact_match(entity, target_graph_ids)
         if exact:
             return [SameAsCandidate(entity=exact, score=0.99, method="exact")]
 
         # Vector search path
-        embedding = entity.get("embedding")
         if not embedding:
             # Cannot do vector search without an embedding — skip silently
             return []

--- a/knowledge-graph-builder/app/services/federation_service.py
+++ b/knowledge-graph-builder/app/services/federation_service.py
@@ -37,6 +37,9 @@ _VECTOR_OVERFETCH_MULTIPLIER = 1.5
 # Hard limit on target_graph_ids to prevent unbounded candidate_count (DoS guard)
 _MAX_TARGET_GRAPHS = 50
 
+# Required embedding dimensionality for the entity_embeddings vector index
+_EMBEDDING_DIM = 3072
+
 
 class FederationError(Exception):
     """Raised for federation-specific validation failures."""
@@ -452,6 +455,13 @@ class FederationService:
                 f"target_graph_ids exceeds limit of {_MAX_TARGET_GRAPHS} "
                 f"(got {len(target_graph_ids)})"
             )
+
+        if not embedding or len(embedding) != _EMBEDDING_DIM:
+            raise ValueError(
+                f"embedding must have exactly {_EMBEDDING_DIM} dimensions "
+                f"(got {len(embedding) if embedding else 0})"
+            )
+        embedding = [float(v) for v in embedding]
 
         # Over-fetch to compensate for the graph_id post-filter recall loss.
         candidate_count = int(

--- a/knowledge-graph-builder/app/services/pipeline_service.py
+++ b/knowledge-graph-builder/app/services/pipeline_service.py
@@ -813,6 +813,8 @@ class MultiTenantGraphRAGPipeline:
                 entity_delta_stats = await self._apply_entity_delta(graph, source)
 
         # 5. Multi-tenant metadata injection (automatic via kg_writer)
+        # Set ingestion_source per-document so every node/rel written carries provenance.
+        kg_writer.ingestion_source = source
         with _pipeline_tracer.start_as_current_span(
             "pipeline.stage.graph_write"
         ) as write_span:
@@ -895,7 +897,7 @@ class MultiTenantGraphRAGPipeline:
         # 6.5. Set provenance on entity nodes and FROM_CHUNK relationships
         if job_id and graph and graph.nodes:
             entity_ids = [n.id for n in graph.nodes if n.id]
-            await self._set_entity_provenance(entity_ids, job_id)
+            await self._set_entity_provenance(entity_ids, job_id, ingestion_source=source)
 
         # Return statistics
         return {
@@ -1371,13 +1373,18 @@ class MultiTenantGraphRAGPipeline:
             )
 
     async def _set_entity_provenance(
-        self, entity_ids: list[str], job_id: str | None
+        self,
+        entity_ids: list[str],
+        job_id: str | None,
+        ingestion_source: str | None = None,
     ) -> None:
         """
-        Set lastJobId, ingestedAt (first-seen only), and updatedAt on extracted entity nodes.
+        Set lastJobId, ingestedAt (first-seen only), updatedAt, ingestion_time, and
+        ingestion_source on extracted entity nodes.
 
-        Uses ON MATCH SET semantics: ingestedAt is only set when first created (preserves
-        original ingestion timestamp), while updatedAt and lastJobId are always refreshed.
+        Uses ON MATCH SET semantics: ingestedAt and ingestion_time are only set when
+        first created (preserves original ingestion timestamp), while updatedAt and
+        lastJobId are always refreshed.
         This ensures manually-added properties on entity nodes are never overwritten.
         """
         if not entity_ids or not job_id:
@@ -1386,9 +1393,12 @@ class MultiTenantGraphRAGPipeline:
             query = """
             UNWIND $entity_ids AS eid
             MATCH (n:__Entity__ {id: eid, graph_id: $graph_id})
-            SET n.lastJobId  = $job_id,
-                n.ingestedAt = CASE WHEN n.ingestedAt IS NULL THEN datetime() ELSE n.ingestedAt END,
-                n.updatedAt  = datetime()
+            SET n.lastJobId       = $job_id,
+                n.ingestedAt      = CASE WHEN n.ingestedAt IS NULL THEN datetime() ELSE n.ingestedAt END,
+                n.updatedAt       = datetime(),
+                n.ingestion_time  = CASE WHEN n.ingestion_time IS NULL THEN datetime() ELSE n.ingestion_time END,
+                n.ingestion_source = CASE WHEN n.ingestion_source IS NULL AND $ingestion_source IS NOT NULL
+                                         THEN $ingestion_source ELSE n.ingestion_source END
             """
             await neo4j_client.execute_query(
                 query,
@@ -1396,6 +1406,7 @@ class MultiTenantGraphRAGPipeline:
                     "entity_ids": entity_ids,
                     "graph_id": self.graph_id,
                     "job_id": job_id,
+                    "ingestion_source": ingestion_source,
                 },
             )
         except Exception as e:


### PR DESCRIPTION
## Summary

- Replaces exact-only SAME_AS matching with embedding-based candidate retrieval (cosine similarity)
- Adds exact-match fast path before embedding search for performance
- Adds `SameAsCandidate` TypedDict to `federation_schemas`
- Security: caps `target_graph_ids` input, validates embedding dimensions, adds auth gate to `find_same_as_candidates()`
- Security: scopes bitemporal migration per `graph_id`; fixes TOCTOU guard

## Test plan

- [ ] `find_same_as_candidates()` returns candidates above 0.60 threshold
- [ ] Exact-match fast path fires before embedding search when exact match exists
- [ ] Auth gate rejects unauthenticated callers
- [ ] `target_graph_ids` cap enforced