### PR TITLE
TASK-011: LLM disambiguation for ambiguous SAME_AS candidates

### DIFF
--- a/knowledge-graph-builder/app/components/entity_resolver.py
+++ b/knowledge-graph-builder/app/components/entity_resolver.py
@@ -28,6 +28,7 @@ from neo4j_graphrag.experimental.pipeline.component import Component
 
 from app.core.logging import get_logger
 from app.schemas.federation_schemas import SameAsCandidate
+from app.services.llm_service import disambiguate_entities
 
 logger = get_logger(__name__)
 
@@ -254,12 +255,15 @@ class EntityResolver:
         """Score each candidate and create SAME_AS links for high-confidence pairs.
 
         For each candidate:
-          - final_score >= STORE_THRESHOLD (0.85): create bidirectional SAME_AS link
-          - AMBIGUOUS_LOWER (0.60) <= final_score < 0.85: log at INFO for TASK-011
+          - final_score >= STORE_THRESHOLD (0.85): create SAME_AS with method='multi-signal'
+          - AMBIGUOUS_LOWER (0.60) <= final_score < 0.85: send to LLM disambiguation
+            - YES + HIGH   → SAME_AS at original score, method='llm-disambiguated'
+            - YES + MEDIUM → SAME_AS at score * 0.9, method='llm-disambiguated'
+            - NO / LOW     → skip (appended to returned ambiguous list for audit)
           - final_score < AMBIGUOUS_LOWER: discard
 
-        Returns a list of ambiguous candidate dicts (score in [0.60, 0.85))
-        for downstream processing (TASK-011).
+        Returns a list of dicts for candidates in the ambiguous zone that the LLM
+        rejected (or that could not be resolved), for audit / downstream use.
         """
         ambiguous: list[dict] = []
 
@@ -287,21 +291,43 @@ class EntityResolver:
                     graph_id_b=graph_id_b,
                 )
             elif final_score >= AMBIGUOUS_LOWER:
+                # LLM disambiguation for the 0.60–0.85 ambiguous zone
                 logger.info(
-                    "ambiguous candidate: %s <-> %s score=%.3f",
+                    "ambiguous candidate — sending to LLM: %s <-> %s score=%.3f",
                     entity_a.get("name", entity_a.get("entity_id", "?")),
                     entity_b.get("name", entity_b.get("entity_id", "?")),
                     final_score,
                 )
-                ambiguous.append(
-                    {
-                        "entity_a": entity_a,
-                        "entity_b": entity_b,
-                        "score": final_score,
-                        "graph_id_a": graph_id_a,
-                        "graph_id_b": graph_id_b,
-                    }
+                should_link, multiplier = await EntityResolver._llm_disambiguate(
+                    entity_a, entity_b, session, graph_id_a, graph_id_b
                 )
+                if should_link:
+                    effective_score = final_score * multiplier
+                    await EntityResolver._create_same_as_link(
+                        session,
+                        entity_a.get("entity_id", ""),
+                        entity_b.get("entity_id", ""),
+                        effective_score,
+                        graph_id_a=graph_id_a,
+                        graph_id_b=graph_id_b,
+                        method="llm-disambiguated",
+                    )
+                else:
+                    logger.info(
+                        "LLM rejected SAME_AS: %s <-> %s score=%.3f",
+                        entity_a.get("name", entity_a.get("entity_id", "?")),
+                        entity_b.get("name", entity_b.get("entity_id", "?")),
+                        final_score,
+                    )
+                    ambiguous.append(
+                        {
+                            "entity_a": entity_a,
+                            "entity_b": entity_b,
+                            "score": final_score,
+                            "graph_id_a": graph_id_a,
+                            "graph_id_b": graph_id_b,
+                        }
+                    )
             # else: discard — below AMBIGUOUS_LOWER
 
         return ambiguous
@@ -314,6 +340,7 @@ class EntityResolver:
         score: float,
         graph_id_a: str,
         graph_id_b: str,
+        method: str = "multi-signal",
     ) -> None:
         """Persist a bidirectional SAME_AS relationship using idempotent MERGE.
 
@@ -323,8 +350,8 @@ class EntityResolver:
         query = """
         MATCH (a:__Entity__ {graph_id: $graph_id_a}) WHERE elementId(a) = $id_a
         MATCH (b:__Entity__ {graph_id: $graph_id_b}) WHERE elementId(b) = $id_b
