### PR TITLE
TASK-025: Diagram structured extraction + CSV/JSON/Markdown extractors + document_processor dispatch

### DIFF
--- a/knowledge-graph-builder/app/services/csv_extractor.py
+++ b/knowledge-graph-builder/app/services/csv_extractor.py
@@ -1,0 +1,136 @@
+"""
+CSV/TSV structured extraction service.
+
+Extracts schema, sample rows, and row count from CSV and TSV files using
+Python stdlib only (csv, io). No pandas or external dependencies.
+"""
+
+import csv
+import io
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+def _infer_type(values: list[str]) -> str:
+    """
+    Infer the column type from a list of sample string values.
+
+    Precedence: bool → int → float → date → str
+    Empty strings are skipped; if all values are empty, returns "str".
+    """
+    non_empty = [v.strip() for v in values if v.strip()]
+    if not non_empty:
+        return "str"
+
+    def is_bool(v: str) -> bool:
+        return v.lower() in {"true", "false", "yes", "no", "1", "0"}
+
+    def is_int(v: str) -> bool:
+        try:
+            int(v)
+            return True
+        except ValueError:
+            return False
+
+    def is_float(v: str) -> bool:
+        try:
+            float(v)
+            return True
+        except ValueError:
+            return False
+
+    def is_date(v: str) -> bool:
+        # Accept YYYY-MM-DD, MM/DD/YYYY, DD-MM-YYYY (most common formats)
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%d-%m-%Y", "%Y/%m/%d"):
+            try:
+                date.fromisoformat(v) if fmt == "%Y-%m-%d" else __import__(
+                    "datetime"
+                ).datetime.strptime(v, fmt)
+                return True
+            except ValueError:
+                continue
+        return False
+
+    if all(is_bool(v) for v in non_empty):
+        return "bool"
+    if all(is_int(v) for v in non_empty):
+        return "int"
+    if all(is_float(v) for v in non_empty):
+        return "float"
+    if all(is_date(v) for v in non_empty):
+        return "date"
+    return "str"
+
+
+def _detect_delimiter(file_path: str) -> str:
+    """
+    Auto-detect CSV delimiter using csv.Sniffer.
+
+    Falls back to comma if detection fails or the file extension is .csv.
+    """
+    ext = Path(file_path).suffix.lower()
+    if ext == ".tsv":
+        return "\t"
+
+    with open(file_path, newline="", encoding="utf-8", errors="replace") as fh:
+        sample = fh.read(4096)
+
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",\t;|")
+        return dialect.delimiter
+    except csv.Error:
+        return ","
+
+
+def extract_csv(file_path: str) -> dict[str, Any]:
+    """
+    Extract schema, sample rows, and row count from a CSV or TSV file.
+
+    Args:
+        file_path: Absolute path to the CSV or TSV file.
+
+    Returns:
+        {
+            "columns": ["col1", "col2", ...],
+            "row_count": int,
+            "sample_rows": [first 5 rows as list of dicts],
+            "schema": {"col_name": "str|int|float|bool|date"}
+        }
+    """
+    delimiter = _detect_delimiter(file_path)
+
+    columns: list[str] = []
+    sample_rows: list[dict[str, str]] = []
+    row_count = 0
+
+    # Accumulate up to 100 rows per column for type inference
+    type_samples: dict[str, list[str]] = {}
+
+    with open(file_path, newline="", encoding="utf-8", errors="replace") as fh:
+        reader = csv.DictReader(fh, delimiter=delimiter)
+
+        # DictReader exposes fieldnames after the first row is read
+        for row in reader:
+            if row_count == 0:
+                columns = list(reader.fieldnames or [])
+                type_samples = {col: [] for col in columns}
+
+            row_count += 1
+
+            if row_count <= 5:
+                sample_rows.append(dict(row))
+
+            if row_count <= 100:
+                for col in columns:
+                    val = row.get(col, "") or ""
+                    type_samples[col].append(val)
+
+    schema: dict[str, str] = {col: _infer_type(type_samples[col]) for col in columns}
+
+    return {
+        "columns": columns,
+        "row_count": row_count,
+        "sample_rows": sample_rows,
+        "schema": schema,
+    }

--- a/knowledge-graph-builder/app/services/document_processor.py
+++ b/knowledge-graph-builder/app/services/document_processor.py
@@ -3,11 +3,12 @@ Document Processing Service
 
 Handles different file types for ingestion:
 - Raw text
-- PDF files
+- PDF files (with diagram-mode image extraction for flagged pages)
 - DOC/DOCX files
-- Future: URLs, structured data
-
-This service prepares documents for the GraphRAG pipeline.
+- CSV / TSV files
+- JSON / JSONL files
+- Markdown files
+- Future: URLs
 """
 
 from typing import Any
@@ -24,10 +25,13 @@ class DocumentProcessor:
     Process different document types for GraphRAG ingestion.
 
     Supported formats:
-    - text: Raw text content
-    - pdf: PDF files (future implementation)
-    - doc/docx: Word documents (future implementation)
-    - url: Web content (future implementation)
+    - text     : Raw text content
+    - pdf      : PDF files (via pdf_extractor; diagram pages routed to VisionExtractor)
+    - doc/docx : Word documents
+    - csv/tsv  : CSV and TSV files (via csv_extractor)
+    - json/jsonl: JSON and JSONL files (via json_extractor)
+    - md/markdown: Markdown files (via md_extractor)
+    - url      : Web content (not yet implemented)
     """
 
     @staticmethod
@@ -38,27 +42,40 @@ class DocumentProcessor:
         Process document content based on source type.
 
         Args:
-            content: Document content (text or base64 for files)
-            source_type: Type of document ("text", "pdf", "doc", "docx", "url")
-            metadata: Additional metadata for the document
+            content: Document content (raw text) or absolute file path on disk.
+            source_type: One of "text", "pdf", "doc", "docx", "csv", "tsv",
+                         "json", "jsonl", "md", "markdown", "url".
+            metadata: Additional metadata for the document.
 
         Returns:
-            Processed document with text content and metadata
+            Processed document with text content and metadata (+ ``structured``
+            key for CSV/JSON/MD documents).
         """
-
         if source_type == "text":
             return DocumentProcessor._process_text(content, metadata)
         elif source_type == "pdf":
             return DocumentProcessor._process_pdf(content, metadata)
-        elif source_type in ["doc", "docx"]:
+        elif source_type in {"doc", "docx"}:
             return DocumentProcessor._process_word(content, metadata)
+        elif source_type in {"csv", "tsv"}:
+            return DocumentProcessor._process_csv(content, metadata)
+        elif source_type in {"json", "jsonl"}:
+            return DocumentProcessor._process_json(content, metadata)
+        elif source_type in {"md", "markdown"}:
+            return DocumentProcessor._process_markdown(content, metadata)
         elif source_type == "url":
             return DocumentProcessor._process_url(content, metadata)
         else:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Unsupported source type: {source_type}. Supported types: text, pdf, doc, docx, url",
+                detail=(
+                    f"Unsupported source type: {source_type}. "
+                    "Supported types: text, pdf, doc, docx, csv, tsv, "
+                    "json, jsonl, md, markdown, url"
+                ),
             )
+
+    # ── Core format handlers ──────────────────────────────────────────────────
 
     @staticmethod
     def _process_text(
@@ -93,8 +110,12 @@ class DocumentProcessor:
         """
         Process a PDF file.
 
