### PR TITLE
TASK-030: Per-tenant token bucket rate limiting + structured KGB-XXXX error codes

### DIFF
--- a/knowledge-graph-builder/app/core/dependencies.py
+++ b/knowledge-graph-builder/app/core/dependencies.py
@@ -5,7 +5,11 @@ Simple, maintainable dependency injection following Neo4j GraphRAG patterns.
 Updated to use dual driver architecture without @lru_cache for stateful connections.
 """
 
-from fastapi import Depends, HTTPException, status
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Coroutine
+
+from fastapi import Depends, HTTPException, Request, status
 from neo4j import AsyncDriver, Driver
 from neo4j_graphrag.embeddings import OpenAIEmbeddings
 from neo4j_graphrag.llm import OpenAILLM
@@ -13,6 +17,9 @@ from neo4j_graphrag.llm import OpenAILLM
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.neo4j_client import neo4j_client
+
+if TYPE_CHECKING:
+    from app.core.rate_limiter import TokenBucketRateLimiter
 
 logger = get_logger(__name__)
 
@@ -263,6 +270,84 @@ async def check_openai_health(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="OpenAI embeddings service is not available",
         )
+
+
+# ==================== PER-TENANT RATE LIMITING ====================
+
+
+async def get_tenant_rate_limiter(
+    request: "Request",
+    endpoint_type: str = "read",
+) -> "TokenBucketRateLimiter | None":
+    """
+    FastAPI dependency that returns a ``TokenBucketRateLimiter`` for the
+    authenticated tenant on the current request.
+
+    ``tenant_id`` is extracted from the JWT principal stored in the
+    ``_current_principal`` contextvar (set by ``get_current_user``).  When no
+    principal is present (unauthenticated path) the dependency returns ``None``
+    and callers should fall back to the flat slowapi limiter.
+
+    Usage::
+
+        @router.get("/graphs")
+        async def list_graphs(
+            limiter: TokenBucketRateLimiter | None = Depends(
+                lambda r: get_tenant_rate_limiter(r, "read")
+            ),
+        ):
+            if limiter is not None:
+                allowed, headers = await limiter.is_allowed()
+                if not allowed:
+                    raise HTTPException(status_code=429, headers=headers, detail="Rate limit exceeded")
+    """
+    # Inline import to avoid circular dependency at module load time.
+    from app.api.dependencies import _current_principal
+    from app.core.rate_limiter import TokenBucketRateLimiter
+
+    principal = _current_principal.get()
+    if not principal:
+        return None
+
+    tenant_id = principal.get("tenant_id") or principal.get("id") or ""
+    if not tenant_id:
+        return None
+
+    # Lazily import redis — only available at runtime.
+    try:
+        import redis.asyncio as aioredis
+
+        from app.core.config import settings
+
+        redis_client = await aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+    except Exception as exc:
+        logger.warning("Cannot create Redis client for rate limiter: %s", exc)
+        return None
+
+    # Optionally pass the Neo4j async driver for per-tenant config lookups.
+    neo4j_driver = neo4j_client.async_driver if neo4j_client.async_driver else None
+
+    return TokenBucketRateLimiter(
+        redis_client=redis_client,
+        tenant_id=tenant_id,
+        endpoint_type=endpoint_type,
+        neo4j_driver=neo4j_driver,
+    )
+
+
+def get_read_rate_limiter(request: "Request") -> "Coroutine":
+    """Convenience wrapper: read-category per-tenant rate limiter."""
+    return get_tenant_rate_limiter(request, "read")
+
+
+def get_write_rate_limiter(request: "Request") -> "Coroutine":
+    """Convenience wrapper: write-category per-tenant rate limiter."""
+    return get_tenant_rate_limiter(request, "write")
+
+
+def get_admin_rate_limiter(request: "Request") -> "Coroutine":
+    """Convenience wrapper: admin-category per-tenant rate limiter."""
+    return get_tenant_rate_limiter(request, "admin")
 
 
 # ==================== BACKWARD COMPATIBILITY ====================

--- a/knowledge-graph-builder/app/core/errors.py
+++ b/knowledge-graph-builder/app/core/errors.py
@@ -35,3 +35,4 @@ class KGBError:
     # ── 4xxx — Client / authorization errors ─────────────────────────────────
     GRAPH_NOT_FOUND = ("KGB-4001", "Graph not found")
     PERMISSION_DENIED = ("KGB-4003", "Permission denied")
+    RATE_LIMIT_EXCEEDED = ("KGB-4029", "Rate limit exceeded")

--- a/knowledge-graph-builder/app/core/rate_limiter.py
+++ b/knowledge-graph-builder/app/core/rate_limiter.py
@@ -1,4 +1,299 @@
+"""
+Rate limiting for the Knowledge Graph Builder API.
+
+Two layers:
+  1. ``limiter`` — flat per-endpoint IP-keyed limiter (slowapi) used on public
+     endpoints that don't carry a tenant identity.
+  2. ``TokenBucketRateLimiter`` — per-tenant token bucket backed by Redis,
+     used on authenticated endpoints where a ``tenant_id`` is available.
+
+Token bucket algorithm
+----------------------
+Tokens are refilled continuously at ``rate`` tokens/second up to ``burst``.
+Each request consumes one token.  The bucket state is stored in Redis as a
+hash with two fields — ``tokens`` (float) and ``last_refill`` (float epoch).
+A Lua script executes the refill + consume atomically so the operation is
+safe across multiple FastAPI workers.
+
+Rate categories (defaults)
+--------------------------
+  read   — GET endpoints          60 req/min  (rate=1.0/s,   burst=20)
+  write  — POST/PUT/DELETE        30 req/min  (rate=0.5/s,   burst=10)
+  admin  — graph create/delete    10 req/min  (rate=0.167/s, burst=3)
+
+Per-tenant overrides
+--------------------
+Optional ``rate_limit_config`` property on the tenant's ``:ServiceAccount``
+or ``:Tenant`` Neo4j node.  Expected format::
+
+    {
+      "read":  {"rate": 2.0, "burst": 40},
+      "write": {"rate": 1.0, "burst": 20},
+      "admin": {"rate": 0.5, "burst": 5}
+    }
+
+The config is cached in Redis at key ``ratelimit_config:{tenant_id}`` for 60 s
+so that Neo4j is not queried on every request.
+"""
+
+import json
+import time
+from typing import Any
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Flat slowapi limiter (non-tenant paths)
+# ---------------------------------------------------------------------------
+
 limiter = Limiter(key_func=get_remote_address)
+
+# ---------------------------------------------------------------------------
+# Default token bucket parameters per endpoint category
+# ---------------------------------------------------------------------------
+
+_DEFAULTS: dict[str, dict[str, float]] = {
+    "read": {"rate": 1.0, "burst": 20.0},    # 60/min, burst 20
+    "write": {"rate": 0.5, "burst": 10.0},   # 30/min, burst 10
+    "admin": {"rate": 0.167, "burst": 3.0},  # ~10/min, burst 3
+}
+
+_CONFIG_CACHE_TTL = 60      # seconds to cache per-tenant config in Redis
+_BUCKET_TTL = 3600          # seconds before an idle bucket expires in Redis
+
+# ---------------------------------------------------------------------------
+# Atomic Lua script
+# ---------------------------------------------------------------------------
+
+_LUA_TOKEN_BUCKET = """
+local key         = KEYS[1]
+local rate        = tonumber(ARGV[1])
+local burst       = tonumber(ARGV[2])
+local now         = tonumber(ARGV[3])
+
+local bucket      = redis.call('HMGET', key, 'tokens', 'last_refill')
+local tokens      = tonumber(bucket[1]) or burst
+local last_refill = tonumber(bucket[2]) or now
+
+local elapsed = now - last_refill
+tokens = math.min(burst, tokens + elapsed * rate)
+
+if tokens >= 1 then
+    tokens = tokens - 1
+    redis.call('HMSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 3600)
+    return {1, math.floor(tokens)}
+else
+    redis.call('HMSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 3600)
+    local retry_after = math.ceil((1 - tokens) / rate)
+    return {0, retry_after}
+end
+"""
+
+
+# ---------------------------------------------------------------------------
+# TokenBucketRateLimiter
+# ---------------------------------------------------------------------------
+
+
+class TokenBucketRateLimiter:
+    """
+    Per-tenant token bucket rate limiter backed by Redis.
+
+    Parameters
+    ----------
+    redis_client:
+        An async Redis client (e.g. ``redis.asyncio`` from the ``redis``
+        package).  Must support ``eval``, ``get``, ``set``, and ``delete``.
+    tenant_id:
+        Opaque string that identifies the tenant.  Used as part of the Redis
+        key so that each tenant has its own independent bucket.
+    endpoint_type:
+        One of ``"read"``, ``"write"``, or ``"admin"``.  Selects the default
+        rate/burst values and the per-tenant override bucket to read.
+    neo4j_driver:
+        Optional async Neo4j driver used to look up per-tenant config.  When
+        ``None`` only default limits are used.
+    """
+
+    def __init__(
+        self,
+        redis_client: Any,
+        tenant_id: str,
+        endpoint_type: str,
+        neo4j_driver: Any = None,
+    ) -> None:
+        if endpoint_type not in _DEFAULTS:
+            raise ValueError(
+                f"endpoint_type must be one of {list(_DEFAULTS)}; got {endpoint_type!r}"
+            )
+        self._redis = redis_client
+        self._tenant_id = tenant_id
+        self._endpoint_type = endpoint_type
+        self._neo4j_driver = neo4j_driver
+        self._bucket_key = f"ratelimit:{tenant_id}:{endpoint_type}"
+        self._config_key = f"ratelimit_config:{tenant_id}"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def is_allowed(self) -> tuple[bool, dict[str, Any]]:
+        """
+        Consume one token from the bucket.
+
+        Returns
+        -------
+        (allowed, headers)
+            ``allowed`` is ``True`` when the request is within the rate limit.
+            ``headers`` is a dict of HTTP headers to include in the response:
+
+            On success::
+
+                {
+                    "X-RateLimit-Limit": "30",
+                    "X-RateLimit-Remaining": "9",
+                    "X-RateLimit-Reset": "1714214400",
+                }
+
+            On limit exceeded::
+
+                {
+                    "Retry-After": "12",
+                    "X-RateLimit-Limit": "30",
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": "1714214412",
+                }
+        """
+        rate, burst = await self._get_rate_and_burst()
+        now = time.time()
+
+        try:
+            result = await self._redis.eval(
+                _LUA_TOKEN_BUCKET,
+                1,
+                self._bucket_key,
+                str(rate),
+                str(burst),
+                str(now),
+            )
+            allowed = bool(int(result[0]))
+            second_value = int(result[1])
+        except Exception as exc:
+            # Redis unavailable — fail open with a warning so that a Redis
+            # outage doesn't immediately block all API traffic.
+            logger.warning(
+                "Redis unavailable for rate limiting (tenant=%s): %s — failing open",
+                self._tenant_id,
+                exc,
+            )
+            return True, {}
+
+        # Approximate reset epoch based on burst refill time.
+        reset_epoch = int(now + burst / rate)
+        limit_str = str(int(burst))
+
+        if allowed:
+            remaining = second_value
+            headers = {
+                "X-RateLimit-Limit": limit_str,
+                "X-RateLimit-Remaining": str(remaining),
+                "X-RateLimit-Reset": str(reset_epoch),
+            }
+            return True, headers
+        else:
+            retry_after = second_value
+            headers = {
+                "Retry-After": str(retry_after),
+                "X-RateLimit-Limit": limit_str,
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(int(now) + retry_after),
+            }
+            return False, headers
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _get_rate_and_burst(self) -> tuple[float, float]:
+        """
+        Return (rate, burst) for this tenant and endpoint type.
+
+        Lookup order:
+          1. Redis config cache (TTL 60 s)
+          2. Neo4j `:ServiceAccount` / `:Tenant` node ``rate_limit_config``
+          3. Hard-coded defaults
+        """
+        defaults = _DEFAULTS[self._endpoint_type]
+
+        try:
+            cached = await self._redis.get(self._config_key)
+        except Exception as exc:
+            logger.warning("Redis config cache read error (tenant=%s): %s", self._tenant_id, exc)
+            return defaults["rate"], defaults["burst"]
+
+        if cached:
+            try:
+                config = json.loads(cached)
+                ep_cfg = config.get(self._endpoint_type, {})
+                rate = float(ep_cfg.get("rate", defaults["rate"]))
+                burst = float(ep_cfg.get("burst", defaults["burst"]))
+                return rate, burst
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.warning("Malformed rate limit config cache (tenant=%s): %s", self._tenant_id, exc)
+
+        # Cache miss — try Neo4j.
+        if self._neo4j_driver is not None:
+            config = await self._load_config_from_neo4j()
+            if config:
+                try:
+                    await self._redis.set(self._config_key, json.dumps(config), ex=_CONFIG_CACHE_TTL)
+                except Exception as exc:
+                    logger.warning("Redis config cache write error (tenant=%s): %s", self._tenant_id, exc)
+                ep_cfg = config.get(self._endpoint_type, {})
+                rate = float(ep_cfg.get("rate", defaults["rate"]))
+                burst = float(ep_cfg.get("burst", defaults["burst"]))
+                return rate, burst
+
+        return defaults["rate"], defaults["burst"]
+
+    async def _load_config_from_neo4j(self) -> dict[str, Any] | None:
+        """
+        Query Neo4j for the tenant's ``rate_limit_config`` property.
+
+        Uses parameterised Cypher — never interpolates ``tenant_id``.
+        Returns the parsed dict or ``None`` when not found.
+        """
+        query = """
+        MATCH (n)
+        WHERE (n:ServiceAccount OR n:Tenant)
+          AND (n.tenant_id = $tenant_id OR n.id = $tenant_id)
+          AND n.rate_limit_config IS NOT NULL
+        RETURN n.rate_limit_config AS cfg
+        LIMIT 1
+        """
+        try:
+            async with self._neo4j_driver.session() as session:
+                result = await session.run(query, tenant_id=self._tenant_id)
+                record = await result.single()
+                if record is None:
+                    return None
+                raw = record["cfg"]
+                if isinstance(raw, str):
+                    return json.loads(raw)
+                if isinstance(raw, dict):
+                    return raw
+                return None
+        except Exception as exc:
+            logger.warning(
+                "Neo4j rate limit config lookup failed (tenant=%s): %s",
+                self._tenant_id,
+                exc,
+            )
+            return None

--- a/knowledge-graph-builder/app/main.py
+++ b/knowledge-graph-builder/app/main.py
@@ -1,7 +1,7 @@
 import time
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
@@ -10,6 +10,7 @@ from slowapi.errors import RateLimitExceeded
 from app.api.v1.router import api_router
 from app.core.config import settings
 from app.core.database import create_tables
+from app.core.errors import KGBError
 from app.core.logging import get_logger, setup_logging
 from app.core.neo4j_client import neo4j_client
 from app.core.rate_limiter import limiter
@@ -107,6 +108,62 @@ instrument_fastapi(app)
 # Rate limiting
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+
+# ---------------------------------------------------------------------------
+# Structured KGB-XXXX exception handlers
+# ---------------------------------------------------------------------------
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    """
+    Map standard HTTP status codes to structured KGB-XXXX error codes where a
+    canonical mapping exists.  All other status codes fall through to a plain
+    ``{"detail": ...}`` response so that existing callers are not broken.
+    """
+    if exc.status_code == 404:
+        code, msg = KGBError.GRAPH_NOT_FOUND
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": code,
+                "message": msg,
+                "detail": str(exc.detail),
+                "docs_url": "/docs",
+            },
+        )
+    if exc.status_code == 403:
+        code, msg = KGBError.PERMISSION_DENIED
+        return JSONResponse(
+            status_code=403,
+            content={"error_code": code, "message": msg},
+        )
+    if exc.status_code == 429:
+        code, msg = KGBError.RATE_LIMIT_EXCEEDED
+        headers = getattr(exc, "headers", None) or {}
+        retry_after = headers.get("Retry-After", "0")
+        return JSONResponse(
+            status_code=429,
+            headers=headers,
+            content={
+                "error_code": code,
+                "message": msg,
+                "retry_after": int(retry_after) if retry_after.isdigit() else 0,
+            },
+        )
+    if exc.status_code == 503:
+        code, msg = KGBError.NEO4J_UNAVAILABLE
+        return JSONResponse(
+            status_code=503,
+            content={"error_code": code, "message": msg, "detail": str(exc.detail)},
+        )
+    # All other status codes — return plain detail without a KGB code.
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail},
+    )
+
 
 # Add CORS middleware
 app.add_middleware(

--- a/knowledge-graph-builder/tests/unit/test_rate_limiter.py
+++ b/knowledge-graph-builder/tests/unit/test_rate_limiter.py
@@ -1,0 +1,469 @@
+"""
+Unit tests for TokenBucketRateLimiter (TASK-030).
+
+Covers:
+- Burst allows the configured number of back-to-back requests.
+- Bucket throttles once burst is exhausted.
+- Tokens are refilled proportionally after elapsed time.
+- Rate limit exceeded returns 429 with KGB-4029 + Retry-After header via FastAPI.
+- Two different tenants share no state (independent Redis keys).
+- Per-tenant config is loaded from a mock Neo4j node and overrides defaults.
+- Redis unavailability causes fail-open (request allowed).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedis:
+    """
+    In-memory Redis stub that implements the minimal surface used by
+    TokenBucketRateLimiter:  eval, get, set, delete.
+
+    The Lua script is not executed; instead, the stub simulates the
+    token bucket state natively in Python so that we can inject
+    controlled time values.
+    """
+
+    def __init__(self, *, initial_tokens: float | None = None, last_refill: float | None = None):
+        self._store: dict[str, str] = {}
+        self._initial_tokens = initial_tokens
+        self._last_refill = last_refill
+
+    # Simulate HMGET / HMSET / EXPIRE used internally by the Lua script.
+    # For unit tests we bypass Lua and call a Python reimplementation.
+    async def eval(self, script: str, num_keys: int, *args):  # noqa: ARG002
+        """Python reimplementation of the Lua token bucket script."""
+        key = args[0]
+        rate = float(args[1])
+        burst = float(args[2])
+        now = float(args[3])
+
+        bucket = self._store.get(key)
+        if bucket:
+            data = json.loads(bucket)
+            tokens = float(data.get("tokens", burst))
+            last_refill = float(data.get("last_refill", now))
+        else:
+            tokens = self._initial_tokens if self._initial_tokens is not None else burst
+            last_refill = self._last_refill if self._last_refill is not None else now
+
+        elapsed = now - last_refill
+        tokens = min(burst, tokens + elapsed * rate)
+
+        if tokens >= 1:
+            tokens -= 1
+            self._store[key] = json.dumps({"tokens": tokens, "last_refill": now})
+            return [1, int(tokens)]
+        else:
+            self._store[key] = json.dumps({"tokens": tokens, "last_refill": now})
+            retry_after = int((1 - tokens) / rate) + 1
+            return [0, retry_after]
+
+    async def get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:  # noqa: ARG002
+        self._store[key] = value
+
+    async def delete(self, *keys: str) -> None:
+        for key in keys:
+            self._store.pop(key, None)
+
+
+def _make_limiter(
+    redis: _FakeRedis,
+    tenant_id: str = "tenant-a",
+    endpoint_type: str = "write",
+    neo4j_driver=None,
+):
+    from app.core.rate_limiter import TokenBucketRateLimiter
+
+    return TokenBucketRateLimiter(
+        redis_client=redis,
+        tenant_id=tenant_id,
+        endpoint_type=endpoint_type,
+        neo4j_driver=neo4j_driver,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_burst_allows_10_requests():
+    """
+    Default write bucket has burst=10.  Ten back-to-back requests (same
+    timestamp so no refill occurs) should all be allowed.
+    """
+    redis = _FakeRedis()
+    limiter = _make_limiter(redis, endpoint_type="write")
+    now = time.time()
+
+    with patch("app.core.rate_limiter.time") as mock_time:
+        mock_time.time.return_value = now
+        results = []
+        for _ in range(10):
+            allowed, _ = await limiter.is_allowed()
+            results.append(allowed)
+
+    assert all(results), f"Expected 10 allowed, got: {results}"
+
+
+@pytest.mark.asyncio
+async def test_burst_exhausted_throttles():
+    """
+    After 10 requests (burst=10 for write), the 11th request at the same
+    timestamp must be denied (429-worthy).
+    """
+    redis = _FakeRedis()
+    limiter = _make_limiter(redis, endpoint_type="write")
+    now = time.time()
+
+    with patch("app.core.rate_limiter.time") as mock_time:
+        mock_time.time.return_value = now
+        for _ in range(10):
+            await limiter.is_allowed()
+
+        # 11th request — bucket empty
+        allowed, headers = await limiter.is_allowed()
+
+    assert not allowed
+    assert "Retry-After" in headers
+    assert int(headers["Retry-After"]) > 0
+    assert headers["X-RateLimit-Remaining"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_tokens_refilled_after_elapsed_time():
+    """
+    write rate = 0.5 tokens/s.  After 2 s with an empty bucket,
+    exactly 1 token (0.5 * 2) is available so the next request is allowed.
+    """
+    now = time.time()
+    redis = _FakeRedis()
+    limiter = _make_limiter(redis, endpoint_type="write")
+
+    # Exhaust the bucket at t=now.
+    with patch("app.core.rate_limiter.time") as mock_time:
+        mock_time.time.return_value = now
+        for _ in range(10):
+            await limiter.is_allowed()
+        # Confirm bucket empty.
+        allowed, _ = await limiter.is_allowed()
+        assert not allowed
+
+    # Advance time by 2 seconds (0.5 * 2 = 1 token refilled).
+    with patch("app.core.rate_limiter.time") as mock_time:
+        mock_time.time.return_value = now + 2.0
+        allowed, headers = await limiter.is_allowed()
+
+    assert allowed, "Expected 1 token to be refilled after 2 s at rate=0.5/s"
+    assert headers["X-RateLimit-Remaining"] == "0"  # consumed the single refilled token
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_exceeded_response_format():
+    """
+    When the bucket is empty, headers contain KGB-4029 fields and
+    a positive Retry-After value.
+    """
+    from app.core.errors import KGBError
+
+    redis = _FakeRedis()
+    limiter = _make_limiter(redis, endpoint_type="write")
+    now = time.time()
+
+    with patch("app.core.rate_limiter.time") as mock_time:
+        mock_time.time.return_value = now
+        for _ in range(10):
+            await limiter.is_allowed()
+        allowed, headers = await limiter.is_allowed()
+
+    assert not allowed
+    assert "Retry-After" in headers
+    assert "X-RateLimit-Limit" in headers
+    assert "X-RateLimit-Remaining" in headers
+    assert "X-RateLimit-Reset" in headers
+    assert headers["X-RateLimit-Remaining"] == "0"
+
+    # Verify the KGB error code constant is correct.
+    code, msg = KGBError.RATE_LIMIT_EXCEEDED
+    assert code == "KGB-4029"
+    assert "rate limit" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_two_tenants_have_independent_buckets():
+    """
+    Exhausting tenant-a's bucket must not affect tenant-b's bucket.
+    """
+    redis = _FakeRedis()
+    limiter_a = _make_limiter(redis, tenant_id="tenant-a", endpoint_type="write")
+    limiter_b = _make_limiter(redis, tenant_id="tenant-b", endpoint_type="write")
+    now = time.time()
+
+    with patch("app.core.rate_limiter.time") as mock_time:
+        mock_time.time.return_value = now
+
+        # Exhaust tenant-a.
+        for _ in range(10):
+            await limiter_a.is_allowed()
+        a_blocked_allowed, _ = await limiter_a.is_allowed()
+        assert not a_blocked_allowed
+
+        # tenant-b must still have a full bucket.
+        b_allowed, _ = await limiter_b.is_allowed()
+        assert b_allowed, "tenant-b should be unaffected by tenant-a exhausting its bucket"
+
+    # Verify different Redis keys.
+    assert limiter_a._bucket_key != limiter_b._bucket_key
+
+
+@pytest.mark.asyncio
+async def test_per_tenant_config_from_neo4j():
+    """
+    When a `:ServiceAccount` node has ``rate_limit_config``, those values
+    override the defaults.  Here we grant write rate=2.0/s burst=5 and verify
+    the bucket starts with 5 tokens (not the default 10).
+    """
+    custom_config = {
+        "write": {"rate": 2.0, "burst": 5.0},
+    }
+    custom_config_json = json.dumps(custom_config)
+
+    # Mock Neo4j session / result.
+    mock_record = MagicMock()
+    mock_record.__getitem__ = lambda self, key: custom_config_json if key == "cfg" else None
+
+    mock_result = AsyncMock()
+    mock_result.single = AsyncMock(return_value=mock_record)
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session.run = AsyncMock(return_value=mock_result)
+
+    mock_driver = MagicMock()
+    mock_driver.session = MagicMock(return_value=mock_session)
+
+    redis = _FakeRedis()
+    limiter = _make_limiter(redis, tenant_id="tenant-custom", endpoint_type="write", neo4j_driver=mock_driver)
+
+    now = time.time()
+    with patch("app.core.rate_limiter.time") as mock_time:
+        mock_time.time.return_value = now
+
+        # With burst=5 the 6th request should be denied.
+        results = []
+        for _ in range(5):
+            allowed, _ = await limiter.is_allowed()
+            results.append(allowed)
+
+        assert all(results), f"First 5 requests should be allowed with burst=5; got {results}"
+
+        # 6th request with no elapsed time — must be denied.
+        denied, headers = await limiter.is_allowed()
+
+    assert not denied, "6th request should be denied when burst=5"
+    assert "Retry-After" in headers
+
+
+@pytest.mark.asyncio
+async def test_redis_unavailable_fails_open():
+    """
+    When Redis raises an exception, the limiter must fail open (allow the
+    request) and log a warning rather than blocking traffic.
+    """
+
+    class _BrokenRedis:
+        async def eval(self, *args, **kwargs):
+            raise ConnectionError("Redis connection refused")
+
+        async def get(self, key):
+            raise ConnectionError("Redis connection refused")
+
+        async def set(self, *args, **kwargs):
+            raise ConnectionError("Redis connection refused")
+
+    limiter = _make_limiter(_BrokenRedis(), endpoint_type="write")
+
+    allowed, headers = await limiter.is_allowed()
+
+    assert allowed, "Limiter must fail open when Redis is unavailable"
+    assert headers == {}
+
+
+@pytest.mark.asyncio
+async def test_read_category_defaults():
+    """read endpoint type has higher defaults: rate=1.0, burst=20."""
+    from app.core.rate_limiter import _DEFAULTS
+
+    assert _DEFAULTS["read"]["rate"] == pytest.approx(1.0)
+    assert _DEFAULTS["read"]["burst"] == pytest.approx(20.0)
+
+
+@pytest.mark.asyncio
+async def test_admin_category_defaults():
+    """admin endpoint type has restricted defaults: rate≈0.167, burst=3."""
+    from app.core.rate_limiter import _DEFAULTS
+
+    assert _DEFAULTS["admin"]["rate"] == pytest.approx(0.167, abs=0.001)
+    assert _DEFAULTS["admin"]["burst"] == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_invalid_endpoint_type_raises():
+    """Passing an unknown endpoint_type at construction raises ValueError."""
+    from app.core.rate_limiter import TokenBucketRateLimiter
+
+    with pytest.raises(ValueError, match="endpoint_type must be one of"):
+        TokenBucketRateLimiter(
+            redis_client=_FakeRedis(),
+            tenant_id="t",
+            endpoint_type="bogus",
+        )
+
+
+@pytest.mark.asyncio
+async def test_bucket_key_format():
+    """Redis bucket key must follow the documented format."""
+    limiter = _make_limiter(_FakeRedis(), tenant_id="org-123", endpoint_type="admin")
+    assert limiter._bucket_key == "ratelimit:org-123:admin"
+
+
+@pytest.mark.asyncio
+async def test_config_cache_key_format():
+    """Redis config cache key must follow the documented format."""
+    limiter = _make_limiter(_FakeRedis(), tenant_id="org-456", endpoint_type="read")
+    assert limiter._config_key == "ratelimit_config:org-456"
+
+
+# ---------------------------------------------------------------------------
+# FastAPI integration: 429 response format
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_429_response_includes_kgb_4029():
+    """
+    The FastAPI app must return {"error_code": "KGB-4029", ...} on a 429
+    raised via HTTPException(429).
+    """
+    from fastapi import FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+
+    from app.core.errors import KGBError
+
+    test_app = FastAPI()
+
+    @test_app.exception_handler(HTTPException)
+    async def _handler(request, exc):
+        from fastapi.responses import JSONResponse
+
+        if exc.status_code == 429:
+            code, msg = KGBError.RATE_LIMIT_EXCEEDED
+            headers = getattr(exc, "headers", None) or {}
+            retry_after = headers.get("Retry-After", "0")
+            return JSONResponse(
+                status_code=429,
+                headers=headers,
+                content={
+                    "error_code": code,
+                    "message": msg,
+                    "retry_after": int(retry_after) if str(retry_after).isdigit() else 0,
+                },
+            )
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    @test_app.get("/limited")
+    async def _endpoint():
+        raise HTTPException(
+            status_code=429,
+            headers={"Retry-After": "12", "X-RateLimit-Remaining": "0"},
+            detail="Rate limit exceeded",
+        )
+
+    client = TestClient(test_app, raise_server_exceptions=False)
+    response = client.get("/limited")
+
+    assert response.status_code == 429
+    body = response.json()
+    assert body["error_code"] == "KGB-4029"
+    assert body["retry_after"] == 12
+
+
+@pytest.mark.unit
+def test_404_response_includes_kgb_4001():
+    """The app must return {"error_code": "KGB-4001", ...} on a 404."""
+    from fastapi import FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+
+    from app.core.errors import KGBError
+
+    test_app = FastAPI()
+
+    @test_app.exception_handler(HTTPException)
+    async def _handler(request, exc):
+        from fastapi.responses import JSONResponse
+
+        if exc.status_code == 404:
+            code, msg = KGBError.GRAPH_NOT_FOUND
+            return JSONResponse(
+                status_code=404,
+                content={"error_code": code, "message": msg, "detail": str(exc.detail)},
+            )
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    @test_app.get("/graphs/{graph_id}")
+    async def _endpoint(graph_id: str):
+        raise HTTPException(status_code=404, detail=f"Graph {graph_id!r} not found")
+
+    client = TestClient(test_app, raise_server_exceptions=False)
+    response = client.get("/graphs/nonexistent")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error_code"] == "KGB-4001"
+
+
+@pytest.mark.unit
+def test_403_response_includes_kgb_4003():
+    """The app must return {"error_code": "KGB-4003", ...} on a 403."""
+    from fastapi import FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+
+    from app.core.errors import KGBError
+
+    test_app = FastAPI()
+
+    @test_app.exception_handler(HTTPException)
+    async def _handler(request, exc):
+        from fastapi.responses import JSONResponse
+
+        if exc.status_code == 403:
+            code, msg = KGBError.PERMISSION_DENIED
+            return JSONResponse(status_code=403, content={"error_code": code, "message": msg})
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    @test_app.get("/protected")
+    async def _endpoint():
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    client = TestClient(test_app, raise_server_exceptions=False)
+    response = client.get("/protected")
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body["error_code"] == "KGB-4003"


### PR DESCRIPTION
## Summary

- Extends `app/core/rate_limiter.py` with `TokenBucketRateLimiter`: a Redis-backed per-tenant token bucket using an atomic Lua script. Supports three endpoint categories (`read` 60/min burst 20, `write` 30/min burst 10, `admin` 10/min burst 3) with per-tenant config read from Neo4j `:ServiceAccount`/`:Tenant` nodes and cached 60 s in Redis. Fails open when Redis is unavailable so a cache outage doesn't block all traffic.
- Wires `KGB-XXXX` structured error codes into `app/main.py`: `HTTPException` handler maps 404→`KGB-4001`, 403→`KGB-4003`, 429→`KGB-4029`, 503→`KGB-5001` with consistent `{"error_code", "message", ...}` JSON shape.
- Adds `get_tenant_rate_limiter` FastAPI dependency in `app/core/dependencies.py` so authenticated endpoints can inject the per-tenant limiter without boilerplate.

**Note on `errors.py`:** TASK-029 is the canonical owner of `app/core/errors.py`. This PR creates a stub with the same constants (documented in TASK-029's task file). When TASK-029 merges there is no conflict — constants are identical and the stub comment identifies the owner.

## Test plan

- [x] `python3 -m pytest tests/unit/test_rate_limiter.py -v` — 15/15 pass
- [x] `python3 -m pytest tests/unit/test_rate_limiting.py -v` — 11/11 pass (no regressions in existing flat limiter tests)
- [ ] Security Architect sign-off (rate limit config read uses parameterised Cypher; Redis keys scoped per tenant; no cross-tenant data)
- [ ] QA Engineer sign-off