-        MERGE (a)-[:SAME_AS {confidence: $score, method: 'multi-signal', created_at: datetime()}]->(b)
-        MERGE (b)-[:SAME_AS {confidence: $score, method: 'multi-signal', created_at: datetime()}]->(a)
+        MERGE (a)-[:SAME_AS {confidence: $score, method: $method, created_at: datetime()}]->(b)
+        MERGE (b)-[:SAME_AS {confidence: $score, method: $method, created_at: datetime()}]->(a)
         """
         try:
             async def _write(tx) -> None:
@@ -334,6 +361,7 @@ class EntityResolver:
                         "id_a": id_a,
                         "id_b": id_b,
                         "score": score,
+                        "method": method,
                         "graph_id_a": graph_id_a,
                         "graph_id_b": graph_id_b,
                     },
@@ -341,12 +369,90 @@ class EntityResolver:
 
             await session.execute_write(_write)
             logger.info(
-                "created SAME_AS link: %s <-> %s confidence=%.3f", id_a, id_b, score
+                "created SAME_AS link: %s <-> %s confidence=%.3f method=%s",
+                id_a, id_b, score, method,
             )
         except Exception as exc:
             logger.warning(
                 "failed to create SAME_AS link %s <-> %s: %s", id_a, id_b, exc
             )
+
+    # ── LLM disambiguation for ambiguous candidates ───────────────────────────
+
+    @staticmethod
+    async def _fetch_neighbor_names_for_context(
+        session: AsyncSession,
+        entity_id: str,
+        graph_id: str,
+    ) -> list[str]:
+        """Fetch up to 3 outgoing neighbor names for LLM context.
+
+        Uses parameterized Cypher with explicit graph_id filtering on both
+        anchor and neighbor nodes — tenant isolation is enforced at the query level.
+        The returned names are only used in the LLM prompt string; they are never
+        interpolated into Cypher query text.
+        """
+        if not entity_id:
+            return []
+        query = """
+        MATCH (e {graph_id: $graph_id})
+        WHERE elementId(e) = $entity_id
+        MATCH (e)-[]->(n:__Entity__ {graph_id: $graph_id})
+        RETURN n.name AS name
+        LIMIT 3
+        """
+        try:
+            result = await session.run(
+                query, {"graph_id": graph_id, "entity_id": entity_id}
+            )
+            rows = await result.data()
+            return [row["name"] for row in rows if row.get("name")]
+        except Exception as exc:
+            logger.warning(
+                "_fetch_neighbor_names_for_context failed for entity %s: %s",
+                entity_id, exc,
+            )
+            return []
+
+    @staticmethod
+    async def _llm_disambiguate(
+        entity_a: dict,
+        entity_b: dict,
+        session: AsyncSession,
+        graph_id_a: str,
+        graph_id_b: str,
+    ) -> tuple[bool, float]:
+        """Ask the LLM whether entity_a and entity_b are the same real-world entity.
+
+        Returns (should_link, score_multiplier):
+            (True, 1.0)   — YES + HIGH confidence
+            (True, 0.9)   — YES + MEDIUM confidence
+            (False, 0.0)  — NO, or YES + LOW, or any error (fail-safe)
+        """
+        context_a = await EntityResolver._fetch_neighbor_names_for_context(
+            session, entity_a.get("entity_id", ""), graph_id_a
+        )
+        context_b = await EntityResolver._fetch_neighbor_names_for_context(
+            session, entity_b.get("entity_id", ""), graph_id_b
+        )
+
+        result = await disambiguate_entities(
+            name_a=entity_a.get("name") or "",
+            type_a=entity_a.get("type") or "",
+            context_a=context_a,
+            name_b=entity_b.get("name") or "",
+            type_b=entity_b.get("type") or "",
+            context_b=context_b,
+        )
+
+        decision = result.get("decision", "NO")
+        confidence = result.get("confidence", "LOW")
+
+        if decision == "YES" and confidence == "HIGH":
+            return True, 1.0
+        if decision == "YES" and confidence == "MEDIUM":
+            return True, 0.9
+        return False, 0.0
 
 
 class MultiTenantEntityDeduplicator(Component):

--- a/knowledge-graph-builder/app/services/analytics_service.py
+++ b/knowledge-graph-builder/app/services/analytics_service.py
@@ -1496,6 +1496,199 @@ class GraphAnalyticsService:
         """
         return self.cached_statistics.get(str(graph_id))
 