+        Image paths returned by pdf_extractor that carry ``likely_diagram: True``
+        in their per-page metadata are forwarded to VisionExtractor in diagram
+        mode so they produce structured nodes/edges rather than plain text.
+
         Args:
-            content: Absolute path to the PDF file on disk (stored in source_content).
+            content: Absolute path to the PDF file on disk.
             metadata: Additional metadata dict.
         """
         from app.services.pdf_extractor import extract_pdf
@@ -117,12 +138,34 @@ class DocumentProcessor:
         processed_metadata.update(result["metadata"])
         processed_metadata["content_length"] = len(result["text"])
 
-        return {
+        # Route diagram-flagged pages through VisionExtractor in diagram mode
+        image_paths = result.get("image_paths", [])
+        diagram_results: list[dict[str, Any]] = []
+        page_metadata: dict[str, Any] = result.get("metadata", {})
+
+        if image_paths and page_metadata.get("likely_diagram"):
+            from app.services.vision_extractor import vision_extractor
+
+            for img_path in image_paths:
+                try:
+                    diagram = vision_extractor.extract(
+                        img_path,
+                        metadata={"likely_diagram": True},
+                    )
+                    diagram_results.append({"image_path": img_path, "diagram": diagram})
+                except Exception as exc:
+                    logger.warning(f"Diagram extraction failed for {img_path}: {exc}")
+
+        response: dict[str, Any] = {
             "text": result["text"],
             "metadata": processed_metadata,
-            "image_paths": result.get("image_paths", []),
+            "image_paths": image_paths,
             "success": True,
         }
+        if diagram_results:
+            response["diagram_extractions"] = diagram_results
+
+        return response
 
     @staticmethod
     def _process_word(
@@ -162,6 +205,121 @@ class DocumentProcessor:
             "success": True,
         }
 
+    # ── Structured format handlers (TASK-025) ─────────────────────────────────
+
+    @staticmethod
+    def _process_csv(
+        content: str, metadata: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """
+        Process a CSV or TSV file.
+
+        Args:
+            content: Absolute path to the CSV/TSV file on disk.
+            metadata: Additional metadata dict.
+        """
+        from app.services.csv_extractor import extract_csv
+
+        try:
+            result = extract_csv(content)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"CSV extraction failed: {exc}",
+            )
+
+        processed_metadata = metadata or {}
+        processed_metadata.update(
+            {
+                "content_type": "text/csv",
+                "processing_method": "csv_extractor",
+                "row_count": result["row_count"],
+                "column_count": len(result["columns"]),
+            }
+        )
+
+        return {
+            "text": "",
+            "structured": result,
+            "metadata": processed_metadata,
+            "success": True,
+        }
+
+    @staticmethod
+    def _process_json(
+        content: str, metadata: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """
+        Process a JSON or JSONL file.
+
+        Args:
+            content: Absolute path to the JSON/JSONL file on disk.
+            metadata: Additional metadata dict.
+        """
+        from app.services.json_extractor import extract_json
+
+        try:
+            result = extract_json(content)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"JSON extraction failed: {exc}",
+            )
+
+        processed_metadata = metadata or {}
+        processed_metadata.update(
+            {
+                "content_type": "application/json",
+                "processing_method": "json_extractor",
+                "record_count": result["record_count"],
+            }
+        )
+
+        return {
+            "text": "",
+            "structured": result,
+            "metadata": processed_metadata,
+            "success": True,
+        }
+
+    @staticmethod
+    def _process_markdown(
+        content: str, metadata: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """
+        Process a Markdown file.
+
+        Args:
+            content: Absolute path to the Markdown file on disk.
+            metadata: Additional metadata dict.
+        """
+        from app.services.md_extractor import extract_markdown
+
+        try:
+            result = extract_markdown(content)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Markdown extraction failed: {exc}",
+            )
+
+        processed_metadata = metadata or {}
+        processed_metadata.update(
+            {
+                "content_type": "text/markdown",
+                "processing_method": "md_extractor",
+                "section_count": len(result["sections"]),
+                "title": result["title"],
+            }
+        )
+
+        return {
+            "text": "",
+            "structured": result,
+            "metadata": processed_metadata,
+            "success": True,
+        }
+
     @staticmethod
     def _process_url(
         content: str, metadata: dict[str, Any] | None = None
@@ -176,16 +334,17 @@ class DocumentProcessor:
         """
         logger.warning("URL processing not yet implemented")
 
-        # For now, return error
         raise HTTPException(
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail="URL processing is not yet implemented. Coming soon!",
         )
 
+    # ── Utility methods ───────────────────────────────────────────────────────
+
     @staticmethod
     def get_supported_types() -> list[str]:
         """Return list of supported document types."""
-        return ["text", "pdf", "doc", "docx"]
+        return ["text", "pdf", "doc", "docx", "csv", "tsv", "json", "jsonl", "md", "markdown"]
 
     @staticmethod
     def validate_source_type(source_type: str) -> bool:

