### PR TITLE
TASK-024: OCR fallback for scanned PDFs — Tesseract integration

### DIFF
--- a/knowledge-graph-builder/Dockerfile
+++ b/knowledge-graph-builder/Dockerfile
@@ -4,11 +4,13 @@ FROM python:3.12-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies (libigraph-dev required by leidenalg)
+# Install system dependencies (libigraph-dev required by leidenalg;
+# tesseract-ocr required by pytesseract OCR fallback in pdf_extractor)
 RUN apt-get update && apt-get install -y \
     curl \
     gcc \
     libigraph-dev \
+    tesseract-ocr \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching

--- a/knowledge-graph-builder/app/services/pdf_extractor.py
+++ b/knowledge-graph-builder/app/services/pdf_extractor.py
@@ -7,6 +7,7 @@ Libraries used:
 - PyMuPDF (fitz)   — primary PDF parser; text + image extraction
 - pdfplumber       — table extraction (optional, gracefully skipped if absent)
 - python-docx      — DOCX text and table extraction
+- pytesseract      — OCR fallback for scanned pages (optional, gracefully skipped)
 """
 
 from pathlib import Path
@@ -19,10 +20,44 @@ logger = get_logger(__name__)
 # Minimum image dimensions to bother extracting (avoids tiny decorative images).
 _MIN_IMAGE_PX = 50
 
+# OCR trigger threshold: pages with fewer characters than this will be OCR'd.
+_OCR_CHAR_THRESHOLD = 100
+
+# Diagram detection threshold: OCR text shorter than this on an image-bearing page
+# signals a likely diagram/figure rather than readable text.
+_DIAGRAM_CHAR_THRESHOLD = 50
+
+# Attempt to import OCR dependencies once at module load time.
+# pytesseract is always defined at module scope (None when unavailable) so
+# tests can patch it regardless of whether the package is installed.
+pytesseract = None  # type: ignore[assignment]
+_OCR_AVAILABLE = False
+
+try:
+    import pytesseract  # noqa: F811  (intentional re-assignment)
+    from PIL import Image as _PilImage
+
+    _OCR_AVAILABLE = True
+except ImportError:
+    logger.warning("pytesseract not available, OCR skipped")
+
+
+def _page_to_pil(page: Any) -> Any:
+    """Render a PyMuPDF page to a PIL Image for OCR."""
+    pixmap = page.get_pixmap()
+    from PIL import Image  # already confirmed importable when _OCR_AVAILABLE is True
+
+    return Image.frombytes("RGB", [pixmap.width, pixmap.height], pixmap.samples)
+
 
 def extract_pdf(file_path: str) -> dict[str, Any]:
     """
     Extract text and embedded images from a PDF file.
+
+    For pages where PyMuPDF extracts fewer than 100 characters, Tesseract OCR
+    is applied as a fallback (if pytesseract is installed). Pages that still
+    yield very short text after OCR AND contain embedded images are flagged
+    as ``likely_diagram`` for downstream structured extraction (TASK-025).
 
     Args:
         file_path: Absolute path to the PDF.
@@ -34,6 +69,7 @@ def extract_pdf(file_path: str) -> dict[str, Any]:
             "has_tables": bool,
             "image_paths": list[str],  # PNG files written alongside the source
             "metadata": dict,
