### PR TITLE
TASK-003: Add COMMUNITY_SUMMARY retriever + global query routing

### DIFF
--- a/knowledge-graph-builder/app/schemas/retriever_schemas.py
+++ b/knowledge-graph-builder/app/schemas/retriever_schemas.py
@@ -20,6 +20,7 @@ class RetrieverType(StrEnum):
     HYBRID_CYPHER = "hybrid_cypher"
     TEXT2CYPHER = "text2cypher"
     MEMORY = "memory"
+    COMMUNITY_SUMMARY = "community_summary"
 
 
 class HybridSearchRanker(StrEnum):

--- a/knowledge-graph-builder/app/services/chat_service.py
+++ b/knowledge-graph-builder/app/services/chat_service.py
@@ -33,7 +33,11 @@ from app.schemas.retriever_schemas import (
     get_default_retriever_config,
 )
 from app.services.fulltext_index_service import fulltext_index_manager
-from app.services.retriever_factory import RetrieverType, retriever_factory
+from app.services.retriever_factory import (
+    CommunitySummaryRetriever,
+    RetrieverType,
+    retriever_factory,
+)
 
 logger = get_logger(__name__)
 _chat_tracer = get_tracer("oraclous.chat")
@@ -171,6 +175,35 @@ _STOPWORDS = frozenset(
     }
 )
 
+# ---------------------------------------------------------------------------
+# Global query detection — routes broad/thematic questions to community
+# summaries instead of vector/fulltext retrieval.
+# ---------------------------------------------------------------------------
+_GLOBAL_KEYWORDS = frozenset(
+    {
+        "overview",
+        "themes",
+        "theme",
+        "main topics",
+        "across all",
+        "summarize",
+        "summarise",
+        "what are the",
+        "broad",
+        "general",
+        "landscape",
+        "areas",
+        "categories",
+        "domains",
+    }
+)
+
+
+def _is_global_query(query: str) -> bool:
+    """Return True when the query is broad/thematic and benefits from community summaries."""
+    q_lower = query.lower()
+    return any(kw in q_lower for kw in _GLOBAL_KEYWORDS)
+
 
 @dataclass
 class GroundedSearchResult:
@@ -208,24 +241,30 @@ class ChatService:
         self.retriever_type = retriever_type
         self.retriever_config_dict = retriever_config or {}
 
-        default_config = get_default_retriever_config(retriever_type, graph_id)
-
-        if retriever_type == RetrieverType.VECTOR:
-            typed_config = cast(VectorRetrieverConfig, default_config)
-        elif retriever_type == RetrieverType.VECTOR_CYPHER:
-            typed_config = cast(VectorCypherRetrieverConfig, default_config)
-        elif retriever_type == RetrieverType.HYBRID:
-            typed_config = cast(HybridRetrieverConfig, default_config)
-        elif retriever_type == RetrieverType.HYBRID_CYPHER:
-            typed_config = cast(HybridCypherRetrieverConfig, default_config)
-        elif retriever_type == RetrieverType.TEXT2CYPHER:
-            typed_config = cast(Text2CypherRetrieverConfig, default_config)
+        # COMMUNITY_SUMMARY bypasses the GraphRAG retriever pipeline — skip
+        # RetrieverConfig construction (CommunitySummaryRetriever is instantiated
+        # directly in _setup_retriever).
+        if retriever_type == RetrieverType.COMMUNITY_SUMMARY:
+            self.retriever_config = None  # type: ignore[assignment]
         else:
-            raise ValueError(f"Unsupported retriever type: {retriever_type}")
+            default_config = get_default_retriever_config(retriever_type, graph_id)
 