--- a/knowledge-graph-builder/app/services/json_extractor.py
+++ b/knowledge-graph-builder/app/services/json_extractor.py
@@ -1,0 +1,181 @@
+"""
+JSON/JSONL structured extraction service.
+
+Handles single JSON objects, JSON arrays, and JSONL (newline-delimited JSON).
+Schema inference recurses into nested objects and detects homogeneous arrays.
+
+Uses Python stdlib only (json, pathlib).
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _type_name(value: Any) -> str:
+    """Return a simple type name for a JSON value."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return "unknown"
+
+
+def _infer_schema(obj: Any) -> Any:
+    """
+    Recursively infer a JSON schema from a value.
+
+    - Primitives → type name string
+    - Dicts → {"key": inferred_schema(value), ...}
+    - Arrays → {"type": "array", "items": merged_schema or type_name}
+    """
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return _type_name(obj)
+
+    if isinstance(obj, dict):
+        return {k: _infer_schema(v) for k, v in obj.items()}
+
+    if isinstance(obj, list):
+        if not obj:
+            return {"type": "array", "items": "unknown"}
+
+        # Collect schemas from up to the first 10 items
+        item_schemas = [_infer_schema(item) for item in obj[:10]]
+
+        # If all items are dicts, merge their keys
+        if all(isinstance(s, dict) for s in item_schemas):
+            merged: dict[str, Any] = {}
+            for schema in item_schemas:
+                for key, val in schema.items():  # type: ignore[union-attr]
+                    if key not in merged:
+                        merged[key] = val
+                    # If schemas differ, keep the first one seen
+            return {"type": "array", "items": merged}
+
+        # If all items have the same primitive type, use that
+        unique = set(
+            s if isinstance(s, str) else str(s) for s in item_schemas
+        )
+        if len(unique) == 1:
+            return {"type": "array", "items": item_schemas[0]}
+
+        return {"type": "array", "items": "mixed"}
+
+    return "unknown"
+
+
+def _merge_schemas(a: Any, b: Any) -> Any:
+    """Merge two inferred schemas, preferring the first on conflict."""
+    if isinstance(a, dict) and isinstance(b, dict):
+        merged = dict(a)
+        for key, val in b.items():
+            if key not in merged:
+                merged[key] = val
+            else:
+                merged[key] = _merge_schemas(merged[key], val)
+        return merged
+    if a == b:
+        return a
+    if a == "unknown":
+        return b
+    if b == "unknown":
+        return a
+    return a  # keep first on type conflict
+
+
+def _load_jsonl(file_path: str) -> list[Any]:
+    """Load all records from a JSONL file (one JSON value per line)."""
+    records: list[Any] = []
+    with open(file_path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def extract_json(file_path: str) -> dict[str, Any]:
+    """
+    Extract schema, record count, and sample records from a JSON or JSONL file.
+
+    Handles:
+    - Single JSON object  {}
+    - JSON array          [{}, {}]
+    - JSONL               one JSON value per line
+
+    Args:
+        file_path: Absolute path to the JSON or JSONL file.
+
+    Returns:
+        {
+            "schema": {...},        # inferred JSON schema
+            "record_count": int,    # 1 for object, N for array/JSONL
+            "sample_records": [...]  # first 5 records
+        }
+    """
+    ext = Path(file_path).suffix.lower()
+
+    # JSONL: explicit extension or fallback if regular JSON parse fails
+    if ext == ".jsonl":
+        records = _load_jsonl(file_path)
+        schema: Any = {}
+        for record in records[:100]:
+            schema = _merge_schemas(schema, _infer_schema(record))
+        return {
+            "schema": schema,
+            "record_count": len(records),
+            "sample_records": records[:5],
+        }
+
+    # Try regular JSON first
+    with open(file_path, encoding="utf-8", errors="replace") as fh:
+        raw = fh.read()
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Fall back to JSONL parsing
+        records = []
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if stripped:
+                try:
+                    records.append(json.loads(stripped))
+                except json.JSONDecodeError:
+                    pass
+        schema = {}
+        for record in records[:100]:
+            schema = _merge_schemas(schema, _infer_schema(record))
+        return {
+            "schema": schema,
+            "record_count": len(records),
+            "sample_records": records[:5],
+        }
+
+    # JSON array
+    if isinstance(data, list):
+        schema = {}
+        for record in data[:100]:
+            schema = _merge_schemas(schema, _infer_schema(record))
+        return {
+            "schema": schema,
+            "record_count": len(data),
+            "sample_records": data[:5],
+        }
+
+    # Single JSON object (or any other scalar)
+    return {
+        "schema": _infer_schema(data),
+        "record_count": 1,
+        "sample_records": [data],
+    }

--- a/knowledge-graph-builder/app/services/md_extractor.py
+++ b/knowledge-graph-builder/app/services/md_extractor.py
@@ -1,0 +1,114 @@
+"""
+Markdown structured extraction service.
+
+Parses Markdown heading structure using Python stdlib (re, pathlib).
+No external markdown library required.
+
+Produces a flat sections list and a parent-child hierarchy tree.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+# Matches ATX-style headings: # Heading, ## Heading, …, ###### Heading
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _build_hierarchy(sections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Build a parent-child hierarchy from a flat list of sections.
+
+    Each entry in the returned list has:
+        {"heading": str, "level": int, "parent": str | None, "children": [str, ...]}
+
+    Children is a list of heading strings (not full nodes) to keep it simple
+    and serialisable.
+    """
+    if not sections:
+        return []
+
+    # Stack holds (level, heading_str) for ancestors
+    stack: list[tuple[int, str]] = []
+    hierarchy: list[dict[str, Any]] = []
+
+    for section in sections:
+        level = section["level"]
+        heading = section["heading"]
+
+        # Pop stack entries that are at the same level or deeper
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+
+        parent = stack[-1][1] if stack else None
+        node: dict[str, Any] = {
+            "heading": heading,
+            "level": level,
+            "parent": parent,
+            "children": [],
+        }
+        hierarchy.append(node)
+        stack.append((level, heading))
+
+    # Fill in children references
+    heading_to_node: dict[str, dict[str, Any]] = {}
+    for node in hierarchy:
+        # Use heading as key; duplicates get overwritten (acceptable heuristic)
+        heading_to_node[node["heading"]] = node
+
+    for node in hierarchy:
+        if node["parent"] is not None:
+            parent_node = heading_to_node.get(node["parent"])
+            if parent_node is not None:
+                parent_node["children"].append(node["heading"])
+
+    return hierarchy
+
+
+def extract_markdown(file_path: str) -> dict[str, Any]:
+    """
+    Extract structure from a Markdown file.
+
+    Args:
+        file_path: Absolute path to the Markdown file.
+
+    Returns:
+        {
+            "title": str,    # first H1 heading, or filename without extension
+            "sections": [
+                {"level": 1-6, "heading": "...", "content": "..."},
+                ...
+            ],
+            "hierarchy": [
+                {"heading": "...", "level": int, "parent": str|None, "children": [str, ...]},
+                ...
+            ]
+        }
+    """
+    with open(file_path, encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+
+    # Find all heading positions
+    matches = list(_HEADING_RE.finditer(text))
+
+    sections: list[dict[str, Any]] = []
+    for i, match in enumerate(matches):
+        level = len(match.group(1))
+        heading = match.group(2).strip()
+
+        # Content: everything from after this heading line until the next heading (or EOF)
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        content = text[start:end].strip()
+
+        sections.append({"level": level, "heading": heading, "content": content})
+
+    # Determine title: first H1 or filename stem
+    title = next(
+        (s["heading"] for s in sections if s["level"] == 1),
+        Path(file_path).stem,
+    )
+
+    hierarchy = _build_hierarchy(sections)
+
+    return {"title": title, "sections": sections, "hierarchy": hierarchy}

--- a/knowledge-graph-builder/app/services/vision_extractor.py
+++ b/knowledge-graph-builder/app/services/vision_extractor.py
@@ -7,6 +7,12 @@ Fallback model: GPT-4o (via OpenAI SDK)
 The extractor returns a structured dict with "entities" and "relationships"
 and also provides a helper to serialise that output as human-readable text
 so it can be fed directly into the existing text-based ingestion pipeline.
+
+Diagram mode (added by TASK-025):
+    When the image is identified as a technical diagram — either through the
+    ``likely_diagram`` flag in metadata (set by pdf_extractor / TASK-024) or
+    through filename heuristics — the extractor switches to a structured prompt
+    that returns nodes + edges instead of entities + relationships.
 """
 
 import base64
@@ -42,6 +48,24 @@ Rules:
 Context: {context}
 """
 
+_DIAGRAM_PROMPT = """\
+This image appears to be a technical diagram (architecture, UML, flowchart, or similar).
+Extract the components and their relationships in this exact JSON structure:
+{
+  "nodes": [{"id": "...", "label": "...", "type": "component|service|database|process|actor|other"}],
+  "edges": [{"from": "...", "to": "...", "label": "...", "type": "connection|data_flow|dependency|inheritance|other"}],
+  "diagram_type": "architecture|uml_class|uml_sequence|flowchart|er|other",
+  "description": "one-sentence summary"
+}
+Only return valid JSON. If you cannot identify structured components, return {"nodes": [], "edges": [], "diagram_type": "other", "description": "..."}.
+"""
+
+# Keywords in filenames that suggest a technical diagram
+_DIAGRAM_FILENAME_KEYWORDS = {"arch", "diagram", "flow", "uml", "schema", "model"}
+
+# File extensions that may carry diagram images (SVG is treated as image/png for API)
+_DIAGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".svg"}
+
 _SUPPORTED_EXTENSIONS = {
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",
@@ -49,6 +73,29 @@ _SUPPORTED_EXTENSIONS = {
     ".webp": "image/webp",
     ".gif": "image/gif",
 }
+
+
+def _is_diagram_mode(
+    image_path: str, metadata: dict[str, Any] | None
+) -> bool:
+    """
+    Return True when diagram-structured extraction should be used.
+
+    Triggers:
+    1. ``metadata["likely_diagram"]`` is True (set by pdf_extractor / TASK-024).
+    2. File extension is in _DIAGRAM_IMAGE_EXTENSIONS AND the filename (stem)
+       contains one of the _DIAGRAM_FILENAME_KEYWORDS.
+    """
+    if metadata and metadata.get("likely_diagram"):
+        return True
+
+    path = Path(image_path)
+    if path.suffix.lower() in _DIAGRAM_IMAGE_EXTENSIONS:
+        stem_lower = path.stem.lower()
+        if any(kw in stem_lower for kw in _DIAGRAM_FILENAME_KEYWORDS):
+            return True
+
+    return False
 
 
 class VisionExtractor:
@@ -63,7 +110,43 @@ class VisionExtractor:
         )
         text = vision_extractor.to_text(result)
         # Feed `text` into the standard ingestion pipeline
+
+    Diagram mode::
+
+        result = vision_extractor.extract(
+            "/tmp/arch_overview.png",
+            metadata={"likely_diagram": True},
+        )
+        # Returns {"nodes": [...], "edges": [...], "diagram_type": "...", "description": "..."}
     """
+
+    def extract(
+        self,
+        image_path: str,
+        context: str = "",
+        model: str = "claude",
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Extract structured information from an image.
+
+        When diagram mode is triggered (via ``metadata["likely_diagram"]`` or
+        filename heuristics), returns a diagram-structured dict with ``nodes``
+        and ``edges``.  Otherwise delegates to ``extract_from_image`` and
+        returns the standard ``{"entities": [...], "relationships": [...]}``.
+
+        Args:
+            image_path: Absolute path to the image.
+            context: Optional domain hint.
+            model: "claude" (default) or "gpt4o".
+            metadata: Optional dict; ``likely_diagram`` key triggers diagram mode.
+
+        Returns:
+            Diagram dict OR standard entities/relationships dict.
+        """
+        if _is_diagram_mode(image_path, metadata):
+            return self._extract_diagram(image_path, model)
+        return self.extract_from_image(image_path, context=context, model=model)
 
     def extract_from_image(
         self,
@@ -133,9 +216,8 @@ class VisionExtractor:
 
     # ── Private helpers ───────────────────────────────────────────────────────
 
-    def _extract_claude(
-        self, image_b64: str, media_type: str, prompt: str
-    ) -> dict[str, Any]:
+    def _call_claude(self, image_b64: str, media_type: str, prompt: str) -> str:
+        """Call Claude vision API and return raw text response."""
         try:
             import anthropic
         except ImportError:
@@ -171,11 +253,10 @@ class VisionExtractor:
                 }
             ],
         )
