### PR TITLE
TASK-007: Add temporal query modes to chat service (point_in_time, knowledge_as_of, changes_since)

### DIFF
--- a/knowledge-graph-builder/app/schemas/chat_schemas.py
+++ b/knowledge-graph-builder/app/schemas/chat_schemas.py
@@ -7,12 +7,31 @@ all Neo4j GraphRAG retriever types with proper validation and examples.
 
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
 from app.schemas.graph_schemas import TemporalFilter
 from app.services.retriever_factory import RetrieverType
+
+
+class TemporalMode(StrEnum):
+    """Temporal query mode — scopes retrieval to a point or range in time.
+
+    POINT_IN_TIME: returns relationships where event_time <= temporal_at
+                   AND (event_time_end IS NULL OR event_time_end >= temporal_at).
+                   Answers "what was true in the world at this instant?"
+
+    KNOWLEDGE_AS_OF: returns relationships where ingestion_time <= temporal_at.
+                     Answers "what did the system know before this date?"
+
+    CHANGES_SINCE: returns relationships where ingestion_time > temporal_since.
+                   Answers "what facts were added to the graph after this date?"
+    """
+
+    POINT_IN_TIME = "point_in_time"
+    KNOWLEDGE_AS_OF = "knowledge_as_of"
+    CHANGES_SINCE = "changes_since"
 
 
 class ChatMode(StrEnum):
@@ -116,6 +135,29 @@ class ChatRequest(BaseModel):
         default=None,
         description="When set, scopes retrieval to facts valid at the specified time. "
         "Clients without this field get current-only results by default.",
+    )
+
+    # Bitemporal query modes (TASK-007) — three explicit temporal lenses.
+    # These complement temporal_filter and apply as a Cypher WHERE clause on
+    # relationship properties (event_time / ingestion_time).
+    # Omitting temporal_mode produces identical behavior to today (no change).
+    temporal_mode: Optional[TemporalMode] = Field(
+        default=None,
+        description=(
+            "Temporal query mode. "
+            "'point_in_time': facts true in the world at temporal_at. "
+            "'knowledge_as_of': facts the system knew before temporal_at. "
+            "'changes_since': facts ingested after temporal_since. "
+            "Omit for current-state behavior."
+        ),
+    )
+    temporal_at: Optional[datetime] = Field(
+        default=None,
+        description="Reference timestamp for point_in_time and knowledge_as_of modes.",
+    )
+    temporal_since: Optional[datetime] = Field(
+        default=None,
+        description="Reference timestamp for changes_since mode.",
     )
 
     # Chat context
@@ -226,6 +268,13 @@ class ChatResponse(BaseModel):
         ge=0.0,
         le=1.0,
         description="Confidence score [0–1] derived from retrieval relevance scores",
+    )
+
+    # Temporal mode confirmation — echoes back which temporal filter was applied.
+    # Null when no temporal_mode was requested (backward-compatible default).
+    temporal_mode_applied: Optional[str] = Field(
+        default=None,
+        description="Temporal query mode that was applied to this response, or null if none.",
     )
 
     # Optional detailed information

--- a/knowledge-graph-builder/app/services/retriever_factory.py
+++ b/knowledge-graph-builder/app/services/retriever_factory.py
@@ -354,6 +354,57 @@ class RetrieverFactory:
             else:
                 return f"{retrieval_query}\nWHERE node.graph_id = $graph_id"
 
+    def inject_temporal_filter_into_retrieval_query(
+        self,
+        retrieval_query: str,
+        temporal_filter: str | None,
+        retriever_type: "RetrieverType | None" = None,
+    ) -> str:
+        """Inject a temporal WHERE clause into a Cypher retrieval query.
+
+        This method is used by Cypher-capable retrievers (VECTOR_CYPHER,
+        HYBRID_CYPHER) to scope results to a specific time window.
+        For vector-only retrievers (VECTOR, HYBRID, TEXT2CYPHER), calling this
+        method logs a warning and returns the query unchanged.
+
+        Security: ``temporal_filter`` must be a trusted clause constructed by
+        ``ChatService._build_temporal_filter()`` — it is NEVER derived from
+        raw user input.  Datetime values must always be passed as Cypher
+        parameters (via ``query_params`` at search time), never interpolated.
+
+        Args:
+            retrieval_query: The base Cypher retrieval query string.
+            temporal_filter: A trusted WHERE-clause fragment, e.g.
+                "(r.event_time IS NULL OR r.event_time <= $temporal_at)".
+                Pass None or empty string to return the query unchanged.
+            retriever_type: The retriever type — used to log a warning for
+                vector-only retrievers that cannot apply relationship filters.
+
+        Returns:
+            The retrieval query with the temporal clause appended to the WHERE
+            block, or the original query if no filter is provided.
+        """
+        if not temporal_filter:
+            return retrieval_query
+
+        # Vector-only retrievers have no relationship traversal — filter is a no-op.
+        _vector_only = {RetrieverType.VECTOR, RetrieverType.HYBRID, RetrieverType.TEXT2CYPHER}
+        if retriever_type in _vector_only:
+            logger.warning(
+                "Temporal filter not supported for %s retriever; ignoring",
+                retriever_type.value if retriever_type else "unknown",
+            )
+            return retrieval_query
+
+        # Append the temporal clause after the existing WHERE predicate(s).
+        # The clause references relationship alias `r` which is present in
+        # all default VECTOR_CYPHER / HYBRID_CYPHER retrieval queries.
+        if "WHERE" in retrieval_query.upper():
+            # Append with AND to keep existing predicates intact.
+            return retrieval_query.rstrip() + f"\n    AND {temporal_filter}"
+        else:
+            return retrieval_query.rstrip() + f"\nWHERE {temporal_filter}"
+
     async def create_memory_retriever(
         self,
         config: MemoryRetrieverConfig,


### PR DESCRIPTION
## Summary

- Adds `TemporalMode` enum to `chat_schemas.py` with three temporal lenses: `point_in_time`, `knowledge_as_of`, `changes_since`
- Adds `temporal_mode`, `temporal_at`, `temporal_since` optional fields to `ChatRequest` schema — backward compatible (all default to None)
- Adds `temporal_mode_applied` field to `ChatResponse` for echo-back confirmation
- Adds `inject_temporal_filter_into_retrieval_query()` to `RetrieverFactory` for safely appending trusted WHERE clauses to Cypher-capable retriever queries

## Changes

- `knowledge-graph-builder/app/schemas/chat_schemas.py` — TemporalMode enum + ChatRequest/ChatResponse temporal fields
- `knowledge-graph-builder/app/services/retriever_factory.py` — inject_temporal_filter_into_retrieval_query() method

## Notes

This branch was rebased cleanly onto develop (after TASK-003, TASK-004, TASK-005 merged). The `_build_temporal_filter()` method and `TemporalMode` import in `chat_service.py` were already applied via earlier commits on develop; this PR supplies the missing schema definition and wires up the full request/response flow.

## Test plan

- [ ] Run `docker exec knowledge-graph-builder python -m pytest tests/unit/ -k "temporal or bitemporal or chat" -v`
- [ ] Verify `ChatRequest` with `temporal_mode="point_in_time"` validates correctly
- [ ] Verify `ChatResponse.temporal_mode_applied` is returned in API responses