-        self.retriever_config = RetrieverConfig(
-            type=retriever_type, config=typed_config
-        )
+            if retriever_type == RetrieverType.VECTOR:
+                typed_config = cast(VectorRetrieverConfig, default_config)
+            elif retriever_type == RetrieverType.VECTOR_CYPHER:
+                typed_config = cast(VectorCypherRetrieverConfig, default_config)
+            elif retriever_type == RetrieverType.HYBRID:
+                typed_config = cast(HybridRetrieverConfig, default_config)
+            elif retriever_type == RetrieverType.HYBRID_CYPHER:
+                typed_config = cast(HybridCypherRetrieverConfig, default_config)
+            elif retriever_type == RetrieverType.TEXT2CYPHER:
+                typed_config = cast(Text2CypherRetrieverConfig, default_config)
+            else:
+                raise ValueError(f"Unsupported retriever type: {retriever_type}")
+
+            self.retriever_config = RetrieverConfig(
+                type=retriever_type, config=typed_config
+            )
 
         self.embedder = OpenAIEmbeddings(
             api_key=settings.OPENAI_API_KEY, model="text-embedding-3-large"
@@ -249,6 +288,13 @@ class ChatService:
         """Async initialization of retriever and GraphRAG components."""
         await self._setup_retriever()
 
+        if self.retriever_type == RetrieverType.COMMUNITY_SUMMARY:
+            # CommunitySummaryRetriever does not use GraphRAG — skip rag setup.
+            logger.info(
+                f"CommunitySummaryRetriever initialized for graph {self.graph_id}"
+            )
+            return
+
         if self.retriever:
             self.rag = GraphRAG(retriever=self.retriever, llm=self.llm)
             logger.info(f"GraphRAG initialized successfully for graph {self.graph_id}")
@@ -258,6 +304,15 @@ class ChatService:
     async def _setup_retriever(self):
         """Set up retriever using factory pattern with full-text index management."""
         try:
+            # CommunitySummaryRetriever is instantiated directly — it does not go
+            # through the RetrieverFactory / GraphRAG pipeline.
+            if self.retriever_type == RetrieverType.COMMUNITY_SUMMARY:
+                self.retriever = CommunitySummaryRetriever(graph_id=self.graph_id)
+                logger.info(
+                    f"Created CommunitySummaryRetriever for graph {self.graph_id}"
+                )
+                return
+
             if self.retriever_type in [
                 RetrieverType.HYBRID,
                 RetrieverType.HYBRID_CYPHER,
@@ -421,6 +476,12 @@ class ChatService:
         temporal_params: dict[str, Any] | None = None,
     ) -> "GroundedSearchResult":
         try:
+            # ------------------------------------------------------------------
+            # Community summary fast path — bypasses GraphRAG vector pipeline.
+            # ------------------------------------------------------------------
+            if self.retriever_type == RetrieverType.COMMUNITY_SUMMARY:
+                return await self._community_summary_search(span, query_text)
+
             if not self.rag:
                 await self.initialize()
 
@@ -570,6 +631,96 @@ class ChatService:
             )
 
     # ------------------------------------------------------------------
+    # Community summary retrieval
+    # ------------------------------------------------------------------
+
+    async def _community_summary_search(
+        self, span, query_text: str
+    ) -> GroundedSearchResult:
+        """
+        Retrieve Leiden community summaries and synthesise an answer via the LLM.
+
+        Bypasses the GraphRAG vector pipeline.  Summaries from Neo4j are passed
+        as plain text context; they are never interpolated into Cypher queries.
+        """
+        if not self.retriever:
+            await self.initialize()
+
+        assert isinstance(self.retriever, CommunitySummaryRetriever)
+
+        community_docs = await self.retriever.search(query_text)
+
+        if not community_docs:
+            logger.warning(
+                "No community summaries found for graph %s", self.graph_id
+            )
+            span.set_attribute("chat.is_grounded", False)
+            span.set_attribute("chat.confidence", 0.0)
+            span.set_attribute("chat.sources_count", 0)
+            span.set_attribute("chat.hallucination_flag", True)
+            return GroundedSearchResult(
+                answer=(
+                    "The knowledge graph does not contain sufficient data "
+                    "to answer this question."
+                ),
+                sources=[],
+                confidence=0.0,
+                is_grounded=False,
+                retriever_used=RetrieverType.COMMUNITY_SUMMARY.value,
+            )
+
+        # Build plain-text context from community summaries.
+        context_parts = [
+            f"[Community {doc['community_id']} — {doc['entity_count']} entities]\n"
+            f"{doc['summary']}"
+            for doc in community_docs
+        ]
+        context = "\n\n".join(context_parts)
+
+        prompt = STRICT_GROUNDING_PROMPT.format(
+            context=context, query_text=query_text
+        )
+        llm_response = await self.llm.ainvoke(prompt)
+        answer = llm_response.content
+
+        is_grounded = not answer.strip().startswith(_INSUFFICIENT_PREFIX)
+        if not is_grounded:
+            answer = (
+                "The knowledge graph does not contain sufficient data "
+                "to answer this question."
+            )
+
+        sources = [
+            {
+                "node_id": doc["community_id"],
+                "node_labels": ["__Community__"],
+                "content": doc["summary"][:500],
+                "relevance_score": None,
+                "properties": {"entity_count": doc["entity_count"]},
+            }
+            for doc in community_docs
+        ]
+        confidence = 0.7 if is_grounded else 0.0
+
+        logger.info(
+            "Community summary search complete — grounded=%s, sources=%d",
+            is_grounded,
+            len(sources),
+        )
+        span.set_attribute("chat.is_grounded", is_grounded)
+        span.set_attribute("chat.confidence", confidence)
+        span.set_attribute("chat.sources_count", len(sources))
+        span.set_attribute("chat.hallucination_flag", not is_grounded)
+
+        return GroundedSearchResult(
+            answer=answer,
+            sources=sources,
+            confidence=confidence,
+            is_grounded=is_grounded,
+            retriever_used=RetrieverType.COMMUNITY_SUMMARY.value,
+        )
+
+    # ------------------------------------------------------------------
     # Auto retriever selection
     # ------------------------------------------------------------------
 
@@ -579,11 +730,14 @@ class ChatService:
         Choose the most appropriate retriever type based on query characteristics.
 
         Rules (evaluated in priority order):