-        return self._parse(response.content[0].text)
+        return response.content[0].text
 
-    def _extract_gpt4o(
-        self, image_b64: str, media_type: str, prompt: str
-    ) -> dict[str, Any]:
+    def _call_gpt4o(self, image_b64: str, media_type: str, prompt: str) -> str:
+        """Call GPT-4o vision API and return raw text response."""
         try:
             from openai import OpenAI
         except ImportError:
@@ -209,7 +290,17 @@ class VisionExtractor:
                 }
             ],
         )
-        return self._parse(response.choices[0].message.content)
+        return response.choices[0].message.content
+
+    def _extract_claude(
+        self, image_b64: str, media_type: str, prompt: str
+    ) -> dict[str, Any]:
+        return self._parse(self._call_claude(image_b64, media_type, prompt))
+
+    def _extract_gpt4o(
+        self, image_b64: str, media_type: str, prompt: str
+    ) -> dict[str, Any]:
+        return self._parse(self._call_gpt4o(image_b64, media_type, prompt))
 
     @staticmethod
     def _to_base64(image_path: str) -> str:
@@ -222,13 +313,19 @@ class VisionExtractor:
         return _SUPPORTED_EXTENSIONS.get(suffix, "image/png")
 
     @staticmethod
-    def _parse(text: str) -> dict[str, Any]:
-        """Parse JSON from LLM response, stripping markdown fences if present."""
+    def _strip_fences(text: str) -> str:
+        """Strip markdown code fences from an LLM response."""
         stripped = text.strip()
         if stripped.startswith("```"):
             lines = stripped.split("\n")
             inner = lines[1:-1] if stripped.endswith("```") else lines[1:]
             stripped = "\n".join(inner)
+        return stripped
+
+    @staticmethod
+    def _parse(text: str) -> dict[str, Any]:
+        """Parse JSON from LLM response, stripping markdown fences if present."""
+        stripped = VisionExtractor._strip_fences(text)
         try:
             data = json.loads(stripped)
             return {
@@ -241,6 +338,43 @@ class VisionExtractor:
                 f"Response (first 500 chars): {stripped[:500]}"
             )
             return {"entities": [], "relationships": []}
+
+    def _extract_diagram(
+        self,
+        image_path: str,
+        model: str = "claude",
+    ) -> dict[str, Any]:
+        """
+        Run diagram-specific structured extraction.
+
+        Returns a dict with ``nodes``, ``edges``, ``diagram_type``,
+        and ``description``.
+        """
+        image_b64 = self._to_base64(image_path)
+        media_type = self._media_type(image_path)
+        prompt = _DIAGRAM_PROMPT
+
+        if model == "gpt4o":
+            raw_text = self._call_gpt4o(image_b64, media_type, prompt)
+        else:
+            raw_text = self._call_claude(image_b64, media_type, prompt)
+
+        stripped = self._strip_fences(raw_text)
+        try:
+            data = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            logger.error(
+                f"Failed to parse diagram response as JSON: {exc}\n"
+                f"Response (first 500 chars): {stripped[:500]}"
+            )
+            data = {}
+
+        return {
+            "nodes": data.get("nodes", []),
+            "edges": data.get("edges", []),
+            "diagram_type": data.get("diagram_type", "other"),
+            "description": data.get("description", ""),
+        }
 
 
 vision_extractor = VisionExtractor()

