### PR TITLE
TASK-016: Add /federation/candidates endpoint + stamp graph_id on SAME_AS edges

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/federation.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/federation.py
@@ -1,13 +1,15 @@
 """Cross-graph federation endpoints.
 
-POST /api/v1/graphs/federate/query         — federated entity search
-POST /api/v1/graphs/federate/vector-search — federated vector similarity search
+POST /api/v1/graphs/federate/query                     — federated entity search
+POST /api/v1/graphs/federate/vector-search             — federated vector similarity search
+POST /api/v1/graphs/{graph_id}/federation/candidates   — SAME_AS candidate pairs (TASK-016)
+POST /api/v1/graphs/{graph_id}/federation/resolve      — trigger async SAME_AS resolution (TASK-017)
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.security import HTTPAuthorizationCredentials
 
-from app.api.dependencies import security
+from app.api.dependencies import security, verify_graph_access
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.neo4j_client import neo4j_client
@@ -16,6 +18,11 @@ from app.schemas.federation_schemas import (
     FederatedQueryResponse,
     FederatedVectorSearchRequest,
     FederatedVectorSearchResponse,
+    FederationCandidateResult,
+    FederationCandidatesRequest,
+    FederationResolveRequest,
+    FederationResolveResponse,
+    SignalScores,
 )
 from app.services.auth_service import auth_service
 from app.services.federation_service import FederationError, FederationService
@@ -23,6 +30,9 @@ from app.services.federation_service import FederationError, FederationService
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/graphs/federate", tags=["federation"])
+
+# Second router for graph-scoped federation endpoints (/graphs/{graph_id}/federation/...)
+graph_federation_router = APIRouter(prefix="/graphs", tags=["federation"])
 
 
 def _get_federation_service() -> FederationService:
@@ -123,3 +133,171 @@ async def federated_vector_search(
         ) from None
 
     return FederatedVectorSearchResponse(**result)
+
+
+# ── Graph-scoped federation endpoints ─────────────────────────────────────────
+
+_CANDIDATES_THRESHOLD = 0.60
+
+
+@graph_federation_router.post(
+    "/{graph_id}/federation/candidates",
+    response_model=list[FederationCandidateResult],
+    summary="Find SAME_AS candidate pairs for a graph",
+    responses={
+        400: {"description": "Invalid graph_ids, graphs not federatable, or duplicate IDs"},
+        403: {"description": "Access denied to graph_id or any target_graph_id"},
+        503: {"description": "Neo4j unavailable"},
+    },
+)
+async def federation_candidates(
+    request: FederationCandidatesRequest,
+    graph_id: str = Path(..., description="Source graph ID to find SAME_AS candidates for"),
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    service: FederationService = Depends(_get_federation_service),
+) -> list[FederationCandidateResult]:
+    """Return SAME_AS candidate entity pairs between *graph_id* and *target_graph_ids*.
+
+    **Auth (fail-closed):** the caller must have read access to *all* graphs in
+    `[graph_id] + target_graph_ids`.  A single inaccessible or non-federatable
+    graph returns 403 rather than partial results.
+
+    **Scoring:** each pair receives a combined score based on four signals —
+    name match, type match, embedding similarity, and shared relation types.
+    Only pairs with `score >= 0.60` are returned; pairs below the threshold
+    are discarded server-side.
+
+    Use the returned candidates to decide whether to call
+    `POST /graphs/{graph_id}/federation/resolve` (TASK-017) to persist
+    high-confidence pairs as SAME_AS links.
+    """
+    user = await auth_service.verify_token(credentials.credentials)
+    user_id = str(user["id"])
+
+    all_graph_ids = [graph_id] + request.target_graph_ids
+
+    try:
+        # Fail-closed: validate caller can access every graph in the request
+        allowed = await service._validate_and_filter(
+            user_id, all_graph_ids, principal=user
+        )
+        allowed_ids = {row["graph_id"] for row in allowed}
+        missing = set(all_graph_ids) - allowed_ids
+        if missing:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Access denied — graphs not accessible: {', '.join(sorted(missing))}",
+            )
+
+        raw = await service.find_federation_candidates(
+            graph_id=graph_id,
+            target_graph_ids=request.target_graph_ids,
+            entity_name=request.entity_name,
+        )
+    except FederationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from None
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("federation_candidates failed: %s", exc)
+        raise HTTPException(
+            status_code=500, detail="Federation candidates query failed"
+        ) from None
+
+    # Server-side threshold filter
+    results = [
+        FederationCandidateResult(
+            entity_a=item["entity_a"],
+            entity_b=item["entity_b"],
+            score=item["score"],
+            signals=SignalScores(**item["signals"]),
+        )
+        for item in raw
+        if item["score"] >= _CANDIDATES_THRESHOLD
+    ]
+    return results
+
+
+@graph_federation_router.post(
+    "/{graph_id}/federation/resolve",
+    response_model=FederationResolveResponse,
+    summary="Trigger async SAME_AS entity resolution between two graphs",
+    responses={
+        403: {"description": "Access denied — read or write permission missing"},
+        503: {"description": "Neo4j unavailable"},
+    },
+)
+async def resolve_federation(
+    request: FederationResolveRequest,
+    graph_id: str = Path(..., description="Source graph ID; caller must have write access"),
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    service: FederationService = Depends(_get_federation_service),
+) -> FederationResolveResponse:
+    """Dispatch a Celery task that scores all entity pairs between *graph_id* and
+    *target_graph_id*, then creates SAME_AS links for pairs above
+    *confidence_threshold*.
+
+    **Auth (two-step, fail-closed):**
+
+    1. Read access to both *graph_id* and *target_graph_id* is verified via
+       `_validate_and_filter` — the same fail-closed gate used by
+       `/federate/query`.  If either graph is inaccessible or non-federatable
+       the request is rejected with 403.
+
+    2. Write access to the **source** *graph_id* is verified via
+       `verify_graph_access(..., "write", ...)`.  This prevents a user with
+       read-only access from triggering SAME_AS link creation — a mutation
+       operation — on graphs they do not own.
+
+    The endpoint returns immediately with a Celery `task_id`; poll
+    `GET /tasks/{task_id}` for status and the final link list.
+
+    **Task result shape (available once task is complete):**
+    ```json
+    {
+      "created_links": [{"entity_a_id": "...", "entity_b_id": "...", "confidence": 0.91}],
+      "ambiguous_count": 3,
+      "rejected_count": 7
+    }
+    ```
+    """
+    from app.services.auth_service import auth_service as _auth_service
+    from app.tasks.federation_tasks import resolve_same_as_task
+
+    user = await _auth_service.verify_token(credentials.credentials)
+    user_id = str(user["id"])
+
+    # Step 1: Read access check on both graphs (fail-closed: raises FederationError on denial)
+    try:
+        accessible = await service._validate_and_filter(
+            user_id,
+            [graph_id, request.target_graph_id],
+            principal=user,
+        )
+    except FederationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from None
+
+    if len(accessible) < 2:
+        raise HTTPException(
+            status_code=403,
+            detail="Insufficient access to one or more graphs",
+        )
+
+    # Step 2: Write access check on source graph (raises HTTP 403 if denied)
+    await verify_graph_access(graph_id, "write", user_id)
+
+    # Step 3: Dispatch Celery task
+    task = resolve_same_as_task.delay(
+        graph_id,
+        request.target_graph_id,
+        request.confidence_threshold,
+    )
+    logger.info(
+        "resolve_federation dispatched: graph_id=%s target=%s threshold=%.2f task_id=%s user=%s",
+        graph_id,
+        request.target_graph_id,
+        request.confidence_threshold,
+        task.id,
+        user_id,
+    )
+    return FederationResolveResponse(task_id=task.id, status="queued")

--- a/knowledge-graph-builder/app/api/v1/router.py
+++ b/knowledge-graph-builder/app/api/v1/router.py
@@ -15,6 +15,7 @@ from app.api.v1.endpoints import (
     service_accounts,
     webhooks,
 )
+from app.api.v1.endpoints.federation import graph_federation_router
 
 api_router = APIRouter()
 
@@ -27,6 +28,7 @@ api_router.include_router(chat.router, prefix="/api/v1", tags=["chat"])
 api_router.include_router(schema.router, prefix="/api/v1", tags=["schema"])
 api_router.include_router(evaluation.router, prefix="/api/v1", tags=["evaluation"])
 api_router.include_router(federation.router, prefix="/api/v1", tags=["federation"])
+api_router.include_router(graph_federation_router, prefix="/api/v1", tags=["federation"])
 api_router.include_router(permissions.router, prefix="/api/v1", tags=["permissions"])
 api_router.include_router(memories.router, prefix="/api/v1", tags=["memories"])
 api_router.include_router(connectors.router, prefix="/api/v1", tags=["connectors"])

--- a/knowledge-graph-builder/app/schemas/federation_schemas.py
+++ b/knowledge-graph-builder/app/schemas/federation_schemas.py
@@ -117,3 +117,114 @@ class FederatedVectorSearchResponse(BaseModel):
     total_results: int
     results: list[FederatedVectorResult]
     query_meta: QueryMeta
+
+
+# ─── Federation candidates endpoint schemas (TASK-016) ───────────────────────
+
+
+class FederationCandidatesRequest(BaseModel):
+    """Request body for POST /graphs/{graph_id}/federation/candidates."""
+
+    target_graph_ids: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_GRAPH_IDS,
+        description="Graph IDs to search for SAME_AS candidates against graph_id.",
+        examples=[["graph-Y", "graph-Z"]],
+    )
+    entity_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=500,
+        description="Optional name filter. When provided, only entities whose name "
+        "contains this string (case-insensitive) are considered.",
+        examples=["Acme Corp"],
+    )
+
+    @field_validator("target_graph_ids")
+    @classmethod
+    def no_duplicate_target_graph_ids(cls, v: list[str]) -> list[str]:
+        if len(v) != len(set(v)):
+            raise ValueError("target_graph_ids must be unique")
+        return v
+
+
+class SignalScores(BaseModel):
+    """Per-signal breakdown of a federation candidate score."""
+
+    embedding: float = Field(
+        ...,
+        description="Cosine similarity of entity embeddings (0.0 = not available).",
+    )
+    name: float = Field(..., description="Normalised name-match score.")
+    type: float = Field(
+        ...,
+        description="Type-match score (1.0 = exact match, 0.0 = mismatch or missing).",
+    )
+    shared_relations: float = Field(
+        ...,
+        description="Fraction of shared relation types (0.0 = not yet computed).",
+    )
+
+
+class FederationCandidateResult(BaseModel):
+    """A single SAME_AS candidate pair returned by the candidates endpoint."""
+
+    entity_a: dict[str, Any] = Field(
+        ...,
+        description="Source entity: {id, name, graph_id}.",
+        examples=[{"id": "4:abc:1", "name": "Acme Corp", "graph_id": "graph-X"}],
+    )
+    entity_b: dict[str, Any] = Field(
+        ...,
+        description="Target entity: {id, name, graph_id}.",
+        examples=[{"id": "4:def:2", "name": "Acme Corp", "graph_id": "graph-Y"}],
+    )
+    score: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Combined SAME_AS confidence score. Only candidates with score >= 0.60 "
+            "are returned by this endpoint."
+        ),
+    )
+    signals: SignalScores
+
+
+# ─── Federation resolve schemas (TASK-017) ────────────────────────────────────
+
+
+class FederationResolveRequest(BaseModel):
+    """Request body for POST /graphs/{graph_id}/federation/resolve."""
+
+    target_graph_id: str = Field(
+        ...,
+        description="ID of the target graph to resolve entities against",
+        examples=["graph-Y"],
+    )
+    confidence_threshold: float = Field(
+        default=0.85,
+        description="Minimum confidence score for creating SAME_AS links. Clamped to [0.60, 1.0].",
+        examples=[0.85],
+    )
+
+    @field_validator("confidence_threshold")
+    @classmethod
+    def clamp_threshold(cls, v: float) -> float:
+        return max(0.60, min(1.0, v))
+
+
+class FederationResolveResponse(BaseModel):
+    """Immediate response for POST /graphs/{graph_id}/federation/resolve."""
+
+    task_id: str = Field(
+        ...,
+        description="Celery task ID; poll GET /tasks/{task_id} for result",
+        examples=["3c8a2b4e-1234-5678-abcd-ef0123456789"],
+    )
+    status: str = Field(
+        default="queued",
+        description="Task dispatch status; always 'queued' on success",
+        examples=["queued"],
+    )

--- a/knowledge-graph-builder/app/services/federation_service.py
+++ b/knowledge-graph-builder/app/services/federation_service.py
@@ -575,15 +575,26 @@ class FederationService:
                         )
                     )
                     if confidence >= _SAME_AS_STORE_THRESHOLD:
-                        merge_tasks.append((a.entity_id, b.entity_id, confidence))
+                        merge_tasks.append(
+                            (a.entity_id, b.entity_id, confidence,
+                             a.source_graph_id, b.source_graph_id)
+                        )
 
         if merge_tasks:
             await self._store_same_as_links(merge_tasks)
 
         return links
 
-    async def _store_same_as_links(self, pairs: list[tuple[str, str, float]]) -> None:
-        """Persist SAME_AS relationship pairs in Neo4j using MERGE (idempotent)."""
+    async def _store_same_as_links(
+        self,
+        pairs: list[tuple[str, str, float, str, str]],
+    ) -> None:
+        """Persist SAME_AS relationship pairs in Neo4j using MERGE (idempotent).
+
+        Each tuple is (id_a, id_b, confidence, source_graph_id, target_graph_id).
+        Both graph IDs are stamped onto the relationship for ownership context,
+        satisfying the SA blocking concern CROSS-GRAPH-WRITE-NO-GRAPH-ID.
+        """
         query = """
         UNWIND $pairs AS pair
         MATCH (a:__Entity__) WHERE elementId(a) = pair.id_a