-        1. Cypher/graph-query keywords → TEXT2CYPHER for precise traversal
-        2. Analytic / enumeration keywords → HYBRID for broader coverage
-        3. Relationship / connectivity keywords → VECTOR_CYPHER for graph traversal
-        4. Default → VECTOR_CYPHER (balanced precision + context)
+        1. Global/thematic keywords → COMMUNITY_SUMMARY for broad overview queries
+        2. Cypher/graph-query keywords → TEXT2CYPHER for precise traversal
+        3. Analytic / enumeration keywords → HYBRID for broader coverage
+        4. Relationship / connectivity keywords → VECTOR_CYPHER for graph traversal
+        5. Default → VECTOR_CYPHER (balanced precision + context)
         """
+        if _is_global_query(query):
+            return RetrieverType.COMMUNITY_SUMMARY
         if _CYPHER_PATTERNS.search(query):
             return RetrieverType.TEXT2CYPHER
         if _ANALYTIC_PATTERNS.search(query):

--- a/knowledge-graph-builder/app/services/retriever_factory.py
+++ b/knowledge-graph-builder/app/services/retriever_factory.py
@@ -447,6 +447,84 @@ class MemoryRetriever:
         return asyncio.run(self.search(query_text))
 
 
+# ==================== COMMUNITY SUMMARY RETRIEVER ====================
+
+_COMMUNITY_SUMMARY_CYPHER = """\
+MATCH (c:__Community__ {graph_id: $graph_id, level: $level})
+WHERE c.summary IS NOT NULL
+RETURN c.id AS community_id, c.summary AS summary, c.entity_count AS entity_count
+ORDER BY c.entity_count DESC
+LIMIT $limit
+"""
+
+
+class CommunitySummaryRetriever:
+    """
+    Retriever that fetches ranked Leiden community summaries from the graph.
+
+    Returns the top-K ``__Community__`` nodes at a given hierarchy level,
+    ordered by entity_count (broadest communities first).  The summaries are
+    used as retrieval context for global / thematic queries.
+
+    Security:
+    - All Cypher parameters are bound ($graph_id, $level, $limit) — no
+      user-supplied strings are ever interpolated into the query text.
+    - Summary text is passed to the LLM as context only; it is never used
+      in subsequent Cypher queries.
+    """
+
+    def __init__(
+        self,
+        graph_id: str,
+        level: int = 2,
+        limit: int = 5,
+    ) -> None:
+        self.graph_id = graph_id
+        self.level = level
+        self.limit = limit
+
+    async def search(self, query: str) -> list[dict]:
+        """Fetch top-K community summaries ordered by entity_count descending."""
+        driver = neo4j_client.async_driver
+        if driver is None:
+            logger.warning(
+                "Async driver unavailable — CommunitySummaryRetriever returning empty"
+            )
+            return []
+
+        try:
+            result = await driver.execute_query(
+                _COMMUNITY_SUMMARY_CYPHER,
+                {
+                    "graph_id": self.graph_id,
+                    "level": self.level,
+                    "limit": self.limit,
+                },
+            )
+            records = result.records if hasattr(result, "records") else result[0]
+            return [
+                {
+                    "community_id": rec["community_id"],
+                    "summary": rec["summary"],
+                    "entity_count": rec["entity_count"],
+                }
+                for rec in records
+            ]
+        except Exception as exc:
+            logger.error(
+                "CommunitySummaryRetriever query failed for graph %s: %s",
+                self.graph_id,
+                exc,
+            )
+            return []
+
+    # Sync shim for callers using the sync Retriever protocol
+    def get_search_results(self, query_text: str, **kwargs) -> list:  # type: ignore[override]
+        import asyncio
+
+        return asyncio.run(self.search(query_text))
+
+
 # ==================== GLOBAL FACTORY INSTANCE ====================
 
 # Global factory instance for dependency injection
@@ -479,4 +557,5 @@ def get_supported_retriever_types() -> dict[str, str]:
         RetrieverType.HYBRID_CYPHER: "Hybrid search with graph traversal",
         RetrieverType.TEXT2CYPHER: "Natural language to Cypher query generation",
         RetrieverType.MEMORY: "Agent memory recall (episodic, semantic, procedural)",
+        RetrieverType.COMMUNITY_SUMMARY: "Leiden community summaries for global/thematic queries",
     }


### PR DESCRIPTION
## Summary

- Adds `COMMUNITY_SUMMARY` retriever type to `RetrieverType` enum in `retriever_schemas.py`
- Implements `CommunitySummaryRetriever` in `retriever_factory.py` — fetches top-K `__Community__` nodes at a given hierarchy level ordered by `entity_count`, all Cypher fully parameterised
- Adds `_is_global_query()` heuristic and `_GLOBAL_KEYWORDS` frozenset to `chat_service.py` for auto-routing broad/thematic queries to the community summary retriever
- `CommunitySummaryRetriever` bypasses the GraphRAG pipeline and is instantiated directly in `_setup_retriever()`

## Test plan

- [ ] Unit tests pass via `pytest tests/unit/ -x -q`
- [ ] `COMMUNITY_SUMMARY` retriever type accepted without raising `ValueError`
- [ ] Global query keywords correctly route to `CommunitySummaryRetriever`
- [ ] All Cypher queries remain parameterised (no string interpolation)

Part of STORY-001: Leiden Community Hierarchy