### PR TITLE
TASK-022: Implement DataFlowAnalyzer — FLOWS_TO edges and taint source marking

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/code_graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/code_graphs.py
@@ -302,6 +302,7 @@ async def code_query(
     | `inheritance_chain` | `class_name`               |
     | `file_deps`         | `file_path`                |
     | `semantic_search`   | `query_text`; optional `top_k` |
+    | `data_flow`         | `source_symbol`; optional `depth` (default 10), `direction` (`forward`\|`backward`\|`both`) |
     """
     await verify_graph_access(str(graph_id), "read", user_id)
 
@@ -490,5 +491,70 @@ async def _run_code_query(
             {"graph_id": graph_id, "top_k": top_k, "embedding": query_embedding},
         )
         return [dict(r) for r in result.records]
+
+    if query_type == "data_flow":
+        source_symbol = params.get("source_symbol")
+        if not source_symbol:
+            raise _QueryParamError(
+                "'source_symbol' is required for query_type=data_flow"
+            )
+        depth = int(params.get("depth", 10))
+        direction = params.get("direction", "forward")
+
+        if direction == "backward":
+            cypher = """
+            MATCH (start {graph_id: $graph_id})
+            WHERE start.qualified_name = $source_symbol OR start.id = $source_symbol
+            MATCH path = (source)-[:FLOWS_TO*1..$depth]->(start)
+            RETURN
+                [node IN nodes(path) | coalesce(node.qualified_name, node.name)] AS path_nodes,
+                [node IN nodes(path) | labels(node)[0]]                          AS path_labels,
+                length(path)                                                       AS depth
+            ORDER BY depth
+            LIMIT $limit
+            """
+        elif direction == "both":
+            cypher = """
+            MATCH (start {graph_id: $graph_id})
+            WHERE start.qualified_name = $source_symbol OR start.id = $source_symbol
+            MATCH path = (start)-[:FLOWS_TO*1..$depth]-(sink)
+            RETURN
+                [node IN nodes(path) | coalesce(node.qualified_name, node.name)] AS path_nodes,
+                [node IN nodes(path) | labels(node)[0]]                          AS path_labels,
+                length(path)                                                       AS depth
+            ORDER BY depth
+            LIMIT $limit
+            """
+        else:
+            # default: forward
+            cypher = """
+            MATCH (start {graph_id: $graph_id})
+            WHERE start.qualified_name = $source_symbol OR start.id = $source_symbol
+            MATCH path = (start)-[:FLOWS_TO*1..$depth]->(sink)
+            RETURN
+                [node IN nodes(path) | coalesce(node.qualified_name, node.name)] AS path_nodes,
+                [node IN nodes(path) | labels(node)[0]]                          AS path_labels,
+                length(path)                                                       AS depth
+            ORDER BY depth
+            LIMIT $limit
+            """
+
+        result = await driver.execute_query(
+            cypher,
+            {
+                "graph_id": graph_id,
+                "source_symbol": source_symbol,
+                "depth": depth,
+                "limit": limit,
+            },
+        )
+        return [
+            {
+                "path_nodes": r["path_nodes"],
+                "path_labels": r["path_labels"],
+                "depth": r["depth"],
+            }
+            for r in result.records
+        ]
 
     raise _QueryParamError(f"Unknown query_type: {query_type}")

--- a/knowledge-graph-builder/app/schemas/code_schemas.py
+++ b/knowledge-graph-builder/app/schemas/code_schemas.py
@@ -54,6 +54,7 @@ class CodeQueryType(StrEnum):
     inheritance_chain = "inheritance_chain"
     file_deps = "file_deps"
     semantic_search = "semantic_search"
+    data_flow = "data_flow"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/knowledge-graph-builder/app/services/background_jobs.py
+++ b/knowledge-graph-builder/app/services/background_jobs.py
@@ -1618,11 +1618,33 @@ def code_ingest_task(self, job_id: str, user_id: str) -> dict[str, Any]:
                 f"[{job_id}] Stage 5 done: {stats.symbols_added} symbols written"
             )
 
-            # ── Stage 6: Stale Cleanup ─────────────────────────────────────
+            # ── Stage 6: Data Flow Analysis (Python only) ─────────────────
+            # Runs after write_code_graph_sync so all Function/Variable/Class
+            # nodes are already in Neo4j and can be referenced by FLOWS_TO edges.
+            # Uses the same sync driver (WorkerNeo4jManager / NullPool).
+            try:
+                from app.services.data_flow_analyzer import DataFlowAnalyzer
+
+                python_files = [f for f in to_parse if f.language == "python"]
+                if python_files:
+                    dfa = DataFlowAnalyzer(sync_driver=driver)
+                    flows_written = dfa.analyze_files(python_files, graph_id)
+                    logger.info(
+                        f"[{job_id}] Stage 6: DataFlowAnalyzer wrote "
+                        f"{flows_written} FLOWS_TO edges for "
+                        f"{len(python_files)} Python file(s)"
+                    )
+            except Exception as dfa_exc:
+                # Non-fatal — data flow analysis failure must not abort ingestion
+                logger.warning(
+                    f"[{job_id}] DataFlowAnalyzer failed (non-fatal): {dfa_exc}"
+                )
+
+            # ── Stage 7: Stale Cleanup ─────────────────────────────────────
             if mode == "full":
                 with driver.session() as session:
                     deleted = cleanup_stale_code_nodes_sync(graph_id, session)
-                logger.info(f"[{job_id}] Stage 6: cleaned up {deleted} stale nodes")
+                logger.info(f"[{job_id}] Stage 7: cleaned up {deleted} stale nodes")
 
         _pg_update_job(job_id, "completed", 100, {"symbols_added": stats.symbols_added})
         logger.info(

--- a/knowledge-graph-builder/app/services/data_flow_analyzer.py
+++ b/knowledge-graph-builder/app/services/data_flow_analyzer.py
@@ -1,0 +1,591 @@
+"""
+Data Flow Analyzer — intra-procedural Python data flow analysis.
+
+Produces FLOWS_TO edges in Neo4j connecting existing Function/Variable/Class
+nodes (written by code_parser_service.py).
+
+Phase 1 scope: Python intra-procedural only.
+
+Flow tracking rules:
+  1. Parameter → local var via assignment  → FLOWS_TO {via: "assignment"}
+  2. Local var  → return value             → FLOWS_TO {via: "return"}
+  3. Local var  → function argument        → FLOWS_TO {via: "argument"}
+  4. Augmented assignment: x = x + y      → both x and y flow into new x
+
+Taint source heuristics:
+  Function name contains: view, handler, endpoint, route, request
+  OR decorator includes: @app.route, @router., @api_view
+  → first parameter marked with taint: "user_input"
+
+Architecture invariants honoured:
+  - graph_id on every FLOWS_TO edge — no exceptions
+  - Parameterised Cypher only — never string-interpolate IDs or graph_id
+  - WorkerNeo4jManager (sync NullPool) — never async_driver here
+  - Python built-in ast module — not Tree-sitter
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Taint heuristics
+# ─────────────────────────────────────────────────────────────────────────────
+
+_TAINT_NAME_PATTERNS = re.compile(
+    r"(view|handler|endpoint|route|request)", re.IGNORECASE
+)
+_TAINT_DECORATOR_PATTERNS = re.compile(
+    r"(app\.route|router\.|api_view)", re.IGNORECASE
+)
+
+
+def _is_taint_source(func_name: str, decorator_names: list[str]) -> bool:
+    """Return True if the function is an HTTP entry-point (taint source)."""
+    if _TAINT_NAME_PATTERNS.search(func_name):
+        return True
+    for dec in decorator_names:
+        if _TAINT_DECORATOR_PATTERNS.search(dec):
+            return True
+    return False
+
+
+def _decorator_text(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Extract decorator expressions as plain strings."""
+    texts: list[str] = []
+    for dec in node.decorator_list:
+        try:
+            texts.append(ast.unparse(dec))
+        except Exception:
+            pass
+    return texts
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Internal data structures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FlowEdge:
+    """Represents one FLOWS_TO edge to write."""
+
+    source_qualified_name: str  # qualified_name of source node
+    target_qualified_name: str  # qualified_name of target node
+    via: str  # "assignment" | "return" | "argument"
+    source_line: int
+    source_file: str
+
+
+@dataclass
+class _TaintMark:
+    """A variable node that should have taint: "user_input" set."""
+
+    qualified_name: str
+
+
+@dataclass
+class _FunctionAnalysis:
+    edges: list[_FlowEdge] = field(default_factory=list)
+    taint_marks: list[_TaintMark] = field(default_factory=list)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Intra-procedural flow analysis
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FunctionFlowVisitor(ast.NodeVisitor):
+    """
+    Walk a single function body and emit flow edges.
+
+    Tracks a set of "tainted" names (parameters + variables derived from
+    parameters) within the function scope.  The tracked set grows as we see
+    assignments whose RHS references already-tracked names.
+    """
+
+    def __init__(
+        self,
+        func_qname: str,
+        param_names: list[str],
+        module_qname: str,
+        source_file: str,
+        is_taint_source: bool,
+    ) -> None:
+        self.func_qname = func_qname
+        self.module_qname = module_qname
+        self.source_file = source_file
+
+        # tracked_vars: name → qualified_name of the source node in Neo4j
+        # For parameters: the Function node is the source (they're not Variable nodes
+        # in the KG unless declared at module level).  We model them as flowing FROM
+        # the Function node.
+        self.tracked_vars: dict[str, str] = {}
+
+        # Build param set; if taint source, mark them
+        self.is_taint_source = is_taint_source
+        self.param_names = param_names
+        for pname in param_names:
+            # In the graph, function parameters are not separate Variable nodes;
+            # we model them as flowing from the Function node itself.
+            self.tracked_vars[pname] = func_qname
+
+        self.edges: list[_FlowEdge] = []
+        self.taint_marks: list[_TaintMark] = []
+
+        # If taint source, the first non-self parameter carries taint.
+        # The Variable node qualified_name would be module_qname.func_qname.param
+        # but those are not guaranteed to exist in Neo4j (only module-level
+        # annotated variables are written by code_parser_service).
+        # We record taint marks for best-effort: the write step MERGEs them only
+        # if the node already exists.
+        if is_taint_source:
+            for pname in param_names:
+                if pname not in ("self", "cls"):
+                    qname = f"{func_qname}.{pname}"
+                    self.taint_marks.append(_TaintMark(qualified_name=qname))
+                    break  # first user-facing param only
+
+    def _names_in_expr(self, node: ast.expr) -> list[str]:
+        """Collect all Name node ids referenced in an expression."""
+        names: list[str] = []
+        for n in ast.walk(node):
+            if isinstance(n, ast.Name):
+                names.append(n.id)
+        return names
+
+    def _expr_refs_tracked(self, node: ast.expr) -> list[str]:
+        """Return tracked variable names referenced in *node*."""
+        return [n for n in self._names_in_expr(node) if n in self.tracked_vars]
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """Handle simple and augmented-style assignments: x = ... """
+        rhs_tracked = self._expr_refs_tracked(node.value)
+
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                tname = target.id
+                tgt_qname = f"{self.func_qname}.{tname}"
+
+                for src_name in rhs_tracked:
+                    src_qname = self.tracked_vars[src_name]
+                    self.edges.append(
+                        _FlowEdge(
+                            source_qualified_name=src_qname,
+                            target_qualified_name=tgt_qname,
+                            via="assignment",
+                            source_line=node.lineno,
+                            source_file=self.source_file,
+                        )
+                    )
+
+                # The target now becomes tracked (derived from a tracked source)
+                if rhs_tracked:
+                    self.tracked_vars[tname] = tgt_qname
+
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        """Handle annotated assignments: x: int = ... """
+        if node.value is None:
+            return
+        rhs_tracked = self._expr_refs_tracked(node.value)
+        if isinstance(node.target, ast.Name):
+            tname = node.target.id
+            tgt_qname = f"{self.func_qname}.{tname}"
+            for src_name in rhs_tracked:
+                src_qname = self.tracked_vars[src_name]
+                self.edges.append(
+                    _FlowEdge(
+                        source_qualified_name=src_qname,
+                        target_qualified_name=tgt_qname,
+                        via="assignment",
+                        source_line=node.lineno,
+                        source_file=self.source_file,
+                    )
+                )
+            if rhs_tracked:
+                self.tracked_vars[tname] = tgt_qname
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        """Handle augmented assignments: x += y, x = x + y style."""
+        rhs_tracked = self._expr_refs_tracked(node.value)
+        if isinstance(node.target, ast.Name):
+            tname = node.target.id
+            tgt_qname = f"{self.func_qname}.{tname}"
+            # target also flows into itself (augmented)
+            all_sources = list(rhs_tracked)
+            if tname in self.tracked_vars:
+                all_sources.append(tname)
+            for src_name in all_sources:
+                src_qname = self.tracked_vars.get(src_name, f"{self.func_qname}.{src_name}")
+                self.edges.append(
+                    _FlowEdge(
+                        source_qualified_name=src_qname,
+                        target_qualified_name=tgt_qname,
+                        via="assignment",
+                        source_line=node.lineno,
+                        source_file=self.source_file,
+                    )
+                )
+            if all_sources:
+                self.tracked_vars[tname] = tgt_qname
+        self.generic_visit(node)
+
+    def visit_Return(self, node: ast.Return) -> None:
+        """Handle return statements: tracked var → function return."""
+        if node.value is None:
+            return
+        rhs_tracked = self._expr_refs_tracked(node.value)
+        for src_name in rhs_tracked:
+            src_qname = self.tracked_vars[src_name]
+            # Target is the Function node itself (represents its return value)
+            self.edges.append(
+                _FlowEdge(
+                    source_qualified_name=src_qname,
+                    target_qualified_name=self.func_qname,
+                    via="return",
+                    source_line=node.lineno,
+                    source_file=self.source_file,
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Handle function calls: tracked var passed as argument → FLOWS_TO call site."""
+        # Derive a call site qualified name
+        try:
+            callee_str = ast.unparse(node.func)
+        except Exception:
+            callee_str = "unknown"
+
+        # For positional arguments
+        for arg in node.args:
+            tracked = self._expr_refs_tracked(arg)
+            for src_name in tracked:
+                src_qname = self.tracked_vars[src_name]
+                # Target is a synthetic "call site" qualified name:
+                # module_qname.callee — best effort
+                tgt_qname = f"{self.module_qname}.{callee_str}"
+                self.edges.append(
+                    _FlowEdge(
+                        source_qualified_name=src_qname,
+                        target_qualified_name=tgt_qname,
+                        via="argument",
+                        source_line=node.lineno,
+                        source_file=self.source_file,
+                    )
+                )
+
+        # For keyword arguments
+        for kw in node.keywords:
+            if kw.value:
+                tracked = self._expr_refs_tracked(kw.value)
+                for src_name in tracked:
+                    src_qname = self.tracked_vars[src_name]
+                    tgt_qname = f"{self.module_qname}.{callee_str}"
+                    self.edges.append(
+                        _FlowEdge(
+                            source_qualified_name=src_qname,
+                            target_qualified_name=tgt_qname,
+                            via="argument",
+                            source_line=node.lineno,
+                            source_file=self.source_file,
+                        )
+                    )
+
+        self.generic_visit(node)
+
+
+def _analyze_function_ast(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    module_qname: str,
+    source_file: str,
+) -> _FunctionAnalysis:
+    """Analyse a single function AST node; return edges + taint marks."""
+    func_name = func_node.name
+    func_qname = f"{module_qname}.{func_name}" if module_qname else func_name
+
+    # Collect parameter names (skip *args, **kwargs annotations — just names)
+    param_names: list[str] = []
+    args = func_node.args
+    for arg in args.args + args.posonlyargs + args.kwonlyargs:
+        param_names.append(arg.arg)
+    if args.vararg:
+        param_names.append(args.vararg.arg)
+    if args.kwarg:
+        param_names.append(args.kwarg.arg)
+
+    decorator_texts = _decorator_text(func_node)
+    taint = _is_taint_source(func_name, decorator_texts)
+
+    visitor = _FunctionFlowVisitor(
+        func_qname=func_qname,
+        param_names=param_names,
+        module_qname=module_qname,
+        source_file=source_file,
+        is_taint_source=taint,
+    )
+    visitor.visit(func_node)
+
+    return _FunctionAnalysis(edges=visitor.edges, taint_marks=visitor.taint_marks)
+
+
+def _module_qname_from_path(file_path: str) -> str:
+    """Convert a file path to a dotted module name (mirrors code_parser_service)."""
+    p = Path(file_path)
+    parts = list(p.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Neo4j write helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MERGE_FLOWS_TO = """
+UNWIND $edges AS e
+MATCH (src {graph_id: $graph_id, qualified_name: e.src_qname})
+MATCH (tgt {graph_id: $graph_id, qualified_name: e.tgt_qname})
+MERGE (src)-[r:FLOWS_TO {
+    via: e.via,
+    graph_id: $graph_id,
+    source_file: e.source_file,
+    source_line: e.source_line
+}]->(tgt)
+RETURN count(r) AS written
+"""
+
+_MARK_TAINT = """
+UNWIND $marks AS m
+MATCH (n {graph_id: $graph_id, qualified_name: m.qname})
+SET n.taint = 'user_input'
+"""
+
+
+def _write_edges_sync(
+    session: Any,
+    graph_id: str,
+    flow_edges: list[_FlowEdge],
+    taint_marks: list[_TaintMark],
+    batch_size: int = 500,
+) -> int:
+    """Write FLOWS_TO edges + taint marks using a sync Neo4j session."""
+    total_written = 0
+
+    # Write edges in batches
+    edge_rows = [
+        {
+            "src_qname": e.source_qualified_name,
+            "tgt_qname": e.target_qualified_name,
+            "via": e.via,
+            "source_file": e.source_file,
+            "source_line": e.source_line,
+        }
+        for e in flow_edges
+    ]
+
+    for i in range(0, len(edge_rows), batch_size):
+        batch = edge_rows[i : i + batch_size]
+        result = session.run(
+            _MERGE_FLOWS_TO,
+            {"edges": batch, "graph_id": graph_id},
+        )
+        rec = result.single()
+        if rec:
+            total_written += int(rec["written"])
+
+    # Write taint marks (best-effort: nodes may not exist)
+    if taint_marks:
+        mark_rows = [{"qname": m.qualified_name} for m in taint_marks]
+        try:
+            session.run(_MARK_TAINT, {"marks": mark_rows, "graph_id": graph_id})
+        except Exception as exc:
+            logger.warning(f"Taint mark write failed (non-fatal): {exc}")
+
+    return total_written
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public interface
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class DataFlowAnalyzer:
+    """
+    Intra-procedural Python data flow analyzer.
+
+    Reads Python source via the built-in `ast` module, emits FLOWS_TO edges
+    to Neo4j using a sync driver session (WorkerNeo4jManager / NullPool).
+
+    Usage in Celery context:
+        with WorkerNeo4jManager() as neo4j:
+            driver = neo4j.get_sync_driver()
+            analyzer = DataFlowAnalyzer(driver)
+            count = analyzer.analyze_file(abs_path, graph_id)
+    """
+
+    def __init__(self, sync_driver: Any | None = None) -> None:
+        """
+        Args:
+            sync_driver: Neo4j sync driver (GraphDatabase.driver).
+                         Required for any method that writes to Neo4j.
+                         Pass None for pure AST analysis (testing / dry-run).
+        """
+        self._driver = sync_driver
+
+    # ------------------------------------------------------------------
+    # Core: analyse a single function's source
+    # ------------------------------------------------------------------
+
+    def analyze_function(
+        self,
+        function_node_id: str,
+        source_code: str,
+        graph_id: str,
+        source_file: str = "<unknown>",
+    ) -> int:
+        """
+        Parse *source_code* as a Python module, find all function definitions,
+        and write FLOWS_TO edges for each one.
+
+        Args:
+            function_node_id: The qualified_name of the function in the KG.
+                              Used to scope the analysis to this function only.
+            source_code:       Full Python source (the function's enclosing module).
+            graph_id:          Multi-tenancy scope key.
+            source_file:       Source path for edge metadata.
+
+        Returns:
+            Number of FLOWS_TO edges written to Neo4j.
+        """
+        try:
+            tree = ast.parse(source_code, filename=source_file)
+        except SyntaxError as exc:
+            logger.warning(f"DataFlowAnalyzer: syntax error in {source_file}: {exc}")
+            return 0
+
+        module_qname = _module_qname_from_path(source_file)
+        all_edges: list[_FlowEdge] = []
+        all_taint: list[_TaintMark] = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                fqname = f"{module_qname}.{node.name}" if module_qname else node.name
+                if fqname != function_node_id and node.name != function_node_id:
+                    continue  # only analyse the requested function
+                analysis = _analyze_function_ast(node, module_qname, source_file)
+                all_edges.extend(analysis.edges)
+                all_taint.extend(analysis.taint_marks)
+
+        if not all_edges and not all_taint:
+            return 0
+
+        if self._driver is None:
+            logger.debug(
+                f"DataFlowAnalyzer: no driver — dry-run for {function_node_id}"
+            )
+            return len(all_edges)
+
+        with self._driver.session() as session:
+            return _write_edges_sync(session, graph_id, all_edges, all_taint)
+
+    # ------------------------------------------------------------------
+    # Analyse an entire file
+    # ------------------------------------------------------------------
+
+    def analyze_file(self, file_path: str, graph_id: str) -> int:
+        """
+        Parse a Python file, analyse every function definition, and write
+        FLOWS_TO edges to Neo4j.
+
+        Args:
+            file_path: Absolute (or relative) path to the Python file.
+            graph_id:  Multi-tenancy scope key.
+
+        Returns:
+            Total number of FLOWS_TO edges written.
+        """
+        try:
+            source_code = Path(file_path).read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning(f"DataFlowAnalyzer: cannot read {file_path}: {exc}")
+            return 0
+
+        try:
+            tree = ast.parse(source_code, filename=file_path)
+        except SyntaxError as exc:
+            logger.warning(f"DataFlowAnalyzer: syntax error in {file_path}: {exc}")
+            return 0
+
+        module_qname = _module_qname_from_path(file_path)
+        all_edges: list[_FlowEdge] = []
+        all_taint: list[_TaintMark] = []
+
+        # Walk only top-level and class-level function definitions
+        # (we do not recurse into nested functions — Phase 1 scope)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                analysis = _analyze_function_ast(node, module_qname, file_path)
+                all_edges.extend(analysis.edges)
+                all_taint.extend(analysis.taint_marks)
+
+        if not all_edges and not all_taint:
+            return 0
+
+        if self._driver is None:
+            logger.debug(
+                f"DataFlowAnalyzer: no driver — dry-run for {file_path}, "
+                f"{len(all_edges)} edges found"
+            )
+            return len(all_edges)
+
+        with self._driver.session() as session:
+            written = _write_edges_sync(session, graph_id, all_edges, all_taint)
+
+        logger.info(
+            f"DataFlowAnalyzer: {file_path} — {written} FLOWS_TO edges written "
+            f"({len(all_taint)} taint marks)"
+        )
+        return written
+
+    # ------------------------------------------------------------------
+    # Convenience: analyse all Python files from a file_meta list
+    # ------------------------------------------------------------------
+
+    def analyze_files(
+        self,
+        file_metas: list[Any],
+        graph_id: str,
+    ) -> int:
+        """
+        Analyse all Python files in *file_metas* (FileMetadata from code_parser_service).
+
+        Args:
+            file_metas: List of FileMetadata objects; only language=="python" are processed.
+            graph_id:   Multi-tenancy scope key.
+
+        Returns:
+            Total FLOWS_TO edges written across all files.
+        """
+        total = 0
+        for fm in file_metas:
+            if getattr(fm, "language", None) != "python":
+                continue
+            try:
+                total += self.analyze_file(fm.abs_path, graph_id)
+            except Exception as exc:
+                logger.warning(
+                    f"DataFlowAnalyzer: error analysing {fm.abs_path}: {exc}"
+                )
+        return total

--- a/knowledge-graph-builder/tests/unit/test_data_flow_analyzer.py
+++ b/knowledge-graph-builder/tests/unit/test_data_flow_analyzer.py
@@ -1,0 +1,472 @@
+"""
+Unit tests for data_flow_analyzer.py
+
+Covers (per TASK-022 Definition of Done):
+  #1  — parameter → local var via assignment   → FLOWS_TO {via: "assignment"}
+  #2  — local var → return value               → FLOWS_TO {via: "return"}
+  #3  — local var → function argument          → FLOWS_TO {via: "argument"}
+  #4  — taint source: handle_request → first param tainted
+  #5  — graph_id on every edge
+  #6  — augmented assignment: x = x + y, both x and y flow into new x
+  #7  — non-taint function: no taint marks produced
+  #8  — decorator taint heuristic (@app.route)
+  #9  — analyze_file returns correct edge count (dry-run, no Neo4j)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.data_flow_analyzer import (
+    DataFlowAnalyzer,
+    _FunctionFlowVisitor,
+    _analyze_function_ast,
+    _is_taint_source,
+    _module_qname_from_path,
+)
+
+import ast
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_first_function(
+    source: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """Parse *source* and return the first function definition node."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return node
+    raise ValueError("No function found in source")
+
+
+def _edges_from_source(source: str, module_qname: str = "mymodule", source_file: str = "mymodule.py"):
+    """Convenience: analyse first function in *source*, return list of _FlowEdge."""
+    func_node = _parse_first_function(source)
+    analysis = _analyze_function_ast(func_node, module_qname, source_file)
+    return analysis.edges, analysis.taint_marks
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #1 — parameter → local var via assignment
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parameter_to_local_var_assignment():
+    """
+    def fn(data):
+        result = data   # data (param) flows into result
+    """
+    source = """\
+def fn(data):
+    result = data
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    assignment_edges = [e for e in edges if e.via == "assignment"]
+    assert len(assignment_edges) >= 1, "Expected at least one assignment edge"
+
+    # The source should be the function node (parameters flow FROM the function)
+    edge = assignment_edges[0]
+    assert "fn" in edge.source_qualified_name, (
+        f"Expected source to reference fn, got: {edge.source_qualified_name}"
+    )
+    assert "result" in edge.target_qualified_name, (
+        f"Expected target to reference result, got: {edge.target_qualified_name}"
+    )
+    assert edge.via == "assignment"
+
+
+@pytest.mark.unit
+def test_parameter_to_multiple_vars():
+    """Two assignments from the same param produce two edges."""
+    source = """\
+def fn(x):
+    a = x
+    b = x
+"""
+    edges, _ = _edges_from_source(source)
+    assignment_edges = [e for e in edges if e.via == "assignment"]
+    assert len(assignment_edges) == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #2 — local var → return value
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_local_var_to_return():
+    """
+    def fn(x):
+        result = x
+        return result  # result flows into the function return
+    """
+    source = """\
+def fn(x):
+    result = x
+    return result
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    return_edges = [e for e in edges if e.via == "return"]
+    assert len(return_edges) >= 1, "Expected at least one return edge"
+
+    edge = return_edges[0]
+    # Source should be the local var (result) or param (x)
+    assert edge.via == "return"
+    # Target should be the function node itself
+    assert "fn" in edge.target_qualified_name
+
+
+@pytest.mark.unit
+def test_direct_param_return():
+    """
+    def fn(x):
+        return x   # param x flows directly to return
+    """
+    source = """\
+def fn(x):
+    return x
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    return_edges = [e for e in edges if e.via == "return"]
+    assert len(return_edges) >= 1
+    # Source is the function (representing the parameter)
+    assert "fn" in return_edges[0].source_qualified_name
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #3 — local var → function argument
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_local_var_to_argument():
+    """
+    def fn(user_input):
+        safe = sanitize(user_input)   # user_input flows into sanitize(...)
+    """
+    source = """\
+def fn(user_input):
+    safe = sanitize(user_input)
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    arg_edges = [e for e in edges if e.via == "argument"]
+    assert len(arg_edges) >= 1, "Expected at least one argument edge"
+
+    edge = arg_edges[0]
+    assert edge.via == "argument"
+    # Source should be the function (param flows from fn node)
+    assert "fn" in edge.source_qualified_name
+
+
+@pytest.mark.unit
+def test_derived_var_to_argument():
+    """Local variable derived from a param also flows to call argument."""
+    source = """\
+def fn(raw):
+    processed = raw
+    execute(processed)
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    arg_edges = [e for e in edges if e.via == "argument"]
+    assert len(arg_edges) >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #4 — taint source: function named handle_request → first param tainted
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_taint_source_by_function_name():
+    """
+    Functions with 'request' in the name should have first param marked tainted.
+    """
+    source = """\
+def handle_request(req, context):
+    data = req.body
+    return data
+"""
+    _, taint_marks = _edges_from_source(source, "views", "views.py")
+    assert len(taint_marks) >= 1, "Expected at least one taint mark"
+    # First non-self param (req) should be marked
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("req" in qn for qn in taint_qnames), (
+        f"Expected 'req' param in taint marks, got: {taint_qnames}"
+    )
+
+
+@pytest.mark.unit
+def test_taint_source_view_name():
+    """Function named 'user_view' should be a taint source."""
+    source = """\
+def user_view(request):
+    return request.data
+"""
+    _, taint_marks = _edges_from_source(source, "views")
+    assert len(taint_marks) >= 1
+
+
+@pytest.mark.unit
+def test_taint_source_endpoint_name():
+    """Function containing 'endpoint' in name → taint source."""
+    source = """\
+def create_endpoint(payload, auth):
+    return payload
+"""
+    _, taint_marks = _edges_from_source(source)
+    assert len(taint_marks) >= 1
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("payload" in qn for qn in taint_qnames)
+
+
+@pytest.mark.unit
+def test_non_taint_function_no_marks():
+    """Regular function should produce no taint marks."""
+    source = """\
+def compute_average(numbers):
+    total = sum(numbers)
+    return total / len(numbers)
+"""
+    _, taint_marks = _edges_from_source(source)
+    assert len(taint_marks) == 0, f"Expected no taint marks, got: {taint_marks}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #5 — graph_id on every edge (checked via DataFlowAnalyzer dry-run)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_graph_id_on_every_edge_metadata(tmp_path):
+    """
+    DataFlowAnalyzer.analyze_file() in dry-run (no driver) returns correct edge
+    count. Separately verify that the Cypher template includes $graph_id.
+    """
+    source = """\
+def process(user_input):
+    result = user_input
+    return result
+"""
+    py_file = tmp_path / "service.py"
+    py_file.write_text(source)
+
+    # Dry-run: pass no driver
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    count = analyzer.analyze_file(str(py_file), graph_id="test-graph-id-123")
+    assert count >= 1, "Expected at least one edge from dry-run"
+
+
+@pytest.mark.unit
+def test_graph_id_in_cypher_template():
+    """The MERGE_FLOWS_TO Cypher must reference $graph_id — architecture invariant."""
+    from app.services.data_flow_analyzer import _MERGE_FLOWS_TO
+
+    assert "$graph_id" in _MERGE_FLOWS_TO, (
+        "FLOWS_TO MERGE query must use $graph_id parameter (architecture invariant)"
+    )
+
+
+@pytest.mark.unit
+def test_taint_cypher_includes_graph_id():
+    """The taint mark Cypher must also scope by $graph_id."""
+    from app.services.data_flow_analyzer import _MARK_TAINT
+
+    assert "$graph_id" in _MARK_TAINT, (
+        "_MARK_TAINT Cypher must use $graph_id (multi-tenancy invariant)"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #6 — augmented assignment
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_augmented_assignment_both_sources_tracked():
+    """
+    def fn(x, y):
+        x += y   # both x and y flow into x
+    """
+    source = """\
+def fn(x, y):
+    x += y
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    assignment_edges = [e for e in edges if e.via == "assignment"]
+    # x+=y: x flows into x (augmented) AND y flows into x
+    assert len(assignment_edges) >= 2, (
+        f"Expected >=2 assignment edges for augmented assignment, got {len(assignment_edges)}"
+    )
+
+
+@pytest.mark.unit
+def test_compound_assignment_chain():
+    """
+    def fn(a):
+        b = a
+        c = b   # b (derived) flows into c
+        return c
+    """
+    source = """\
+def fn(a):
+    b = a
+    c = b
+    return c
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    assert len([e for e in edges if e.via == "assignment"]) >= 2
+    assert len([e for e in edges if e.via == "return"]) >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #7 — taint heuristic: decorator @app.route
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_taint_source_app_route_decorator():
+    """@app.route decorator marks first param as taint source."""
+    source = """\
+@app.route("/create", methods=["POST"])
+def create(request):
+    data = request.json
+    return data
+"""
+    _, taint_marks = _edges_from_source(source)
+    assert len(taint_marks) >= 1
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("request" in qn for qn in taint_qnames)
+
+
+@pytest.mark.unit
+def test_taint_source_router_decorator():
+    """@router.get / @router.post marks function as taint source."""
+    assert _is_taint_source("my_func", ["router.get('/path')"]) is True
+
+
+@pytest.mark.unit
+def test_taint_source_api_view_decorator():
+    """@api_view marks function as taint source."""
+    assert _is_taint_source("my_func", ["api_view(['GET'])"]) is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #8 — _is_taint_source helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_is_taint_source_by_name():
+    assert _is_taint_source("handle_request", []) is True
+    assert _is_taint_source("list_view", []) is True
+    assert _is_taint_source("route_handler", []) is True
+    assert _is_taint_source("compute_sum", []) is False
+
+
+@pytest.mark.unit
+def test_is_taint_source_by_decorator():
+    assert _is_taint_source("my_fn", ["app.route('/path')"]) is True
+    assert _is_taint_source("my_fn", ["router.post('/items')"]) is True
+    assert _is_taint_source("my_fn", ["login_required"]) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #9 — analyze_file edge counting (dry-run, no Neo4j)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_analyze_file_returns_edge_count(tmp_path):
+    """analyze_file in dry-run mode returns the correct edge count."""
+    source = """\
+def first(a, b):
+    x = a
+    y = b
+    return x
+
+def second(p):
+    q = p
+    process(q)
+"""
+    py_file = tmp_path / "myservice.py"
+    py_file.write_text(source)
+
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    count = analyzer.analyze_file(str(py_file), graph_id="g-123")
+
+    # first(): a→x (assignment), b→y (assignment), x→return = 3 edges
+    # second(): p→q (assignment), q→process (argument) = 2 edges
+    # Total: 5 edges minimum
+    assert count >= 5, f"Expected >=5 edges, got {count}"
+
+
+@pytest.mark.unit
+def test_analyze_file_skips_non_python(tmp_path):
+    """analyze_file returns 0 for non-Python files (not a crash)."""
+    ts_file = tmp_path / "app.ts"
+    ts_file.write_text("const x = 1;")
+
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    # TypeScript file — SyntaxError on parse → graceful 0
+    count = analyzer.analyze_file(str(ts_file), graph_id="g-ts")
+    assert count == 0
+
+
+@pytest.mark.unit
+def test_analyze_file_syntax_error_returns_zero(tmp_path):
+    """analyze_file handles SyntaxError gracefully."""
+    bad_file = tmp_path / "broken.py"
+    bad_file.write_text("def fn(: pass")
+
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    count = analyzer.analyze_file(str(bad_file), graph_id="g-bad")
+    assert count == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #10 — module_qname helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_module_qname_from_path():
+    assert _module_qname_from_path("app/services/data_flow_analyzer.py") == (
+        "app.services.data_flow_analyzer"
+    )
+    assert _module_qname_from_path("main.py") == "main"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #11 — self/cls excluded from taint marks
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_self_param_excluded_from_taint():
+    """self is not a user-controlled parameter and must not be taint-marked."""
+    source = """\
+class MyView:
+    def handle_request(self, request):
+        return request.data
+"""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            analysis = _analyze_function_ast(node, "myapp.MyView", "myapp.py")
+            taint_qnames = [m.qualified_name for m in analysis.taint_marks]
+            # self should not be marked, request should be
+            assert not any("self" in qn for qn in taint_qnames), (
+                f"'self' should not be in taint marks: {taint_qnames}"
+            )
+            if analysis.taint_marks:
+                assert any("request" in qn for qn in taint_qnames)
+            break


### PR DESCRIPTION
## Summary

- Adds `app/services/data_flow_analyzer.py` with `DataFlowAnalyzer` class performing intra-procedural Python data flow analysis using the built-in `ast` module
- Tracks parameter→local var (assignment), local var→return, and local var→function argument flows; augmented assignments handled correctly
- Taint source heuristics mark HTTP entry-point parameters (`taint: "user_input"`) based on function name patterns (view, handler, endpoint, route, request) and decorator patterns (@app.route, @router., @api_view)
- All `FLOWS_TO` edges carry `graph_id`, `source_file`, `source_line`, and `via` properties — multi-tenancy invariant upheld
- Adds `data_flow` query type to `code_graphs.py` endpoint (`source_symbol` required; optional `depth` and `direction`)
- Wires `DataFlowAnalyzer.analyze_files()` into `code_ingest_task()` after Stage 5 (write); failure is non-fatal

## Test plan

- [x] 25 unit tests in `tests/unit/test_data_flow_analyzer.py` — all pass (`python3 -m pytest tests/unit/test_data_flow_analyzer.py -v`)
- [x] Parameter→local var via assignment edge produced correctly
- [x] Local var→return edge produced correctly
- [x] Local var→function argument edge produced correctly
- [x] Augmented assignment: both LHS and RHS tracked vars flow into target
- [x] Taint source marking: `handle_request`, `user_view`, `create_endpoint` all detected
- [x] Non-taint function produces zero taint marks
- [x] `self`/`cls` excluded from taint marks
- [x] `@app.route`, `@router.`, `@api_view` decorators trigger taint source
- [x] `$graph_id` present in both `_MERGE_FLOWS_TO` and `_MARK_TAINT` Cypher templates
- [x] `analyze_file` returns correct edge count in dry-run mode
- [x] `analyze_file` returns 0 for syntax errors and non-Python files (graceful)
- [x] `CodeQueryType.data_flow` added to schema enum
- [x] `_run_code_query` dispatcher handles `data_flow` with parameterised Cypher