+            "pages": list[dict],    # per-page metadata (ocr_used, likely_diagram, …)
         }
     """
     try:
@@ -49,6 +85,8 @@ def extract_pdf(file_path: str) -> dict[str, Any]:
     text_parts: list[str] = []
     image_paths: list[str] = []
     has_tables = False
+    pages_meta: list[dict] = []
+    ocr_used_any = False
 
     img_dir = Path(file_path).parent / "extracted_images"
     img_dir.mkdir(parents=True, exist_ok=True)
@@ -56,10 +94,38 @@ def extract_pdf(file_path: str) -> dict[str, Any]:
     # ── Per-page text + image extraction ─────────────────────────────────────
     for page_num, page in enumerate(doc):
         page_text = page.get_text("text")
+        page_images = page.get_images(full=True)
+
+        page_meta: dict[str, Any] = {
+            "page_number": page_num + 1,
+            "ocr_used": False,
+            "likely_diagram": False,
+        }
+
+        # ── OCR fallback ──────────────────────────────────────────────────────
+        if len(page_text.strip()) < _OCR_CHAR_THRESHOLD:
+            if _OCR_AVAILABLE:
+                try:
+                    pil_image = _page_to_pil(page)
+                    ocr_text = pytesseract.image_to_string(pil_image)
+                    page_text = page_text + ocr_text
+                    page_meta["ocr_used"] = True
+                    ocr_used_any = True
+                except Exception as exc:
+                    logger.warning(f"OCR failed on page {page_num + 1}: {exc}")
+            # If _OCR_AVAILABLE is False, module-load warning was already emitted.
+
+            # ── Diagram detection ─────────────────────────────────────────────
+            # After OCR, if text is still very short AND the page has images,
+            # mark it as a likely diagram for TASK-025 to handle.
+            if len(page_text.strip()) < _DIAGRAM_CHAR_THRESHOLD and page_images:
+                page_meta["likely_diagram"] = True
+
         if page_text.strip():
             text_parts.append(f"[Page {page_num + 1}]\n{page_text.strip()}")
 
-        for img_index, img_ref in enumerate(page.get_images(full=True)):
+        # ── Embedded image extraction ─────────────────────────────────────────
+        for img_index, img_ref in enumerate(page_images):
             xref = img_ref[0]
             base_image = doc.extract_image(xref)
             if (
@@ -72,6 +138,8 @@ def extract_pdf(file_path: str) -> dict[str, Any]:
             with open(img_path, "wb") as fh:
                 fh.write(base_image["image"])
             image_paths.append(str(img_path))
+
+        pages_meta.append(page_meta)
 
     doc.close()
 
@@ -97,16 +165,20 @@ def extract_pdf(file_path: str) -> dict[str, Any]:
     except Exception as exc:
         logger.warning(f"Table extraction failed: {exc}")
 
+    processing_method = "pymupdf+tesseract" if ocr_used_any else "pymupdf"
+
     return {
         "text": "\n\n".join(text_parts),
         "page_count": page_count,
         "has_tables": has_tables,
         "image_paths": image_paths,
+        "pages": pages_meta,
         "metadata": {
             "page_count": page_count,
             "content_type": "application/pdf",
-            "processing_method": "pymupdf",
+            "processing_method": processing_method,
             "has_embedded_images": len(image_paths) > 0,
+            "ocr_used": ocr_used_any,
         },
     }
 

--- a/knowledge-graph-builder/requirements.txt
+++ b/knowledge-graph-builder/requirements.txt
@@ -29,6 +29,7 @@ python-docx==1.2.0
 pymupdf>=1.24.0          # PDF parsing — text, image, table extraction
 pdfplumber>=0.11.0       # Table extraction (used alongside PyMuPDF)
 pillow>=10.0.0           # Image handling (dependency of PyMuPDF image export)
+pytesseract>=0.3.10      # OCR fallback for scanned PDFs (requires tesseract-ocr system pkg)
 python-magic>=0.4.27     # MIME type detection for uploaded files
 
 # LLM required configurations

--- a/knowledge-graph-builder/tests/unit/test_pdf_extractor_ocr.py
+++ b/knowledge-graph-builder/tests/unit/test_pdf_extractor_ocr.py
@@ -1,0 +1,273 @@
+"""
+Unit tests for OCR fallback in pdf_extractor.extract_pdf().
+
+All PyMuPDF, pytesseract, and filesystem calls are mocked so no real PDFs or
+Tesseract installation are required.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build minimal fitz / pytesseract mocks
+# ---------------------------------------------------------------------------
+
+def _make_page(text: str, images: list | None = None):
+    """Return a mock PyMuPDF page object."""
+    page = MagicMock()
+    page.get_text.return_value = text
+    page.get_images.return_value = images if images is not None else []
+    # get_pixmap returns a minimal pixmap-like object
+    pixmap = MagicMock()
+    pixmap.width = 800
+    pixmap.height = 600
+    pixmap.samples = b"\x00" * (800 * 600 * 3)
+    page.get_pixmap.return_value = pixmap
+    return page
+
+
+def _make_doc(pages: list, page_count: int | None = None):
+    """Return a mock fitz.Document."""
+    doc = MagicMock()
+    doc.page_count = page_count if page_count is not None else len(pages)
+    doc.__iter__ = MagicMock(return_value=iter(pages))
+    doc.extract_image.return_value = {"width": 0, "height": 0, "image": b""}
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Patches applied to every test in this module
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_filesystem(tmp_path, monkeypatch):
+    """Redirect img_dir creation to a temp directory so nothing hits disk."""
+    import app.services.pdf_extractor as mod
+
+    orig_path = mod.Path
+
+    def fake_path(p):
+        np = orig_path(tmp_path) / "extracted_images"
+        np.mkdir(parents=True, exist_ok=True)
+
+        class _FakePath:
+            def __truediv__(self, other):
+                return tmp_path / other
+
+            def mkdir(self, **kw):
+                pass
+
+            @property
+            def parent(self):
+                return _FakePath()
+
+        return _FakePath()
+
+    # We only need mkdir to not fail; easiest is to patch Path.mkdir directly.
+    monkeypatch.setattr(mod.Path, "mkdir", lambda self, **kw: None)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — short text → OCR called, ocr_used: True in metadata
+# ---------------------------------------------------------------------------
+
+def test_short_page_triggers_ocr():
+    """When PyMuPDF returns <100 chars, pytesseract.image_to_string is called."""
+    short_text = "A" * 10  # well below threshold
+    page = _make_page(short_text)
+    doc = _make_doc([page])
+
+    ocr_result = "OCR extracted text from scanned page.\n"
+
+    with (
+        patch("fitz.open", return_value=doc),
+        patch("app.services.pdf_extractor._OCR_AVAILABLE", True),
+        patch("app.services.pdf_extractor.pytesseract") as mock_tess,
+        patch("app.services.pdf_extractor._page_to_pil", return_value=MagicMock()),
+        patch("pdfplumber.open", side_effect=ImportError),
+    ):
+        mock_tess.image_to_string.return_value = ocr_result
+
+        from app.services.pdf_extractor import extract_pdf
+
+        result = extract_pdf("/fake/doc.pdf")
+
+    mock_tess.image_to_string.assert_called_once()
+    assert result["metadata"]["ocr_used"] is True
+    assert result["pages"][0]["ocr_used"] is True
+    assert ocr_result.strip() in result["text"]
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — long text → OCR NOT called
+# ---------------------------------------------------------------------------
+
+def test_long_page_skips_ocr():
+    """When PyMuPDF returns ≥100 chars, pytesseract must not be called."""
+    long_text = "B" * 200  # above threshold
+    page = _make_page(long_text)
+    doc = _make_doc([page])
+
+    with (
+        patch("fitz.open", return_value=doc),
+        patch("app.services.pdf_extractor._OCR_AVAILABLE", True),
+        patch("app.services.pdf_extractor.pytesseract") as mock_tess,
+        patch("app.services.pdf_extractor._page_to_pil", return_value=MagicMock()),
+        patch("pdfplumber.open", side_effect=ImportError),
+    ):
+        from app.services.pdf_extractor import extract_pdf
+
+        result = extract_pdf("/fake/doc.pdf")
+
+    mock_tess.image_to_string.assert_not_called()
+    assert result["metadata"]["ocr_used"] is False
+    assert result["pages"][0]["ocr_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — short text + embedded images → likely_diagram: True
+# ---------------------------------------------------------------------------
+
+def test_short_text_with_images_flags_likely_diagram():
+    """
+    A page with <50 chars after OCR AND embedded images must have
+    likely_diagram: True in its per-page metadata.
+    """
+    # OCR returns very short text so total is still < 50 chars
+    short_page_text = ""
+    fake_image_ref = (1, 0, 0, 0, 0, 0, 0, 0)
+    page = _make_page(short_page_text, images=[fake_image_ref])
+    doc = _make_doc([page])
+
+    with (
+        patch("fitz.open", return_value=doc),
+        patch("app.services.pdf_extractor._OCR_AVAILABLE", True),
+        patch("app.services.pdf_extractor.pytesseract") as mock_tess,
+        patch("app.services.pdf_extractor._page_to_pil", return_value=MagicMock()),
+        patch("pdfplumber.open", side_effect=ImportError),
+    ):
+        # OCR also returns very short text → still below diagram threshold
+        mock_tess.image_to_string.return_value = "Fig"
+
+        from app.services.pdf_extractor import extract_pdf
+
+        result = extract_pdf("/fake/doc.pdf")
+
+    assert result["pages"][0]["likely_diagram"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — long text page with images → NOT flagged as likely_diagram
+# ---------------------------------------------------------------------------
+
+def test_long_text_with_images_not_flagged_as_diagram():
+    """A page with ≥100 chars is never flagged as a diagram, even with images."""
+    long_text = "C" * 200
+    fake_image_ref = (1, 0, 0, 0, 0, 0, 0, 0)
+    page = _make_page(long_text, images=[fake_image_ref])
+    doc = _make_doc([page])
+
+    with (
+        patch("fitz.open", return_value=doc),
+        patch("app.services.pdf_extractor._OCR_AVAILABLE", True),
+        patch("app.services.pdf_extractor.pytesseract") as mock_tess,
+        patch("app.services.pdf_extractor._page_to_pil", return_value=MagicMock()),
+        patch("pdfplumber.open", side_effect=ImportError),
+    ):
+        from app.services.pdf_extractor import extract_pdf
+
+        result = extract_pdf("/fake/doc.pdf")
+
+    mock_tess.image_to_string.assert_not_called()
+    assert result["pages"][0]["likely_diagram"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — pytesseract ImportError → graceful skip, no exception raised
+# ---------------------------------------------------------------------------
+
+def test_ocr_unavailable_skips_gracefully():
+    """
+    When _OCR_AVAILABLE is False (pytesseract not importable), extract_pdf must
+    complete without raising an exception and must NOT set ocr_used: True.
+    """
+    short_text = "X" * 5
+    page = _make_page(short_text)
+    doc = _make_doc([page])
+
+    with (
+        patch("fitz.open", return_value=doc),
+        patch("app.services.pdf_extractor._OCR_AVAILABLE", False),
+        patch("pdfplumber.open", side_effect=ImportError),
+    ):
+        from app.services.pdf_extractor import extract_pdf
+
+        # Must not raise
+        result = extract_pdf("/fake/doc.pdf")
+
+    assert result["metadata"]["ocr_used"] is False
+    assert result["pages"][0]["ocr_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — OCR exception on a page → graceful skip, processing continues
+# ---------------------------------------------------------------------------
+
+def test_ocr_exception_on_page_is_swallowed():
+    """
+    If pytesseract.image_to_string raises, the page is skipped gracefully and
+    the rest of the document is still returned.
+    """
+    pages = [_make_page("short"), _make_page("D" * 200)]
+    doc = _make_doc(pages)
+
+    with (
+        patch("fitz.open", return_value=doc),
+        patch("app.services.pdf_extractor._OCR_AVAILABLE", True),
+        patch("app.services.pdf_extractor.pytesseract") as mock_tess,
+        patch("app.services.pdf_extractor._page_to_pil", return_value=MagicMock()),
+        patch("pdfplumber.open", side_effect=ImportError),
+    ):
+        mock_tess.image_to_string.side_effect = RuntimeError("tesseract crashed")
+
+        from app.services.pdf_extractor import extract_pdf
+
+        result = extract_pdf("/fake/doc.pdf")
+
+    # The second page (long text) must still appear in the output
+    assert "D" * 200 in result["text"]
+    # OCR was attempted (and failed) on page 1, ocr_used_any remains False
+    assert result["metadata"]["ocr_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — pages key present in result and contains correct structure
+# ---------------------------------------------------------------------------
+
+def test_result_includes_pages_metadata():
+    """extract_pdf always returns a 'pages' list with per-page dicts."""
+    pages = [_make_page("Hello world " * 10), _make_page("Z" * 5)]
+    doc = _make_doc(pages)
+
+    with (
+        patch("fitz.open", return_value=doc),
+        patch("app.services.pdf_extractor._OCR_AVAILABLE", True),
+        patch("app.services.pdf_extractor.pytesseract") as mock_tess,
+        patch("app.services.pdf_extractor._page_to_pil", return_value=MagicMock()),
+        patch("pdfplumber.open", side_effect=ImportError),
+    ):
+        mock_tess.image_to_string.return_value = "ocr text\n"
+
+        from app.services.pdf_extractor import extract_pdf
+
+        result = extract_pdf("/fake/doc.pdf")
+
+    assert "pages" in result
+    assert len(result["pages"]) == 2
+    for meta in result["pages"]:
+        assert "page_number" in meta
+        assert "ocr_used" in meta
+        assert "likely_diagram" in meta


### PR DESCRIPTION
## Summary

- Adds Tesseract OCR as a fallback in `pdf_extractor.extract_pdf()`: when PyMuPDF extracts <100 chars from a page, the page is rendered to a PIL image and `pytesseract.image_to_string()` is called; `ocr_used: True` is set in per-page and top-level metadata
- Pages with <50 chars after OCR that also carry embedded images are flagged `likely_diagram: True` in per-page metadata for TASK-025 to consume
- If `pytesseract` is not importable a one-time warning is logged at startup and extraction continues without crashing (fail-open, not fail-closed, since OCR is a best-effort enhancement)
- `Dockerfile`: adds `tesseract-ocr` apt package alongside existing system deps
- `requirements.txt`: adds `pytesseract>=0.3.10` (Pillow already present)

## Files changed

| File | Change |
|------|--------|
| `knowledge-graph-builder/app/services/pdf_extractor.py` | OCR fallback, diagram flag, `pages` key in return dict |
| `knowledge-graph-builder/Dockerfile` | `tesseract-ocr` system package |
| `knowledge-graph-builder/requirements.txt` | `pytesseract>=0.3.10` |
| `knowledge-graph-builder/tests/unit/test_pdf_extractor_ocr.py` | 7 new unit tests |

## Test plan

- [x] `python3 -m pytest tests/unit/test_pdf_extractor_ocr.py -v` — 7/7 pass
- [ ] Short page (<100 chars) → `ocr_used: True` in metadata
- [ ] Long page (≥100 chars) → pytesseract not called
- [ ] Page with images + short OCR text → `likely_diagram: True`
- [ ] pytesseract absent → no crash, warning logged
- [ ] Docker image rebuilds cleanly after merge (Reza runs `docker compose build`)