+    # ==================== PER-LEVEL LLM SUMMARIES ====================
+
+    async def _generate_level_summaries(self, graph_id: str) -> dict[str, Any]:
+        """
+        Generate LLM summaries for every __Community__ node across all levels.
+
+        Strategy:
+        - Level 0 (finest): prompt built from member __Entity__ names + types.
+        - Level 1+: prompt built from child community summaries (hierarchical roll-up).
+          Children are linked via PARENT_COMMUNITY edges to their parent community.
+
+        Stale summaries are cleared before generation so that re-runs after new
+        community detection always produce fresh output.
+
+        Security rules enforced:
+        - Every Cypher query includes {graph_id: $graph_id} in MATCH clause.
+        - No f-strings in Cypher query text — all values passed as parameters.
+
+        Args:
+            graph_id: UUID string of the target graph.
+
+        Returns:
+            Dict with per-level counts of communities summarised.
+        """
+        import asyncio as _asyncio
+
+        from openai import AsyncOpenAI
+
+        openai_client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+        llm_model = "gpt-4o-mini"
+
+        # ── Step 1: Clear stale summaries ─────────────────────────────────────
+        await neo4j_client.execute_query(
+            "MATCH (c:__Community__ {graph_id: $graph_id}) SET c.summary = null",
+            {"graph_id": graph_id},
+        )
+
+        # ── Step 2: Discover all levels present (ascending order) ─────────────
+        level_rows = await neo4j_client.execute_query(
+            "MATCH (c:__Community__ {graph_id: $graph_id}) "
+            "RETURN DISTINCT c.level AS level ORDER BY level",
+            {"graph_id": graph_id},
+        )
+        levels = [r["level"] for r in level_rows if r["level"] is not None]
+
+        summaries_per_level: dict[str, int] = {}
+        LLM_CONCURRENCY = getattr(settings, "LLM_SUMMARY_CONCURRENCY", 5)
+        semaphore = _asyncio.Semaphore(LLM_CONCURRENCY)
+
+        async def _call_llm(prompt: str) -> str:
+            """Call the LLM with the given user prompt; return generated text."""
+            async with semaphore:
+                response = await openai_client.chat.completions.create(
+                    model=llm_model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are a knowledge graph analyst. "
+                                "Generate a concise, informative summary of a cluster "
+                                "of related entities from a knowledge graph."
+                            ),
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    temperature=0.3,
+                    max_tokens=200,
+                )
+                return response.choices[0].message.content.strip()
+
+        # Process levels in ascending order so child summaries exist before parents
+        for level in sorted(levels):
+            # Fetch all community IDs at this level
+            community_rows = await neo4j_client.execute_query(
+                "MATCH (c:__Community__ {graph_id: $graph_id, level: $level}) "
+                "RETURN c.id AS community_id",
+                {"graph_id": graph_id, "level": level},
+            )
+            community_ids = [r["community_id"] for r in community_rows]
+
+            async def _summarise_community(cid: str, lvl: int) -> bool:
+                """Build prompt, call LLM, write summary. Returns True on success."""
+                if lvl == 0:
+                    # Level-0: summarise from raw entity names + types
+                    entity_rows = await neo4j_client.execute_query(
+                        """
+                        MATCH (e:__Entity__ {graph_id: $graph_id})
+                              -[:IN_COMMUNITY {graph_id: $graph_id, level: $level}]->
+                              (c:__Community__ {id: $community_id, graph_id: $graph_id})
+                        RETURN e.name AS name, labels(e) AS lbls
+                        LIMIT 50
+                        """,
+                        {
+                            "graph_id": graph_id,
+                            "level": lvl,
+                            "community_id": cid,
+                        },
+                    )
+                    entity_list = ", ".join(
+                        "{name} ({etype})".format(
+                            name=r["name"] or cid,
+                            etype=next(
+                                (
+                                    lbl
+                                    for lbl in (r["lbls"] or [])
+                                    if lbl != "__Entity__"
+                                ),
+                                "Entity",
+                            ),
+                        )
+                        for r in entity_rows
+                    )
+                    if not entity_list:
+                        return False
+                    prompt = (
+                        "Summarize the entities and their relationships in this group: "
+                        + entity_list
+                    )
+                else:
+                    # Level 1+: roll up from child community summaries.
+                    # Children (level lvl-1) link to parent via PARENT_COMMUNITY.
+                    child_rows = await neo4j_client.execute_query(
+                        """
+                        MATCH (child:__Community__ {graph_id: $graph_id, level: $child_level})
+                              -[:PARENT_COMMUNITY {graph_id: $graph_id}]->
+                              (parent:__Community__ {id: $community_id, graph_id: $graph_id})
+                        WHERE child.summary IS NOT NULL
+                        RETURN child.summary AS summary
+                        LIMIT 20
+                        """,
+                        {
+                            "graph_id": graph_id,
+                            "child_level": lvl - 1,
+                            "community_id": cid,
+                        },
+                    )
+                    child_summaries = [r["summary"] for r in child_rows if r["summary"]]
+                    if not child_summaries:
+                        return False
+                    joined = " | ".join(child_summaries)
+                    if lvl == 1:
+                        prompt = (
+                            "Summarize the themes and patterns across these sub-communities: "
+                            + joined
+                        )
+                    else:
+                        prompt = (
+                            "What are the overarching topics and insights? " + joined
+                        )
+
+                try:
+                    summary_text = await _call_llm(prompt)
+                except Exception as exc:
+                    logger.warning(
+                        f"LLM summary failed for community {cid} at level {lvl}: {exc}"
+                    )
+                    summary_text = f"Community at level {lvl} (summary unavailable)"
+
+                # Write summary back — all values as parameters, no Cypher interpolation
+                await neo4j_client.execute_query(
+                    """
+                    MATCH (c:__Community__ {id: $community_id, graph_id: $graph_id})
+                    SET c.summary = $summary,
+                        c.summary_level = $level,
+                        c.last_updated = datetime()
+                    """,
+                    {
+                        "community_id": cid,
+                        "graph_id": graph_id,
+                        "summary": summary_text,
+                        "level": lvl,
+                    },
+                )
+                return True
+
+            results = await _asyncio.gather(
+                *(_summarise_community(cid, level) for cid in community_ids),
+                return_exceptions=False,
+            )
+            count_written = sum(1 for r in results if r is True)
+            summaries_per_level[str(level)] = count_written
+            logger.info(
+                f"Level {level}: summarised {count_written}/{len(community_ids)} "
+                f"communities for graph {graph_id}"
+            )
+
+        return {
+            "status": "completed",
+            "graph_id": graph_id,
+            "summaries_per_level": summaries_per_level,
+            "total_summarised": sum(summaries_per_level.values()),
+        }
+
     # ==================== COMPREHENSIVE ANALYSIS ====================
 
     async def comprehensive_graph_analysis(

--- a/knowledge-graph-builder/app/services/llm_service.py
+++ b/knowledge-graph-builder/app/services/llm_service.py
@@ -4,12 +4,108 @@ from langchain_anthropic import ChatAnthropic
 from langchain_experimental.graph_transformers import LLMGraphTransformer
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
+from openai import AsyncOpenAI
 
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.services.credential_service import credential_service
 
 logger = get_logger(__name__)
+
+# ── SAME_AS disambiguation ────────────────────────────────────────────────────
+
+_DISAMBIGUATE_MODEL = "gpt-4o-mini"
+_DISAMBIGUATE_SYSTEM = (
+    "You are a precise entity disambiguation assistant. "
+    "Answer only in the structured format requested."
+)
+
+
+async def disambiguate_entities(
+    name_a: str,
+    type_a: str,
+    context_a: list[str],
+    name_b: str,
+    type_b: str,
+    context_b: list[str],
+) -> dict:
+    """Ask the LLM whether two entities refer to the same real-world entity.
+
+    Returns a dict with keys:
+        decision:   "YES" | "NO"
+        confidence: "HIGH" | "MEDIUM" | "LOW"
+        reason:     str (one sentence)
+
+    On any LLM failure or parse error, returns the fail-safe default:
+        {"decision": "NO", "confidence": "LOW", "reason": "parse_error"}
+
+    Security: name_a, name_b, context_a, context_b are only embedded in the
+    LLM prompt string — they are never interpolated into Cypher queries.
+    """
+    api_key = settings.OPENAI_API_KEY
+    if not api_key:
+        logger.warning("disambiguate_entities: OPENAI_API_KEY not set — returning NO/LOW")
+        return {"decision": "NO", "confidence": "LOW", "reason": "no_api_key"}
+
+    context_a_str = ", ".join(context_a[:3]) if context_a else "none"
+    context_b_str = ", ".join(context_b[:3]) if context_b else "none"
+
+    prompt = (
+        f'Are these two entities the same real-world entity? Answer YES or NO, '
+        f'and provide a brief reason.\n\n'
+        f'Entity A: "{name_a}" (type: {type_a})\n'
+        f'Context A: {context_a_str}\n\n'
+        f'Entity B: "{name_b}" (type: {type_b})\n'
+        f'Context B: {context_b_str}\n\n'
+        f'Answer format:\n'
+        f'DECISION: YES | NO\n'
+        f'CONFIDENCE: HIGH | MEDIUM | LOW\n'
+        f'REASON: <one sentence>'
+    )
+
+    try:
+        client = AsyncOpenAI(api_key=api_key)
+        response = await client.chat.completions.create(
+            model=_DISAMBIGUATE_MODEL,
+            messages=[
+                {"role": "system", "content": _DISAMBIGUATE_SYSTEM},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.0,
+            max_tokens=120,
+        )
+        raw = (response.choices[0].message.content or "").strip()
+    except Exception as exc:
+        logger.warning("disambiguate_entities: LLM call failed: %s", exc)
+        return {"decision": "NO", "confidence": "LOW", "reason": "parse_error"}
+
+    # Defensive line-by-line parse
+    decision = "NO"
+    confidence = "LOW"
+    reason = "parse_error"
+    try:
+        for line in raw.splitlines():
+            line = line.strip()
+            upper = line.upper()
+            if upper.startswith("DECISION:"):
+                val = line[len("DECISION:"):].strip().upper()
+                if val in {"YES", "NO"}:
+                    decision = val
+            elif upper.startswith("CONFIDENCE:"):
+                val = line[len("CONFIDENCE:"):].strip().upper()
+                if val in {"HIGH", "MEDIUM", "LOW"}:
+                    confidence = val
+            elif upper.startswith("REASON:"):
+                reason = line[len("REASON:"):].strip()
+    except Exception as exc:
+        logger.warning("disambiguate_entities: parse failed on %r: %s", raw, exc)
+        return {"decision": "NO", "confidence": "LOW", "reason": "parse_error"}
+
+    logger.debug(
+        "disambiguate_entities: %r vs %r → decision=%s confidence=%s",
+        name_a, name_b, decision, confidence,
+    )
+    return {"decision": decision, "confidence": confidence, "reason": reason}
 
 
 class LLMService:

--- a/knowledge-graph-builder/app/tasks/community_tasks.py
+++ b/knowledge-graph-builder/app/tasks/community_tasks.py
@@ -753,3 +753,68 @@ def _update_communities_status_pg(
             conn.commit()
     except Exception as exc:
         logger.warning(f"Failed to update communities_status in Postgres: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# LLM summary task — chained after detect_communities_task
+# ---------------------------------------------------------------------------
+
+
+@celery_app.task(bind=True, name="generate_community_summaries")
+def generate_community_summaries_task(
+    self,
+    _detect_result: dict | None = None,
+    graph_id: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """
+    Celery task: generate per-level LLM summaries for all __Community__ nodes.
+
+    Designed to run as a Celery chain link after detect_communities_task.
+    When called via `.apply_async(link=generate_community_summaries_task.s(graph_id=...))`,
+    Celery passes the upstream result as the first positional argument.
+
+    Args:
+        _detect_result: Result dict forwarded by Celery chain (ignored; graph_id is used).
+        graph_id: UUID string of the target graph.
+
+    Returns:
+        Dict with summarisation statistics.
+    """
+    from app.services.task_executor import AsyncTaskExecutor
+
+    return AsyncTaskExecutor.run_async_task(
+        _generate_summaries_async,
+        self,
+        graph_id,
+    )
+
+
+async def _generate_summaries_async(
+    task,
+    graph_id: str | None,
+) -> dict[str, Any]:
+    """Async implementation: delegates to analytics_service._generate_level_summaries."""
+    if not graph_id:
+        logger.warning("generate_community_summaries_task called without graph_id — skipping")
+        return {"status": "skipped", "reason": "no graph_id provided"}
+
+    logger.info(f"Starting per-level LLM summary generation for graph {graph_id}")
+
+    from app.core.neo4j_client import neo4j_client as _neo4j_client
+    from app.services.analytics_service import analytics_service
+
+    # Ensure async Neo4j driver is available (Celery worker context)
+    if not _neo4j_client.async_driver:
+        await _neo4j_client.connect_async()
+
+    try:
+        result = await analytics_service._generate_level_summaries(graph_id)
+        logger.info(
+            f"Summary generation complete for graph {graph_id}: "
+            f"{result.get('total_summarised', 0)} communities summarised"
+        )
+        return result
+    except Exception as exc:
+        logger.exception(f"Summary generation failed for graph {graph_id}: {exc}")
+        raise


### PR DESCRIPTION
## Summary

- Adds `disambiguate_entities()` LLM function for SAME_AS candidate resolution in the 0.60–0.85 score range
- Wires LLM disambiguation into `EntityResolver` for ambiguous candidates
- Adds per-level LLM summary generation for Leiden community hierarchy

## Test plan

- [ ] `disambiguate_entities()` resolves ambiguous candidates using LLM judgement
- [ ] EntityResolver routes 0.60–0.85 candidates through LLM disambiguation
- [ ] Candidates above 0.85 bypass LLM (direct link)
- [ ] Leiden per-level summaries generated correctly

*Stacked on #32 (TASK-010)*