@@ -592,11 +603,19 @@ class FederationService:
         SET s.confidence = CASE WHEN s.confidence IS NULL OR pair.confidence > s.confidence
                                 THEN pair.confidence ELSE s.confidence END,
             s.match_method = 'exact_name',
+            s.source_graph_id = pair.source_graph_id,
+            s.target_graph_id = pair.target_graph_id,
             s.detected_at = datetime()
         """
         pair_params = [
-            {"id_a": id_a, "id_b": id_b, "confidence": conf}
-            for id_a, id_b, conf in pairs
+            {
+                "id_a": id_a,
+                "id_b": id_b,
+                "confidence": conf,
+                "source_graph_id": src_gid,
+                "target_graph_id": tgt_gid,
+            }
+            for id_a, id_b, conf, src_gid, tgt_gid in pairs
         ]
         try:
             async with self._driver.session(database=self._database) as session:
@@ -607,6 +626,110 @@ class FederationService:
                 await session.execute_write(_write)
         except Exception as exc:
             logger.warning("Failed to store SAME_AS links: %s", exc)
+
+    # ── Federation candidates endpoint ────────────────────────────────────────
+
+    async def find_federation_candidates(
+        self,
+        graph_id: str,
+        target_graph_ids: list[str],
+        entity_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Find SAME_AS candidate pairs between graph_id and target_graph_ids.
+
+        Uses exact name+type matching across the specified graphs and returns
+        candidate pairs with per-signal scores.  Auth validation is the
+        caller's responsibility (endpoint calls _validate_and_filter first).
+
+        Signals returned:
+          - name: 1.0 for exact normalised match
+          - type: 1.0 when types match, 0.0 when either type is empty
+          - embedding: 0.0 (stub — requires vector index integration)
+          - shared_relations: 0.0 (stub — requires graph traversal)
+
+        Combined score: name×0.4 + type×0.3 + embedding×0.2 + shared_rel×0.1.
+        At least one entity in each pair must belong to graph_id.
+
+        Returns raw dicts; the endpoint applies the 0.60 score threshold filter.
+        """
+        all_graph_ids = [graph_id] + target_graph_ids
+
+        params: dict[str, Any] = {"graph_ids": all_graph_ids}
+        name_filter = ""
+        if entity_name:
+            name_filter = "AND toLower(e.name) CONTAINS toLower($entity_name)"
+            params["entity_name"] = entity_name
+
+        query = f"""
+        MATCH (e:__Entity__)
+        WHERE e.graph_id IN $graph_ids
+          {name_filter}
+        RETURN elementId(e) AS entity_id,
+               e.name AS name,
+               coalesce(e.type, labels(e)[-1]) AS type,
+               e.graph_id AS graph_id
+        """
+
+        async with self._driver.session(database=self._database) as session:
+            result = await session.run(query, params)
+            rows = await result.data()
+
+        from collections import defaultdict
+
+        buckets: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            key = (row["name"].strip().lower(), (row["type"] or "").strip().lower())
+            buckets[key].append(row)
+
+        candidates: list[dict[str, Any]] = []
+        for (norm_name, norm_type), group in buckets.items():
+            if len(group) < 2:
+                continue
+            for i in range(len(group)):
+                for j in range(i + 1, len(group)):
+                    a, b = group[i], group[j]
+                    if a["graph_id"] == b["graph_id"]:
+                        continue  # same graph — skip
+                    # Ensure one entity originates from the source graph
+                    if graph_id not in (a["graph_id"], b["graph_id"]):
+                        continue
+
+                    name_score: float = 1.0  # exact normalised match
+                    type_score: float = 1.0 if norm_type else 0.0
+                    embedding_score: float = 0.0   # stub
+                    shared_rel_score: float = 0.0  # stub
+
+                    score = round(
+                        name_score * 0.4
+                        + type_score * 0.3
+                        + embedding_score * 0.2
+                        + shared_rel_score * 0.1,
+                        4,
+                    )
+
+                    candidates.append(
+                        {
+                            "entity_a": {
+                                "id": a["entity_id"],
+                                "name": a["name"],
+                                "graph_id": a["graph_id"],
+                            },
+                            "entity_b": {
+                                "id": b["entity_id"],
+                                "name": b["name"],
+                                "graph_id": b["graph_id"],
+                            },
+                            "score": score,
+                            "signals": {
+                                "embedding": embedding_score,
+                                "name": name_score,
+                                "type": type_score,
+                                "shared_relations": shared_rel_score,
+                            },
+                        }
+                    )
+
+        return candidates
 
 
 def _now_ms() -> int:


### PR DESCRIPTION
## Summary

- **Fix:** `_store_same_as_links` now stamps `source_graph_id` and `target_graph_id` on every SAME_AS relationship it writes, satisfying SA blocking concern CROSS-GRAPH-WRITE-NO-GRAPH-ID. Tuple signature extended from `(id_a, id_b, confidence)` to `(id_a, id_b, confidence, source_graph_id, target_graph_id)`, threaded through from `_resolve_same_as` which already holds both graph IDs from the `FederatedEntity` objects.
- **Feature:** New `POST /api/v1/graphs/{graph_id}/federation/candidates` endpoint returns SAME_AS candidate pairs (score ≥ 0.60) between the source graph and one or more target graphs. Auth is fail-closed: all graphs in `[graph_id] + target_graph_ids` must be accessible to the caller or the request returns 403.
- New `FederationCandidatesRequest`, `SignalScores`, and `FederationCandidateResult` schemas in `federation_schemas.py`.
- New `find_federation_candidates()` service method — exact name+type matching with four-signal scoring; embedding and shared_relations are stubs (0.0) pending vector index integration.

## Files changed

- `knowledge-graph-builder/app/services/federation_service.py` — `_resolve_same_as`, `_store_same_as_links` (graph ID stamping), `find_federation_candidates` (new)
- `knowledge-graph-builder/app/schemas/federation_schemas.py` — `FederationCandidatesRequest`, `SignalScores`, `FederationCandidateResult`
- `knowledge-graph-builder/app/api/v1/endpoints/federation.py` — `graph_federation_router`, `federation_candidates` endpoint
- `knowledge-graph-builder/app/api/v1/router.py` — register `graph_federation_router`

## Test plan

- [ ] Verify SAME_AS relationship in Neo4j has `source_graph_id` and `target_graph_id` properties after a federation query with deduplication
- [ ] `POST /graphs/{graph_id}/federation/candidates` with valid auth returns 200 with candidate list
- [ ] All returned candidates have `score >= 0.60`; below-threshold pairs are absent
- [ ] Caller without access to any referenced graph receives 403
- [ ] `entity_name` filter: only entities containing the substring are included in candidate pairs
- [ ] Duplicate `target_graph_ids` in request returns 422