--- a/knowledge-graph-builder/tests/unit/test_csv_extractor.py
+++ b/knowledge-graph-builder/tests/unit/test_csv_extractor.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for csv_extractor.py
+
+Covers:
+- 5-column / 100-row CSV: schema inference, sample_rows, row_count
+- TSV auto-detection via csv.Sniffer
+- Type inference: int, float, bool, date, str
+- Empty values handled gracefully
+"""
+
+import csv
+import io
+import os
+import tempfile
+
+import pytest
+
+from app.services.csv_extractor import _infer_type, extract_csv
+
+
+# ─── _infer_type unit tests ───────────────────────────────────────────────────
+
+
+class TestInferType:
+    @pytest.mark.unit
+    def test_infers_int(self):
+        assert _infer_type(["1", "2", "3", "100"]) == "int"
+
+    @pytest.mark.unit
+    def test_infers_float(self):
+        assert _infer_type(["1.5", "2.0", "3.14"]) == "float"
+
+    @pytest.mark.unit
+    def test_infers_bool(self):
+        assert _infer_type(["true", "false", "True", "False"]) == "bool"
+
+    @pytest.mark.unit
+    def test_infers_bool_yes_no(self):
+        assert _infer_type(["yes", "no"]) == "bool"
+
+    @pytest.mark.unit
+    def test_infers_date(self):
+        assert _infer_type(["2024-01-01", "2025-06-15"]) == "date"
+
+    @pytest.mark.unit
+    def test_infers_str(self):
+        assert _infer_type(["hello", "world", "foo"]) == "str"
+
+    @pytest.mark.unit
+    def test_empty_values_return_str(self):
+        assert _infer_type(["", "", ""]) == "str"
+
+    @pytest.mark.unit
+    def test_mixed_int_str_returns_str(self):
+        assert _infer_type(["1", "two", "3"]) == "str"
+
+
+# ─── extract_csv unit tests ───────────────────────────────────────────────────
+
+
+def _write_csv(rows: list[list[str]], delimiter: str = ",") -> str:
+    """Write rows to a temp file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    with os.fdopen(fd, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh, delimiter=delimiter)
+        for row in rows:
+            writer.writerow(row)
+    return path
+
+
+class TestExtractCSVBasic:
+    @pytest.mark.unit
+    def test_5_columns_100_rows(self):
+        header = ["id", "name", "score", "active", "joined"]
+        rows = [header]
+        for i in range(100):
+            rows.append(
+                [
+                    str(i),
+                    f"user_{i}",
+                    str(float(i) * 1.5),
+                    "true",
+                    f"2024-{(i % 12) + 1:02d}-01",
+                ]
+            )
+
+        path = _write_csv(rows)
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+
+        assert result["columns"] == header
+        assert result["row_count"] == 100
+        assert len(result["sample_rows"]) == 5
+        assert result["sample_rows"][0]["id"] == "0"
+
+        schema = result["schema"]
+        assert schema["id"] == "int"
+        assert schema["name"] == "str"
+        assert schema["score"] == "float"
+        assert schema["active"] == "bool"
+        assert schema["joined"] == "date"
+
+    @pytest.mark.unit
+    def test_sample_rows_capped_at_5(self):
+        header = ["x"]
+        rows = [header] + [[str(i)] for i in range(50)]
+        path = _write_csv(rows)
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+        assert len(result["sample_rows"]) == 5
+
+    @pytest.mark.unit
+    def test_row_count_is_accurate(self):
+        header = ["a", "b"]
+        rows = [header] + [["1", "2"]] * 37
+        path = _write_csv(rows)
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+        assert result["row_count"] == 37
+
+    @pytest.mark.unit
+    def test_sample_rows_are_dicts(self):
+        header = ["col1", "col2"]
+        rows = [header, ["hello", "world"]]
+        path = _write_csv(rows)
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+        assert isinstance(result["sample_rows"][0], dict)
+        assert result["sample_rows"][0]["col1"] == "hello"
+
+    @pytest.mark.unit
+    def test_schema_keys_match_columns(self):
+        header = ["alpha", "beta", "gamma"]
+        rows = [header, ["foo", "1", "3.14"]]
+        path = _write_csv(rows)
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+        assert set(result["schema"].keys()) == set(header)
+
+
+class TestExtractCSVTSV:
+    @pytest.mark.unit
+    def test_tsv_auto_detection(self):
+        """TSV file with .csv extension should be auto-detected by Sniffer."""
+        header = ["col_a", "col_b", "col_c"]
+        rows = [header, ["1", "hello", "3.14"], ["2", "world", "2.71"]]
+
+        fd, path = tempfile.mkstemp(suffix=".csv")
+        with os.fdopen(fd, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            for row in rows:
+                writer.writerow(row)
+
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+
+        assert result["columns"] == header
+        assert result["row_count"] == 2
+
+    @pytest.mark.unit
+    def test_explicit_tsv_extension(self):
+        """File with .tsv extension is always parsed as tab-delimited."""
+        header = ["x", "y"]
+        rows = [header, ["10", "20"]]
+
+        fd, path = tempfile.mkstemp(suffix=".tsv")
+        with os.fdopen(fd, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            for row in rows:
+                writer.writerow(row)
+
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+
+        assert result["columns"] == header
+        assert result["row_count"] == 1
+        assert result["schema"]["x"] == "int"
+        assert result["schema"]["y"] == "int"
+
+
+class TestExtractCSVEdgeCases:
+    @pytest.mark.unit
+    def test_empty_values_in_column_treated_as_str(self):
+        header = ["val"]
+        rows = [header] + [[""], [""]] + [["hello"]]
+        path = _write_csv(rows)
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+        assert result["schema"]["val"] == "str"
+
+    @pytest.mark.unit
+    def test_single_row(self):
+        header = ["n"]
+        rows = [header, ["42"]]
+        path = _write_csv(rows)
+        try:
+            result = extract_csv(path)
+        finally:
+            os.unlink(path)
+        assert result["row_count"] == 1
+        assert result["schema"]["n"] == "int"

--- a/knowledge-graph-builder/tests/unit/test_diagram_extraction.py
+++ b/knowledge-graph-builder/tests/unit/test_diagram_extraction.py
@@ -1,0 +1,258 @@
+"""
+Unit tests for VisionExtractor diagram mode (TASK-025).
+
+Covers:
+- Diagram mode triggers when metadata has likely_diagram: True
+- Diagram mode triggers from filename heuristics (arch, diagram, flow, uml, schema, model)
+- Diagram mode does NOT trigger for regular images
+- _is_diagram_mode() logic
+- extract() routes to diagram mode vs standard mode
+- Diagram extraction returns dict with nodes/edges keys
+- Non-diagram path returns entities/relationships dict
+"""
+
+import json
+import tempfile
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.vision_extractor import VisionExtractor, _is_diagram_mode
+
+
+# ─── _is_diagram_mode logic ───────────────────────────────────────────────────
+
+
+class TestIsDiagramMode:
+    @pytest.mark.unit
+    def test_likely_diagram_true_in_metadata(self):
+        assert _is_diagram_mode("/tmp/random.png", {"likely_diagram": True}) is True
+
+    @pytest.mark.unit
+    def test_likely_diagram_false_in_metadata(self):
+        assert _is_diagram_mode("/tmp/random.png", {"likely_diagram": False}) is False
+
+    @pytest.mark.unit
+    def test_no_metadata_no_keyword_is_false(self):
+        assert _is_diagram_mode("/tmp/photo.png", None) is False
+
+    @pytest.mark.unit
+    def test_empty_metadata_no_keyword_is_false(self):
+        assert _is_diagram_mode("/tmp/photo.png", {}) is False
+
+    @pytest.mark.unit
+    def test_filename_with_arch_keyword(self):
+        assert _is_diagram_mode("/tmp/system_arch.png", None) is True
+
+    @pytest.mark.unit
+    def test_filename_with_diagram_keyword(self):
+        assert _is_diagram_mode("/tmp/network_diagram.png", None) is True
+
+    @pytest.mark.unit
+    def test_filename_with_flow_keyword(self):
+        assert _is_diagram_mode("/tmp/auth_flow.png", None) is True
+
+    @pytest.mark.unit
+    def test_filename_with_uml_keyword(self):
+        assert _is_diagram_mode("/tmp/class_uml.jpg", None) is True
+
+    @pytest.mark.unit
+    def test_filename_with_schema_keyword(self):
+        assert _is_diagram_mode("/tmp/db_schema.png", None) is True
+
+    @pytest.mark.unit
+    def test_filename_with_model_keyword(self):
+        assert _is_diagram_mode("/tmp/data_model.svg", None) is True
+
+    @pytest.mark.unit
+    def test_filename_with_no_keyword_is_false(self):
+        assert _is_diagram_mode("/tmp/screenshot.png", None) is False
+
+    @pytest.mark.unit
+    def test_non_image_extension_with_keyword_is_false(self):
+        # .txt extension is not in _DIAGRAM_IMAGE_EXTENSIONS
+        assert _is_diagram_mode("/tmp/arch_notes.txt", None) is False
+
+    @pytest.mark.unit
+    def test_likely_diagram_true_overrides_filename(self):
+        # Even a non-keyword filename triggers if likely_diagram is set
+        assert _is_diagram_mode("/tmp/photo.png", {"likely_diagram": True}) is True
+
+    @pytest.mark.unit
+    def test_svg_extension_with_keyword(self):
+        assert _is_diagram_mode("/tmp/component_diagram.svg", None) is True
+
+
+# ─── VisionExtractor.extract() routing ───────────────────────────────────────
+
+
+class TestVisionExtractorExtractRouting:
+    """Tests that extract() routes to diagram or standard mode correctly."""
+
+    def _make_png(self) -> str:
+        """Create a minimal PNG temp file."""
+        fd, path = tempfile.mkstemp(suffix=".png")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+        return path
+
+    @pytest.mark.unit
+    def test_extract_with_likely_diagram_returns_nodes_edges(self):
+        """When likely_diagram is True, extract() returns diagram structure."""
+        extractor = VisionExtractor()
+        path = self._make_png()
+
+        diagram_response = json.dumps({
+            "nodes": [{"id": "svc1", "label": "Service A", "type": "service"}],
+            "edges": [{"from": "svc1", "to": "db1", "label": "reads", "type": "data_flow"}],
+            "diagram_type": "architecture",
+            "description": "A simple service architecture.",
+        })
+
+        try:
+            with (
+                patch("app.services.vision_extractor.settings") as mock_settings,
+                patch("anthropic.Anthropic") as mock_anthropic_cls,
+            ):
+                mock_settings.ANTHROPIC_API_KEY = "test-key"
+                mock_client = MagicMock()
+                mock_anthropic_cls.return_value = mock_client
+                mock_client.messages.create.return_value = MagicMock(
+                    content=[MagicMock(text=diagram_response)]
+                )
+
+                result = extractor.extract(path, metadata={"likely_diagram": True})
+        finally:
+            os.unlink(path)
+
+        assert "nodes" in result
+        assert "edges" in result
+        assert "diagram_type" in result
+        assert result["diagram_type"] == "architecture"
+        assert len(result["nodes"]) == 1
+
+    @pytest.mark.unit
+    def test_extract_without_diagram_flag_returns_entities_relationships(self):
+        """Non-diagram image returns standard entities/relationships."""
+        extractor = VisionExtractor()
+        path = self._make_png()
+
+        standard_response = json.dumps({
+            "entities": [{"name": "Alice", "type": "Person", "description": ""}],
+            "relationships": [],
+        })
+
+        try:
+            with (
+                patch("app.services.vision_extractor.settings") as mock_settings,
+                patch("anthropic.Anthropic") as mock_anthropic_cls,
+            ):
+                mock_settings.ANTHROPIC_API_KEY = "test-key"
+                mock_client = MagicMock()
+                mock_anthropic_cls.return_value = mock_client
+                mock_client.messages.create.return_value = MagicMock(
+                    content=[MagicMock(text=standard_response)]
+                )
+
+                result = extractor.extract(path, metadata={"likely_diagram": False})
+        finally:
+            os.unlink(path)
+
+        assert "entities" in result
+        assert "relationships" in result
+        assert "nodes" not in result
+
+    @pytest.mark.unit
+    def test_extract_filename_heuristic_triggers_diagram_mode(self):
+        """PNG named *_arch.png should trigger diagram mode."""
+        extractor = VisionExtractor()
+        fd, path = tempfile.mkstemp(prefix="system_arch_", suffix=".png")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+
+        diagram_response = json.dumps({
+            "nodes": [],
+            "edges": [],
+            "diagram_type": "other",
+            "description": "Empty diagram.",
+        })
+
+        try:
+            with (
+                patch("app.services.vision_extractor.settings") as mock_settings,
+                patch("anthropic.Anthropic") as mock_anthropic_cls,
+            ):
+                mock_settings.ANTHROPIC_API_KEY = "test-key"
+                mock_client = MagicMock()
+                mock_anthropic_cls.return_value = mock_client
+                mock_client.messages.create.return_value = MagicMock(
+                    content=[MagicMock(text=diagram_response)]
+                )
+
+                result = extractor.extract(path, metadata=None)
+        finally:
+            os.unlink(path)
+
+        assert "nodes" in result
+        assert "edges" in result
+
+    @pytest.mark.unit
+    def test_diagram_extraction_with_bad_json_returns_empty_diagram(self):
+        """If LLM returns non-JSON, extract() returns empty nodes/edges gracefully."""
+        extractor = VisionExtractor()
+        fd, path = tempfile.mkstemp(prefix="arch_", suffix=".png")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+
+        try:
+            with (
+                patch("app.services.vision_extractor.settings") as mock_settings,
+                patch("anthropic.Anthropic") as mock_anthropic_cls,
+            ):
+                mock_settings.ANTHROPIC_API_KEY = "test-key"
+                mock_client = MagicMock()
+                mock_anthropic_cls.return_value = mock_client
+                mock_client.messages.create.return_value = MagicMock(
+                    content=[MagicMock(text="I cannot extract a diagram from this.")]
+                )
+
+                result = extractor.extract(path, metadata={"likely_diagram": True})
+        finally:
+            os.unlink(path)
+
+        assert result["nodes"] == []
+        assert result["edges"] == []
+        assert result["diagram_type"] == "other"
+
+    @pytest.mark.unit
+    def test_extract_no_metadata_no_keyword_uses_standard_mode(self):
+        """A generic image filename without any keywords uses standard entity mode."""
+        extractor = VisionExtractor()
+        fd, path = tempfile.mkstemp(prefix="photo_", suffix=".png")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+
+        standard_response = json.dumps({
+            "entities": [],
+            "relationships": [],
+        })
+
+        try:
+            with (
+                patch("app.services.vision_extractor.settings") as mock_settings,
+                patch("anthropic.Anthropic") as mock_anthropic_cls,
+            ):
+                mock_settings.ANTHROPIC_API_KEY = "test-key"
+                mock_client = MagicMock()
+                mock_anthropic_cls.return_value = mock_client
+                mock_client.messages.create.return_value = MagicMock(
+                    content=[MagicMock(text=standard_response)]
+                )
+
+                result = extractor.extract(path, metadata=None)
+        finally:
+            os.unlink(path)
+
+        assert "entities" in result
+        assert "relationships" in result

--- a/knowledge-graph-builder/tests/unit/test_json_extractor.py
+++ b/knowledge-graph-builder/tests/unit/test_json_extractor.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for json_extractor.py
+
+Covers:
+- Single JSON object  {}
+- JSON array          [{}, {}]
+- JSONL               one JSON value per line
+- Schema inference with nested objects
+- record_count correctness
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from app.services.json_extractor import _infer_schema, extract_json
+
+
+# ─── _infer_schema unit tests ─────────────────────────────────────────────────
+
+
+class TestInferSchema:
+    @pytest.mark.unit
+    def test_string_returns_string(self):
+        assert _infer_schema("hello") == "string"
+
+    @pytest.mark.unit
+    def test_int_returns_integer(self):
+        assert _infer_schema(42) == "integer"
+
+    @pytest.mark.unit
+    def test_float_returns_number(self):
+        assert _infer_schema(3.14) == "number"
+
+    @pytest.mark.unit
+    def test_bool_returns_boolean(self):
+        assert _infer_schema(True) == "boolean"
+
+    @pytest.mark.unit
+    def test_none_returns_null(self):
+        assert _infer_schema(None) == "null"
+
+    @pytest.mark.unit
+    def test_dict_recurses(self):
+        schema = _infer_schema({"name": "Alice", "age": 30})
+        assert schema == {"name": "string", "age": "integer"}
+
+    @pytest.mark.unit
+    def test_nested_dict(self):
+        schema = _infer_schema({"user": {"id": 1, "email": "a@b.com"}})
+        assert schema == {"user": {"id": "integer", "email": "string"}}
+
+    @pytest.mark.unit
+    def test_empty_list(self):
+        schema = _infer_schema([])
+        assert schema == {"type": "array", "items": "unknown"}
+
+    @pytest.mark.unit
+    def test_homogeneous_int_list(self):
+        schema = _infer_schema([1, 2, 3])
+        assert schema == {"type": "array", "items": "integer"}
+
+    @pytest.mark.unit
+    def test_list_of_dicts(self):
+        schema = _infer_schema([{"id": 1}, {"id": 2}])
+        assert schema["type"] == "array"
+        assert schema["items"] == {"id": "integer"}
+
+
+# ─── extract_json: single object ─────────────────────────────────────────────
+
+
+class TestExtractJSONObject:
+    def _write(self, data, suffix=".json") -> str:
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+        return path
+
+    @pytest.mark.unit
+    def test_single_object_record_count_is_1(self):
+        path = self._write({"name": "Alice", "age": 30})
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["record_count"] == 1
+
+    @pytest.mark.unit
+    def test_single_object_sample_records_contains_object(self):
+        obj = {"name": "Alice", "age": 30}
+        path = self._write(obj)
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["sample_records"] == [obj]
+
+    @pytest.mark.unit
+    def test_single_object_schema(self):
+        path = self._write({"x": 1, "y": "hello"})
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["schema"] == {"x": "integer", "y": "string"}
+
+
+# ─── extract_json: array ──────────────────────────────────────────────────────
+
+
+class TestExtractJSONArray:
+    def _write(self, data, suffix=".json") -> str:
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+        return path
+
+    @pytest.mark.unit
+    def test_array_record_count(self):
+        data = [{"id": i} for i in range(20)]
+        path = self._write(data)
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["record_count"] == 20
+
+    @pytest.mark.unit
+    def test_array_sample_records_capped_at_5(self):
+        data = [{"id": i} for i in range(100)]
+        path = self._write(data)
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert len(result["sample_records"]) == 5
+        assert result["sample_records"][0] == {"id": 0}
+
+    @pytest.mark.unit
+    def test_array_schema_inferred(self):
+        data = [{"name": "Alice", "score": 95.5}, {"name": "Bob", "score": 88.0}]
+        path = self._write(data)
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["schema"]["name"] == "string"
+        assert result["schema"]["score"] == "number"
+
+    @pytest.mark.unit
+    def test_empty_array(self):
+        path = self._write([])
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["record_count"] == 0
+        assert result["sample_records"] == []
+
+
+# ─── extract_json: JSONL ──────────────────────────────────────────────────────
+
+
+class TestExtractJSONL:
+    def _write_jsonl(self, records: list, suffix=".jsonl") -> str:
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            for rec in records:
+                fh.write(json.dumps(rec) + "\n")
+        return path
+
+    @pytest.mark.unit
+    def test_jsonl_record_count(self):
+        records = [{"id": i, "val": f"v{i}"} for i in range(30)]
+        path = self._write_jsonl(records)
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["record_count"] == 30
+
+    @pytest.mark.unit
+    def test_jsonl_sample_records(self):
+        records = [{"id": i} for i in range(10)]
+        path = self._write_jsonl(records)
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["sample_records"] == records[:5]
+
+    @pytest.mark.unit
+    def test_jsonl_schema_merged(self):
+        records = [{"x": 1}, {"x": 2, "y": "hello"}]
+        path = self._write_jsonl(records)
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        # x is present in all; y added from second record
+        assert "x" in result["schema"]
+        assert "y" in result["schema"]
+
+    @pytest.mark.unit
+    def test_jsonl_blank_lines_ignored(self):
+        fd, path = tempfile.mkstemp(suffix=".jsonl")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write('{"id": 1}\n\n{"id": 2}\n')
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["record_count"] == 2
+
+    @pytest.mark.unit
+    def test_json_file_with_jsonl_content_fallback(self):
+        """A .json file containing JSONL is parsed via fallback."""
+        fd, path = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write('{"a": 1}\n{"a": 2}\n')
+        try:
+            result = extract_json(path)
+        finally:
+            os.unlink(path)
+        assert result["record_count"] == 2

--- a/knowledge-graph-builder/tests/unit/test_md_extractor.py
+++ b/knowledge-graph-builder/tests/unit/test_md_extractor.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for md_extractor.py
+
+Covers:
+- Heading hierarchy extraction
+- Title detection (first H1 or filename)
+- Section content extraction
+- Parent-child hierarchy building
+- Nested headings
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from app.services.md_extractor import extract_markdown
+
+
+def _write_md(content: str) -> str:
+    """Write content to a temporary .md file and return the path."""
+    fd, path = tempfile.mkstemp(suffix=".md")
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    return path
+
+
+# ─── Title detection ─────────────────────────────────────────────────────────
+
+
+class TestTitleDetection:
+    @pytest.mark.unit
+    def test_first_h1_is_title(self):
+        path = _write_md("# My Document\n\nSome content.\n\n## Section A\n\nText.")
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        assert result["title"] == "My Document"
+
+    @pytest.mark.unit
+    def test_filename_used_when_no_h1(self):
+        path = _write_md("## Only an H2\n\nContent here.\n")
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        # Title falls back to the file's stem (no .md extension)
+        assert result["title"] != ""
+        assert ".md" not in result["title"]
+
+    @pytest.mark.unit
+    def test_first_h1_wins_over_later_h1(self):
+        path = _write_md("# First\n\n# Second\n")
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        assert result["title"] == "First"
+
+
+# ─── Sections extraction ─────────────────────────────────────────────────────
+
+
+class TestSectionsExtraction:
+    @pytest.mark.unit
+    def test_sections_list_populated(self):
+        md = "# Title\n\nIntro.\n\n## Chapter 1\n\nChapter content.\n\n## Chapter 2\n\nMore.\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        assert len(result["sections"]) == 3
+
+    @pytest.mark.unit
+    def test_section_level_correct(self):
+        md = "# H1\n\n## H2\n\n### H3\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        levels = [s["level"] for s in result["sections"]]
+        assert levels == [1, 2, 3]
+
+    @pytest.mark.unit
+    def test_section_heading_correct(self):
+        md = "# Introduction\n\nContent.\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        assert result["sections"][0]["heading"] == "Introduction"
+
+    @pytest.mark.unit
+    def test_section_content_stripped(self):
+        md = "# Title\n\nParagraph one.\n\nParagraph two.\n\n## Next\n\nFoo.\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        # Content under Title should contain the paragraphs
+        assert "Paragraph one" in result["sections"][0]["content"]
+
+    @pytest.mark.unit
+    def test_empty_document_returns_empty_sections(self):
+        path = _write_md("")
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        assert result["sections"] == []
+        assert result["hierarchy"] == []
+
+    @pytest.mark.unit
+    def test_no_headings_returns_empty_sections(self):
+        path = _write_md("Just plain text with no headings.\n")
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        assert result["sections"] == []
+
+
+# ─── Hierarchy building ───────────────────────────────────────────────────────
+
+
+class TestHierarchyBuilding:
+    @pytest.mark.unit
+    def test_top_level_sections_have_no_parent(self):
+        md = "# Alpha\n\n# Beta\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        for node in result["hierarchy"]:
+            assert node["parent"] is None
+
+    @pytest.mark.unit
+    def test_h2_parent_is_h1(self):
+        md = "# Root\n\n## Child\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        hierarchy = result["hierarchy"]
+        child = next(n for n in hierarchy if n["heading"] == "Child")
+        assert child["parent"] == "Root"
+
+    @pytest.mark.unit
+    def test_h3_parent_is_h2(self):
+        md = "# Top\n\n## Middle\n\n### Leaf\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        hierarchy = result["hierarchy"]
+        leaf = next(n for n in hierarchy if n["heading"] == "Leaf")
+        assert leaf["parent"] == "Middle"
+
+    @pytest.mark.unit
+    def test_children_populated(self):
+        md = "# Root\n\n## Child A\n\n## Child B\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        root = next(n for n in result["hierarchy"] if n["heading"] == "Root")
+        assert "Child A" in root["children"]
+        assert "Child B" in root["children"]
+
+    @pytest.mark.unit
+    def test_deep_nesting(self):
+        md = "# L1\n\n## L2\n\n### L3\n\n#### L4\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        hierarchy = result["hierarchy"]
+        assert len(hierarchy) == 4
+        l4 = next(n for n in hierarchy if n["heading"] == "L4")
+        assert l4["parent"] == "L3"
+
+    @pytest.mark.unit
+    def test_sibling_sections_at_h2_same_parent(self):
+        md = "# Parent\n\n## A\n\n## B\n\n## C\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        parent_node = next(n for n in result["hierarchy"] if n["heading"] == "Parent")
+        assert set(parent_node["children"]) == {"A", "B", "C"}
+
+    @pytest.mark.unit
+    def test_hierarchy_all_nodes_present(self):
+        md = "# One\n\n## Two\n\n### Three\n"
+        path = _write_md(md)
+        try:
+            result = extract_markdown(path)
+        finally:
+            os.unlink(path)
+        headings = {n["heading"] for n in result["hierarchy"]}
+        assert headings == {"One", "Two", "Three"}


### PR DESCRIPTION
## Summary

- **csv_extractor.py** (new): stdlib-only CSV/TSV extractor with auto-delimiter detection via `csv.Sniffer`, type inference (bool/int/float/date/str) from first 100 rows, 5-row sample output
- **json_extractor.py** (new): handles single `{}`, `[{}, ...]` array, and JSONL; recursive schema inference with homogeneous array detection; merges schemas across up to 100 records
- **md_extractor.py** (new): ATX heading parser using `re` only; extracts sections with level/heading/content; builds parent-child hierarchy from heading levels
- **vision_extractor.py** (extended): adds `extract()` entry point with `_is_diagram_mode()` check; diagram mode fires when `metadata["likely_diagram"]=True` (from TASK-024 pdf_extractor) OR filename contains `arch/diagram/flow/uml/schema/model` with image extension; uses `_DIAGRAM_PROMPT` to return `nodes/edges/diagram_type/description` instead of entities/relationships
- **document_processor.py** (updated): dispatch for `csv/tsv → extract_csv`, `json/jsonl → extract_json`, `md/markdown → extract_markdown`; PDF pages with `likely_diagram` flag in metadata route to `VisionExtractor.extract()` in diagram mode

## Test plan

- [ ] `python3 -m pytest tests/unit/test_csv_extractor.py -v` — 17 tests (type inference, 100-row schema, TSV detection)
- [ ] `python3 -m pytest tests/unit/test_json_extractor.py -v` — 19 tests (object/array/JSONL, schema merge)
- [ ] `python3 -m pytest tests/unit/test_md_extractor.py -v` — 17 tests (heading hierarchy, title detection)
- [ ] `python3 -m pytest tests/unit/test_diagram_extraction.py -v` — 21 tests (is_diagram_mode logic, routing, bad JSON graceful)
- [ ] All 74 new tests pass (verified locally)
- [ ] All 53 existing multimodal + document_processor tests still pass (verified locally)
- [ ] No new dependencies — stdlib only for CSV/JSON/MD parsing