### PR TITLE
TASK-020: Implement RowTransformer and wire into full_snapshot Celery task

### DIFF
--- a/knowledge-graph-builder/app/services/background_jobs.py
+++ b/knowledge-graph-builder/app/services/background_jobs.py
@@ -1699,6 +1699,7 @@ async def _sync_database_connector_async(
         make_connector,
         write_table_to_kg,
     )
+    from app.services.schema_mapper import SchemaMapper
 
     logger.info(
         f"Starting database connector sync: connector={connector_id} graph={graph_id}"
@@ -1833,35 +1834,106 @@ async def _sync_database_connector_async(
                             logger.warning(f"CDC soft-delete failed for {tname}: {e}")
 
             # ------------------------------------------------------------------
-            # Write each table to Neo4j
+            # SchemaMapper → GraphMappingRules
             # ------------------------------------------------------------------
-            for table in snapshot.tables:
-                sample_rows = []
-                if sync_mode != DbSyncMode.SCHEMA_ONLY:
+            mapper = SchemaMapper()
+            mapping_rules = mapper.map(
+                schema_snapshot=snapshot,
+                connector_id=connector_id,
+                graph_id=graph_id,
+            )
+
+            # Partition table mappings into entity tables and junction/self-ref tables
+            entity_mappings = [
+                tm for tm in mapping_rules.tables if tm.kind == "entity_table"
+            ]
+            junction_mappings = [
+                tm
+                for tm in mapping_rules.tables
+                if tm.kind in ("junction_table", "self_ref_table")
+            ]
+
+            # ------------------------------------------------------------------
+            # Write each table to Neo4j
+            # Full-snapshot path: use RowTransformer for batched UNWIND writes.
+            # Schema-only path: fall through to write_table_to_kg (placeholder nodes).
+            # ------------------------------------------------------------------
+            if sync_mode == DbSyncMode.SCHEMA_ONLY:
+                # Schema-only: create placeholder __Entity__ type nodes (no row data)
+                for table in snapshot.tables:
                     try:
-                        sample_rows = await connector.extract_sample_data(
-                            table.name, config["sample_row_limit"]
+                        count = await write_table_to_kg(
+                            graph_id=graph_id,
+                            connector_id=connector_id,
+                            table=table,
+                            sync_mode=sync_mode,
+                            sample_rows=[],
+                            driver=async_driver,
+                        )
+                        total_entities += count
+                    except Exception as e:
+                        logger.warning(f"Schema-only KG write failed for {table.name}: {e}")
+                        tables_failed.append(table.name)
+            else:
+                from app.services.row_transformer import RowTransformer
+
+                # Use the sync driver for RowTransformer (NullPool — Celery invariant)
+                row_xfm = RowTransformer(neo4j)
+
+                # Step 1: write entity tables first (FK targets must exist before junctions)
+                for tm in entity_mappings:
+                    try:
+                        rows = await connector.fetch_rows(
+                            table_name=tm.table_name,
+                            schema_snapshot=snapshot,
+                            limit=config.get("sample_row_limit", 1000),
+                            offset=0,
+                        )
+                    except Exception as e:
+                        logger.warning(f"Row fetch failed for {tm.table_name}: {e}")
+                        tables_failed.append(tm.table_name)
+                        continue
+                    try:
+                        count = row_xfm.transform_table(
+                            table_mapping=tm,
+                            rows=rows,
+                            graph_id=graph_id,
+                            connector_id=connector_id,
+                        )
+                        total_entities += count
+                    except Exception as e:
+                        logger.warning(f"Entity write failed for {tm.table_name}: {e}")
+                        tables_failed.append(tm.table_name)
+
+                # Step 2: write junction/self-ref tables (entity nodes now exist)
+                rows_by_table: dict[str, list[dict]] = {}
+                for tm in junction_mappings:
+                    try:
+                        rows_by_table[tm.table_name] = await connector.fetch_rows(
+                            table_name=tm.table_name,
+                            schema_snapshot=snapshot,
+                            limit=config.get("sample_row_limit", 1000),
+                            offset=0,
                         )
                     except Exception as e:
                         logger.warning(
-                            f"Sample extraction failed for {table.name}: {e}"
+                            f"Row fetch failed for junction table {tm.table_name}: {e}"
                         )
-                        tables_failed.append(table.name)
-                        continue
+                        tables_failed.append(tm.table_name)
 
-                try:
-                    count = await write_table_to_kg(
-                        graph_id=graph_id,
-                        connector_id=connector_id,
-                        table=table,
-                        sync_mode=sync_mode,
-                        sample_rows=sample_rows,
-                        driver=async_driver,
-                    )
-                    total_entities += count
-                except Exception as e:
-                    logger.warning(f"KG write failed for {table.name}: {e}")
-                    tables_failed.append(table.name)
+                if junction_mappings:
+                    try:
+                        row_xfm.transform_junctions(
+                            junction_mappings=junction_mappings,
+                            rows_by_table=rows_by_table,
+                            graph_id=graph_id,
+                            connector_id=connector_id,
+                        )
+                    except Exception as e:
+                        logger.warning(f"Junction write failed: {e}")
+                        for tm in junction_mappings:
+                            if tm.table_name not in tables_failed:
+                                tables_failed.append(tm.table_name)
 
             # Store snapshot for future CDC runs
             await async_driver.execute_query(

--- a/knowledge-graph-builder/app/services/database_connector_service.py
+++ b/knowledge-graph-builder/app/services/database_connector_service.py
@@ -182,6 +182,42 @@ class DatabaseConnector(ABC):
         """Release DB connection."""
         ...
 
+    async def fetch_rows(
+        self,
+        table_name: str,
+        schema_snapshot: "SchemaSnapshot",
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Return rows from *table_name* as plain dicts.
+
+        Security: table_name MUST be validated against schema_snapshot.tables
+        before use. This default implementation enforces that allowlist check
+        and delegates to _fetch_rows_impl() for the actual query.
+
+        Implementations that need pagination (limit/offset) should override
+        _fetch_rows_impl(); do NOT override this method.
+        """
+        allowed_table_names = {t.name for t in schema_snapshot.tables}
+        if table_name not in allowed_table_names:
+            raise ValueError(
+                f"fetch_rows: table {table_name!r} is not in the SchemaSnapshot allowlist. "
+                "Table names must come from schema introspection, never from user input."
+            )
+        return await self._fetch_rows_impl(table_name, limit, offset)
+
+    async def _fetch_rows_impl(
+        self, table_name: str, limit: int, offset: int
+    ) -> list[dict[str, Any]]:
+        """Internal row-fetch implementation.  Override in concrete connectors.
+
+        Default: raises NotImplementedError — connectors that support row fetching
+        must override this method.  MongoDBConnector is out of scope for TASK-020.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement fetch_rows."
+        )
+
 
 # ---------------------------------------------------------------------------
 # SSRF guard
@@ -356,6 +392,22 @@ class PostgreSQLConnector(DatabaseConnector):
         )
         return [SampleRow(table_name=table, row_data=dict(r)) for r in rows]
 
+    async def _fetch_rows_impl(
+        self, table_name: str, limit: int, offset: int
+    ) -> list[dict[str, Any]]:
+        if not self._conn:
+            raise RuntimeError("Not connected. Call connect() first.")
+        # table_name is already validated against the SchemaSnapshot allowlist by
+        # the base-class fetch_rows() method.  Standard SQL double-quoting prevents
+        # injection from names that contain special characters.  limit/offset are
+        # integers and passed as parameterized $N placeholders.
+        rows = await self._conn.fetch(
+            f'SELECT * FROM "{self._schema}"."{table_name}" LIMIT $1 OFFSET $2',
+            limit,
+            offset,
+        )
+        return [dict(r) for r in rows]
+
     async def detect_schema_changes(
         self, previous_snapshot: SchemaSnapshot
     ) -> dict[str, Any]:
@@ -468,6 +520,25 @@ class MySQLConnector(DatabaseConnector):
             )
             rows = await cur.fetchall()
         return [SampleRow(table_name=table, row_data=dict(r)) for r in rows]
+
+    async def _fetch_rows_impl(
+        self, table_name: str, limit: int, offset: int
+    ) -> list[dict[str, Any]]:
+        if not self._conn:
+            raise RuntimeError("Not connected.")
+        import aiomysql  # type: ignore
+
+        # table_name is already validated against the SchemaSnapshot allowlist by
+        # the base-class fetch_rows() method.  MySQL backtick-quoting prevents
+        # injection from names that contain special characters.  limit/offset are
+        # integers and passed as parameterized %s placeholders.
+        async with self._conn.cursor(aiomysql.DictCursor) as cur:
+            await cur.execute(
+                f"SELECT * FROM `{self._database}`.`{table_name}` LIMIT %s OFFSET %s",
+                (limit, offset),
+            )
+            rows = await cur.fetchall()
+        return [dict(r) for r in rows]
 
     async def detect_schema_changes(
         self, previous_snapshot: SchemaSnapshot

--- a/knowledge-graph-builder/app/services/row_transformer.py
+++ b/knowledge-graph-builder/app/services/row_transformer.py
@@ -1,0 +1,303 @@
+"""Row Transformer Service — convert relational rows to Neo4j graph nodes/edges (TASK-020).
+
+Consumes GraphMappingRules produced by SchemaMapper (TASK-019) and writes:
+- Entity nodes  → __Entity__ nodes via MERGE (entity_table and self_ref_table)
+- Relationships → relationship edges via MERGE (junction_table and self_ref_table)
+
+Architecture invariants:
+- graph_id on EVERY written node and relationship — no cross-tenant writes
+- WorkerNeo4jManager (sync NullPool driver) — NEVER async_driver in Celery tasks
+- Parameterized Cypher only — table names come from SchemaSnapshot allowlist
+- UNWIND batch writes at 500 rows — no per-row round trips
+- Entity tables written BEFORE junction tables (FK targets must exist first)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.core.logging import get_logger
+
+if TYPE_CHECKING:
+    from app.services.background_jobs import WorkerNeo4jManager
+    from app.services.schema_mapper import GraphMappingRules, TableMapping
+
+logger = get_logger(__name__)
+
+_BATCH_SIZE = 500
+
+
+class RowTransformer:
+    """Write entity nodes and relationship edges to Neo4j from relational rows.
+
+    Parameters
+    ----------
+    neo4j_manager:
+        A connected WorkerNeo4jManager instance (sync NullPool driver).
+        Must be used inside a context manager so the driver is available.
+    """
+
+    def __init__(self, neo4j_manager: "WorkerNeo4jManager") -> None:
+        self._manager = neo4j_manager
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def transform_table(
+        self,
+        table_mapping: "TableMapping",
+        rows: list[dict[str, Any]],
+        graph_id: str,
+        connector_id: str,
+    ) -> int:
+        """Write entity nodes for all rows in *table_mapping*.
+
+        Only called for entity_table and self_ref_table kinds.
+        Junction tables are handled by transform_junctions().
+
+        Returns count of rows written.
+        """
+        if not rows:
+            return 0
+
+        driver = self._manager.get_sync_driver()
+        total = 0
+
+        for batch in _chunks(rows, _BATCH_SIZE):
+            batch_params = [
+                _build_entity_row_param(row, table_mapping, graph_id, connector_id)
+                for row in batch
+            ]
+            # Filter out rows where we couldn't determine the PK
+            batch_params = [p for p in batch_params if p is not None]
+            if not batch_params:
+                continue
+
+            with driver.session() as session:
+                session.run(
+                    """
+                    UNWIND $batch AS row
+                    MERGE (e:__Entity__ {id: row.id, graph_id: $graph_id})
+                    SET e += row.properties,
+                        e.source_table   = $table_name,
+                        e.ingestion_time = datetime(),
+                        e.label          = $neo4j_label
+                    """,
+                    {
+                        "batch": batch_params,
+                        "graph_id": graph_id,
+                        "table_name": table_mapping.table_name,
+                        "neo4j_label": table_mapping.neo4j_label,
+                    },
+                )
+            total += len(batch_params)
+
+        logger.info(
+            "row_transformer: wrote %d entity rows for table %r (graph=%r)",
+            total,
+            table_mapping.table_name,
+            graph_id,
+        )
+        return total
+
+    def transform_junctions(
+        self,
+        junction_mappings: list["TableMapping"],
+        rows_by_table: dict[str, list[dict[str, Any]]],
+        graph_id: str,
+        connector_id: str,
+    ) -> int:
+        """Write relationship edges for junction tables and self-ref FK tables.
+
+        Entity nodes for the referenced tables must already exist in Neo4j
+        (call transform_table() for all entity tables first).
+
+        Returns total count of edges written.
+        """
+        total = 0
+        driver = self._manager.get_sync_driver()
+
+        for table_mapping in junction_mappings:
+            rows = rows_by_table.get(table_mapping.table_name, [])
+            if not rows:
+                continue
+
+            for rel_mapping in table_mapping.relationships:
+                rel_type = rel_mapping.rel_type
+                # Validate rel_type is a safe Cypher identifier (letters, digits, underscores only)
+                if not _safe_rel_type(rel_type):
+                    logger.warning(
+                        "row_transformer: unsafe rel_type %r for table %r — skipping",
+                        rel_type,
+                        table_mapping.table_name,
+                    )
+                    continue
+
+                for batch in _chunks(rows, _BATCH_SIZE):
+                    if table_mapping.kind == "junction_table":
+                        batch_params = [
+                            _build_junction_row_param(
+                                row, table_mapping, rel_mapping, graph_id, connector_id
+                            )
+                            for row in batch
+                        ]
+                    else:
+                        # self_ref_table — source and target are the same table
+                        batch_params = [
+                            _build_self_ref_row_param(
+                                row, table_mapping, rel_mapping, graph_id, connector_id
+                            )
+                            for row in batch
+                        ]
+
+                    batch_params = [p for p in batch_params if p is not None]
+                    if not batch_params:
+                        continue
+
+                    cypher = f"""
+                    UNWIND $batch AS row
+                    MATCH (a:__Entity__ {{id: row.from_id, graph_id: $graph_id}})
+                    MATCH (b:__Entity__ {{id: row.to_id, graph_id: $graph_id}})
+                    MERGE (a)-[r:{rel_type} {{graph_id: $graph_id}}]->(b)
+                    SET r.ingestion_time = datetime(),
+                        r.source_table   = $junction_table
+                    """
+                    with driver.session() as session:
+                        session.run(
+                            cypher,
+                            {
+                                "batch": batch_params,
+                                "graph_id": graph_id,
+                                "junction_table": table_mapping.table_name,
+                            },
+                        )
+                    total += len(batch_params)
+
+        logger.info(
+            "row_transformer: wrote %d relationship edges (graph=%r)", total, graph_id
+        )
+        return total
+
+
+# ---------------------------------------------------------------------------
+# Row parameter builders
+# ---------------------------------------------------------------------------
+
+
+def _entity_id(connector_id: str, table_name: str, pk_value: Any) -> str:
+    """Build the deterministic entity id: {connector_id}:{table_name}:{pk_value}."""
+    return f"{connector_id}:{table_name}:{pk_value}"
+
+
+def _build_entity_row_param(
+    row: dict[str, Any],
+    table_mapping: "TableMapping",
+    graph_id: str,
+    connector_id: str,
+) -> dict[str, Any] | None:
+    """Build a single UNWIND parameter dict for an entity row.
+
+    Returns None if the PK value is missing/None (cannot create a unique node).
+    """
+    pk_col = table_mapping.pk_column
+    pk_value = row.get(pk_col)
+    if pk_value is None:
+        return None
+
+    entity_id = _entity_id(connector_id, table_mapping.table_name, pk_value)
+
+    # Property columns: non-PK, non-FK columns mapped to neo4j_property names
+    props: dict[str, Any] = {}
+    for col_mapping in table_mapping.property_columns:
+        raw_value = row.get(col_mapping.column_name)
+        if raw_value is not None:
+            props[col_mapping.neo4j_property] = _coerce_value(raw_value)
+
+    return {"id": entity_id, "properties": props}
+
+
+def _build_junction_row_param(
+    row: dict[str, Any],
+    table_mapping: "TableMapping",
+    rel_mapping: "RelationshipMapping",  # type: ignore[name-defined]
+    graph_id: str,
+    connector_id: str,
+) -> dict[str, Any] | None:
+    """Build a single UNWIND parameter dict for a junction table row.
+
+    from_id is built from the FK column pointing to from_table.
+    to_id   is built from the FK column pointing to to_table.
+    Returns None if either FK value is missing.
+    """
+    from_fk_value = row.get(rel_mapping.from_fk_column)
+    to_fk_value = row.get(rel_mapping.to_fk_column)
+    if from_fk_value is None or to_fk_value is None:
+        return None
+
+    from_id = _entity_id(connector_id, rel_mapping.from_table, from_fk_value)
+    to_id = _entity_id(connector_id, rel_mapping.to_table, to_fk_value)
+
+    return {"from_id": from_id, "to_id": to_id}
+
+
+def _build_self_ref_row_param(
+    row: dict[str, Any],
+    table_mapping: "TableMapping",
+    rel_mapping: "RelationshipMapping",  # type: ignore[name-defined]
+    graph_id: str,
+    connector_id: str,
+) -> dict[str, Any] | None:
+    """Build a single UNWIND parameter dict for a self-referential FK row.
+
+    Source entity = this row's PK (table_mapping.table_name).
+    Target entity = the FK value (also in table_mapping.table_name).
+    Returns None if PK or FK value is missing.
+    """
+    pk_value = row.get(table_mapping.pk_column) if table_mapping.pk_column else None
+    fk_value = row.get(rel_mapping.from_fk_column)
+    if pk_value is None or fk_value is None:
+        return None
+
+    from_id = _entity_id(connector_id, table_mapping.table_name, pk_value)
+    to_id = _entity_id(connector_id, table_mapping.table_name, fk_value)
+
+    return {"from_id": from_id, "to_id": to_id}
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _chunks(lst: list, size: int):
+    """Yield successive fixed-size chunks from lst."""
+    for i in range(0, len(lst), size):
+        yield lst[i : i + size]
+
+
+def _safe_rel_type(rel_type: str) -> bool:
+    """Return True if rel_type is a safe Cypher relationship type identifier."""
+    import re
+
+    return bool(re.match(r"^[A-Z_][A-Z0-9_]*$", rel_type))
+
+
+def _coerce_value(value: Any) -> Any:
+    """Coerce a row value to a Neo4j-compatible type.
+
+    Neo4j driver supports: bool, int, float, str, list, dict, None.
+    Dates and datetimes are serialized to ISO strings.
+    """
+    import datetime
+
+    if isinstance(value, (bool, int, float, str, type(None))):
+        return value
+    if isinstance(value, (datetime.datetime, datetime.date)):
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_coerce_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _coerce_value(v) for k, v in value.items()}
+    # Fallback: stringify
+    return str(value)

--- a/knowledge-graph-builder/app/services/schema_mapper.py
+++ b/knowledge-graph-builder/app/services/schema_mapper.py
@@ -1,0 +1,579 @@
+"""Schema Mapper Service — analyse SchemaSnapshot objects and emit GraphMappingRules.
+
+Consumes the SchemaSnapshot produced by database_connector_service and produces a
+declarative GraphMappingRules spec that tells RowTransformer (TASK-020) exactly how
+to convert rows into graph nodes and edges.
+
+Architecture invariants:
+- graph_id is threaded through every output structure — no cross-tenant objects
+- Pure analysis only — NO Neo4j writes (that is TASK-020's responsibility)
+- One service per functionality — this file is self-contained
+"""
+
+from __future__ import annotations
+
+import re as _re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
+
+from app.core.logging import get_logger
+
+if TYPE_CHECKING:
+    pass
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Audit column names that do NOT count as "real" non-FK columns when
+# deciding if a table qualifies as a junction table.
+# ---------------------------------------------------------------------------
+_AUDIT_COLUMN_NAMES: frozenset[str] = frozenset(
+    {
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "created_by",
+        "updated_by",
+        "modified_at",
+        "modified_by",
+        "id",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Output dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ColumnMapping:
+    """Maps a source column to its Neo4j property name."""
+
+    column_name: str
+    neo4j_property: str  # camelCase of column_name
+
+
+@dataclass
+class RelationshipMapping:
+    """Describes one relationship edge to be created in Neo4j."""
+
+    from_table: str
+    to_table: str
+    rel_type: str  # e.g. WORKS_ON
+    from_fk_column: str
+    to_fk_column: str  # PK column on the target table
+    via_junction: str | None  # junction table name if applicable
+
+
+@dataclass
+class TableMapping:
+    """Full mapping specification for one source table."""
+
+    table_name: str
+    kind: Literal["entity_table", "junction_table", "self_ref_table"]
+    neo4j_label: str  # PascalCase of table_name
+    pk_column: str
+    property_columns: list[ColumnMapping]
+    relationships: list[RelationshipMapping]
+
+
+@dataclass
+class GraphMappingRules:
+    """Top-level container — the output of SchemaMapper.map()."""
+
+    connector_id: str
+    graph_id: str  # tenant isolation — present on every output structure
+    tables: list[TableMapping]
+    generated_at: str  # ISO timestamp
+
+
+# ---------------------------------------------------------------------------
+# Naming utilities
+# ---------------------------------------------------------------------------
+
+
+def _to_camel_case(name: str) -> str:
+    """Convert snake_case (or any underscore-separated) name to camelCase.
+
+    Examples:
+        user_name       → userName
+        department_id   → departmentId
+        created_at      → createdAt
+        id              → id
+    """
+    parts = name.replace("-", "_").split("_")
+    if not parts:
+        return name
+    return parts[0] + "".join(word.capitalize() for word in parts[1:])
+
+
+def _to_pascal_case(name: str) -> str:
+    """Convert snake_case table name to PascalCase Neo4j label.
+
+    Examples:
+        employee        → Employee
+        employee_project → EmployeeProject
+        t_emp_proj      → TEmpProj
+    """
+    return "".join(word.capitalize() for word in name.replace("-", "_").split("_"))
+
+
+def _validate_rel_type(rel_type: str) -> str:
+    """Ensure rel_type is a valid Neo4j relationship type identifier.
+
+    Raises ValueError if the derived type would produce unsafe Cypher.
+    All rel types used in Cypher are derived from schema introspection (never
+    direct user input) and validated here before any interpolation.
+    """
+    if not _re.match(r"^[A-Z_][A-Z0-9_]*$", rel_type):
+        raise ValueError(
+            f"Derived relationship type is not a valid Cypher identifier: {rel_type!r}"
+        )
+    return rel_type
+
+
+# ---------------------------------------------------------------------------
+# Relationship type derivation rules
+# ---------------------------------------------------------------------------
+
+# Self-referential FK patterns: column name → (outgoing rel, incoming rel)
+# We use the outgoing direction (parent → child or manager → report).
+_SELF_REF_PATTERNS: dict[str, str] = {
+    "parent_id": "HAS_CHILD",
+    "manager_id": "MANAGES",
+    "supervisor_id": "SUPERVISES",
+    "reports_to": "MANAGES",
+    "parent": "HAS_CHILD",
+}
+
+
+def _rel_type_for_fk(
+    fk_column: str,
+    fk_table: str,
+    source_table: str,
+) -> str:
+    """Derive a relationship type string from an FK column + its target table.
+
+    Strategy (in priority order):
+    1. Self-referential FK → use _SELF_REF_PATTERNS or fall back to REFERENCES_SELF
+    2. Suffix stripping: column ends with _id or _ref → strip it, use the bare word
+       e.g. department_id → BELONGS_TO_DEPARTMENT (but we simplify to BELONGS_TO)
+    3. Default: BELONGS_TO (generic FK relationship)
+    """
+    col_lower = fk_column.lower()
+    tbl_lower = fk_table.lower()
+
+    # Self-referential
+    if fk_table == source_table:
+        # Exact match against known self-ref column name patterns
+        if col_lower in _SELF_REF_PATTERNS:
+            return _SELF_REF_PATTERNS[col_lower]
+        return "REFERENCES_SELF"
+
+    # Column name encodes semantic (e.g. manager_id on employee → MANAGED_BY)
+    # Strip _id / _fk / _ref suffix to get the semantic word
+    bare = _re.sub(r"_(id|fk|ref|key)$", "", col_lower)
+    target_bare = _re.sub(r"s$", "", tbl_lower)  # naïve singularize
+
+    if bare == target_bare or bare == tbl_lower:
+        # Column name matches table name → generic BELONGS_TO
+        return "BELONGS_TO"
+
+    # If bare is something meaningful and different from the table name,
+    # build: BELONGS_TO_<TABLE_UPPER>
+    target_upper = _to_pascal_case(fk_table).upper()
+    rel = f"BELONGS_TO"
+    return rel
+
+
+def _junction_rel_type_from_name(table_name: str, from_table: str, to_table: str) -> str | None:
+    """Try to extract a verb from a junction table name.
+
+    Returns an UPPER_SNAKE_CASE string if the name contains a recognisable verb,
+    otherwise returns None (caller should invoke LLM).
+
+    Heuristic: strip the two referenced table names (and common prefixes like
+    t_, rel_, jn_, jt_) from the junction table name; if anything remains and
+    it looks like a real word (≥3 chars, all alpha), use it as the verb.
+    """
+    name_clean = table_name.lower()
+
+    # Strip common junction table prefixes
+    for prefix in ("t_", "rel_", "jn_", "jt_", "map_", "link_", "xref_", "assoc_"):
+        if name_clean.startswith(prefix):
+            name_clean = name_clean[len(prefix):]
+
+    # Strip the two referenced table names from the junction name
+    for ref in (from_table.lower(), to_table.lower()):
+        name_clean = name_clean.replace(ref, "").strip("_")
+
+    # Whatever is left — if it looks like a word, turn it into a rel type
+    word = name_clean.strip("_")
+    if word and len(word) >= 3 and word.isalpha():
+        return word.upper()
+
+    return None  # ambiguous — caller must use LLM
+
+
+def _call_llm_for_rel_type(table_name: str, from_table: str, to_table: str) -> str:
+    """Synchronous LLM call to name an ambiguous junction table relationship.
+
+    Uses the OpenAI sync client.  Called at most once per ambiguous junction table.
+    Falls back to ASSOCIATED_WITH if the API key is absent or the call fails.
+    """
+    try:
+        from openai import OpenAI  # type: ignore
+
+        from app.core.config import settings
+
+        api_key = getattr(settings, "OPENAI_API_KEY", None)
+        if not api_key:
+            logger.warning(
+                "schema_mapper: OPENAI_API_KEY not set — using fallback rel type for %r",
+                table_name,
+            )
+            return "ASSOCIATED_WITH"
+
+        prompt = (
+            f"Table `{table_name}` is a junction table that joins `{from_table}` "
+            f"and `{to_table}`. "
+            f"Suggest a concise uppercase verb relationship type (e.g. WORKS_ON, ASSIGNED_TO, ENROLLED_IN). "
+            f"Reply with ONLY the relationship type string, nothing else."
+        )
+
+        client = OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a graph schema expert. "
+                        "Output only a valid Neo4j relationship type: ALL_CAPS_SNAKE_CASE."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.0,
+            max_tokens=20,
+        )
+        raw = (response.choices[0].message.content or "").strip().upper()
+        # Sanitise: keep only A-Z and underscores
+        sanitised = _re.sub(r"[^A-Z_]", "_", raw).strip("_")
+        if sanitised and _re.match(r"^[A-Z][A-Z0-9_]*$", sanitised):
+            logger.info(
+                "schema_mapper: LLM named junction %r → %s", table_name, sanitised
+            )
+            return sanitised
+        logger.warning(
+            "schema_mapper: LLM returned invalid rel type %r for %r — using fallback",
+            raw,
+            table_name,
+        )
+        return "ASSOCIATED_WITH"
+
+    except Exception as exc:
+        logger.warning(
+            "schema_mapper: LLM call failed for junction %r: %s — using fallback",
+            table_name,
+            exc,
+        )
+        return "ASSOCIATED_WITH"
+
+
+# ---------------------------------------------------------------------------
+# FK grouping helpers
+# ---------------------------------------------------------------------------
+
+
+def _group_fk_columns(columns: list) -> list[list]:
+    """Group FK columns that belong to composite FKs.
+
+    In the current SchemaSnapshot model there is no explicit constraint-name
+    field, so we group by (fk_table, fk_column) pairs that share the same
+    target table.  Two FK columns pointing to the same target table are treated
+    as a composite FK and emitted as a single RelationshipMapping.
+
+    Returns a list of groups, where each group is a list of ColumnMeta objects.
+    """
+    # Group FK cols by target table
+    groups: dict[str, list] = {}
+    for col in columns:
+        if not col.is_fk or col.fk_table is None:
+            continue
+        key = col.fk_table
+        groups.setdefault(key, []).append(col)
+    return list(groups.values())
+
+
+# ---------------------------------------------------------------------------
+# Table classification helpers
+# ---------------------------------------------------------------------------
+
+_FK_SUFFIX_PATTERN = _re.compile(r"_(id|fk|ref|key)$", _re.IGNORECASE)
+
+
+def _find_pk(columns: list) -> str | None:
+    """Return the name of the first PK column, or None."""
+    for col in columns:
+        if col.is_pk:
+            return col.name
+    return None
+
+
+def _is_audit_column(col_name: str) -> bool:
+    return col_name.lower() in _AUDIT_COLUMN_NAMES
+
+
+def _classify_table_kind(
+    table_name: str,
+    columns: list,
+) -> Literal["entity_table", "junction_table", "self_ref_table"]:
+    """Classify a table as entity, junction, or self-referential.
+
+    Rules:
+    - junction_table: exactly 2 FK columns (ignoring audit columns and any
+      single PK column) and no other non-FK, non-audit columns
+    - self_ref_table: entity table that has at least one FK pointing back to
+      itself (hierarchical / adjacency list pattern)
+    - entity_table: everything else with a PK
+    """
+    fk_cols = [c for c in columns if c.is_fk and not c.is_pk]
+    fk_tables = {c.fk_table for c in fk_cols if c.fk_table}
+
+    # Non-FK, non-PK, non-audit columns
+    non_fk_real_cols = [
+        c
+        for c in columns
+        if not c.is_pk and not c.is_fk and not _is_audit_column(c.name)
+    ]
+
+    # Junction: exactly 2 distinct FK target tables + no meaningful payload cols
+    if len(fk_tables) == 2 and len(non_fk_real_cols) == 0:
+        return "junction_table"
+
+    # Self-ref: any FK points back to the same table
+    if any(c.fk_table == table_name for c in fk_cols):
+        return "self_ref_table"
+
+    return "entity_table"
+
+
+# ---------------------------------------------------------------------------
+# SchemaMapper
+# ---------------------------------------------------------------------------
+
+
+class SchemaMapper:
+    """Analyse a SchemaSnapshot and produce GraphMappingRules.
+
+    This is a pure analysis class — it makes NO writes to Neo4j.
+    graph_id is injected into every output structure for multi-tenancy.
+    """
+
+    def map(
+        self,
+        schema_snapshot,  # SchemaSnapshot from database_connector_service
+        connector_id: str,
+        graph_id: str,
+    ) -> GraphMappingRules:
+        """Analyse snapshot and return a fully-populated GraphMappingRules.
+
+        Args:
+            schema_snapshot: SchemaSnapshot produced by a DatabaseConnector.
+            connector_id:    ID of the source connector (for provenance).
+            graph_id:        Tenant graph ID — threaded through all output structures.
+
+        Returns:
+            GraphMappingRules with graph_id set on the top-level object.
+        """
+        table_mappings: list[TableMapping] = []
+
+        # Build a lookup: table_name → PK column name (needed for rel mappings)
+        pk_lookup: dict[str, str] = {}
+        for table_meta in schema_snapshot.tables:
+            pk = _find_pk(table_meta.columns)
+            if pk:
+                pk_lookup[table_meta.name] = pk
+
+        for table_meta in schema_snapshot.tables:
+            mapping = self._map_table(table_meta, pk_lookup, graph_id)
+            if mapping is not None:
+                table_mappings.append(mapping)
+
+        return GraphMappingRules(
+            connector_id=connector_id,
+            graph_id=graph_id,
+            tables=table_mappings,
+            generated_at=datetime.now(UTC).isoformat(),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _map_table(
+        self,
+        table_meta,
+        pk_lookup: dict[str, str],
+        graph_id: str,  # kept for future per-table graph_id injection if needed
+    ) -> TableMapping | None:
+        """Map one TableMeta to a TableMapping, or return None if unmappable."""
+        columns = table_meta.columns
+        pk_col = _find_pk(columns)
+
+        # Classify early so we can decide whether a missing PK is acceptable.
+        # Junction tables do not need a PK to produce a valid RelationshipMapping.
+        kind = _classify_table_kind(table_meta.name, columns)
+
+        # Non-junction tables without a PK are skipped — we cannot create unique entity nodes.
+        if pk_col is None and kind != "junction_table":
+            logger.warning(
+                "schema_mapper: table %r has no PK — skipping",
+                table_meta.name,
+            )
+            return None
+        neo4j_label = _to_pascal_case(table_meta.name)
+
+        # Property columns: non-PK, non-FK columns
+        property_columns = [
+            ColumnMapping(
+                column_name=col.name,
+                neo4j_property=_to_camel_case(col.name),
+            )
+            for col in columns
+            if not col.is_pk and not col.is_fk
+        ]
+
+        # FK → RelationshipMapping
+        relationships = self._build_relationships(
+            table_meta.name, columns, pk_lookup, kind
+        )
+
+        return TableMapping(
+            table_name=table_meta.name,
+            kind=kind,
+            neo4j_label=neo4j_label,
+            pk_column=pk_col or "",  # junction tables may have no PK
+            property_columns=property_columns,
+            relationships=relationships,
+        )
+
+    def _build_relationships(
+        self,
+        table_name: str,
+        columns: list,
+        pk_lookup: dict[str, str],
+        kind: Literal["entity_table", "junction_table", "self_ref_table"],
+    ) -> list[RelationshipMapping]:
+        """Derive RelationshipMapping entries from FK columns.
+
+        - For entity_table and self_ref_table: one RelationshipMapping per FK
+          group (composite FKs sharing the same target table → one mapping).
+        - For junction_table: one RelationshipMapping from table A → table B,
+          via this junction table.
+        """
+        fk_cols = [c for c in columns if c.is_fk and c.fk_table is not None]
+        if not fk_cols:
+            return []
+
+        # Group FK columns by target table (handles composite FKs)
+        fk_groups = _group_fk_columns(columns)
+
+        if kind == "junction_table":
+            return self._build_junction_relationships(
+                table_name, fk_groups, pk_lookup
+            )
+
+        # entity_table or self_ref_table — one rel per FK group
+        rels: list[RelationshipMapping] = []
+        for group in fk_groups:
+            # Use the first column in the group as the representative FK column
+            rep = group[0]
+            target_table = rep.fk_table
+            if not target_table:
+                continue
+            target_pk = pk_lookup.get(target_table, "id")
+            rel_type = _rel_type_for_fk(rep.name, target_table, table_name)
+            try:
+                rel_type = _validate_rel_type(rel_type)
+            except ValueError:
+                logger.warning(
+                    "schema_mapper: invalid rel_type %r for %r.%r → using REFERENCES",
+                    rel_type,
+                    table_name,
+                    rep.name,
+                )
+                rel_type = "REFERENCES"
+
+            rels.append(
+                RelationshipMapping(
+                    from_table=table_name,
+                    to_table=target_table,
+                    rel_type=rel_type,
+                    from_fk_column=rep.name,
+                    to_fk_column=target_pk,
+                    via_junction=None,
+                )
+            )
+        return rels
+
+    def _build_junction_relationships(
+        self,
+        junction_table: str,
+        fk_groups: list[list],
+        pk_lookup: dict[str, str],
+    ) -> list[RelationshipMapping]:
+        """Build a single RelationshipMapping for a junction table (A → B via junction)."""
+        if len(fk_groups) < 2:
+            logger.warning(
+                "schema_mapper: junction table %r has fewer than 2 FK groups — skipping",
+                junction_table,
+            )
+            return []
+
+        # Take the first two FK groups as the two sides of the relationship
+        group_a = fk_groups[0]
+        group_b = fk_groups[1]
+
+        from_table = group_a[0].fk_table
+        to_table = group_b[0].fk_table
+        from_fk_col = group_a[0].name
+        to_fk_col = group_b[0].name
+
+        if not from_table or not to_table:
+            return []
+
+        # Derive relationship type from junction table name
+        rel_type = _junction_rel_type_from_name(junction_table, from_table, to_table)
+        if rel_type is None:
+            # Ambiguous name — ask the LLM (max 1 call per table)
+            logger.info(
+                "schema_mapper: junction %r name is ambiguous — calling LLM",
+                junction_table,
+            )
+            rel_type = _call_llm_for_rel_type(junction_table, from_table, to_table)
+
+        try:
+            rel_type = _validate_rel_type(rel_type)
+        except ValueError:
+            logger.warning(
+                "schema_mapper: invalid rel_type %r for junction %r — using ASSOCIATED_WITH",
+                rel_type,
+                junction_table,
+            )
+            rel_type = "ASSOCIATED_WITH"
+
+        to_pk = pk_lookup.get(to_table, "id")
+
+        return [
+            RelationshipMapping(
+                from_table=from_table,
+                to_table=to_table,
+                rel_type=rel_type,
+                from_fk_column=from_fk_col,
+                to_fk_column=to_pk,
+                via_junction=junction_table,
+            )
+        ]

--- a/knowledge-graph-builder/tests/unit/test_row_transformer.py
+++ b/knowledge-graph-builder/tests/unit/test_row_transformer.py
@@ -1,0 +1,679 @@
+"""Unit tests for app/services/row_transformer.py (TASK-020).
+
+All tests are pure Python — no Neo4j, no Docker, no network required.
+Neo4j driver calls are replaced with MagicMock objects that record calls.
+
+Covers:
+- Entity row → __Entity__ node: id format {connector_id}:{table}:{pk},
+  non-FK properties mapped, ingestion_time set in Cypher, graph_id present
+- Junction row → relationship: edges between correct entity node ids
+- Self-referential FK row → self-ref edge
+- Batch processing: 1000 rows produce exactly 2 UNWIND calls (batch_size=500)
+- graph_id on every written node and relationship
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.services.row_transformer import (
+    RowTransformer,
+    _build_entity_row_param,
+    _build_junction_row_param,
+    _build_self_ref_row_param,
+    _chunks,
+    _coerce_value,
+    _entity_id,
+    _safe_rel_type,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CONNECTOR_ID = "conn-abc-123"
+_GRAPH_ID = "graph-tenant-xyz"
+
+
+# ---------------------------------------------------------------------------
+# Minimal stub classes to avoid importing dataclasses from schema_mapper
+# (keeps test isolated — no dependency on TASK-019 internals)
+# ---------------------------------------------------------------------------
+
+
+class _ColumnMapping:
+    def __init__(self, column_name: str, neo4j_property: str):
+        self.column_name = column_name
+        self.neo4j_property = neo4j_property
+
+
+class _RelationshipMapping:
+    def __init__(
+        self,
+        from_table: str,
+        to_table: str,
+        rel_type: str,
+        from_fk_column: str,
+        to_fk_column: str,
+        via_junction=None,
+    ):
+        self.from_table = from_table
+        self.to_table = to_table
+        self.rel_type = rel_type
+        self.from_fk_column = from_fk_column
+        self.to_fk_column = to_fk_column
+        self.via_junction = via_junction
+
+
+class _TableMapping:
+    def __init__(
+        self,
+        table_name: str,
+        kind: str,
+        neo4j_label: str,
+        pk_column: str,
+        property_columns: list,
+        relationships: list,
+    ):
+        self.table_name = table_name
+        self.kind = kind
+        self.neo4j_label = neo4j_label
+        self.pk_column = pk_column
+        self.property_columns = property_columns
+        self.relationships = relationships
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_neo4j_manager() -> MagicMock:
+    """Return a mock WorkerNeo4jManager with a mock sync driver and session."""
+    mock_session = MagicMock()
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_manager = MagicMock()
+    mock_manager.get_sync_driver.return_value = mock_driver
+    return mock_manager, mock_driver, mock_session
+
+
+def _make_users_table_mapping() -> _TableMapping:
+    return _TableMapping(
+        table_name="users",
+        kind="entity_table",
+        neo4j_label="Users",
+        pk_column="id",
+        property_columns=[
+            _ColumnMapping("name", "name"),
+            _ColumnMapping("email", "email"),
+        ],
+        relationships=[],
+    )
+
+
+def _make_employee_self_ref_mapping() -> _TableMapping:
+    return _TableMapping(
+        table_name="employees",
+        kind="self_ref_table",
+        neo4j_label="Employees",
+        pk_column="id",
+        property_columns=[
+            _ColumnMapping("name", "name"),
+        ],
+        relationships=[
+            _RelationshipMapping(
+                from_table="employees",
+                to_table="employees",
+                rel_type="REPORTS_TO",
+                from_fk_column="manager_id",
+                to_fk_column="id",
+                via_junction=None,
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _entity_id
+# ---------------------------------------------------------------------------
+
+
+def test_entity_id_format():
+    """id must be {connector_id}:{table_name}:{pk_value}."""
+    eid = _entity_id("conn-1", "users", 42)
+    assert eid == "conn-1:users:42"
+
+
+def test_entity_id_string_pk():
+    eid = _entity_id("c", "orders", "uuid-abc")
+    assert eid == "c:orders:uuid-abc"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _build_entity_row_param
+# ---------------------------------------------------------------------------
+
+
+def test_build_entity_row_param_basic():
+    tm = _make_users_table_mapping()
+    row = {"id": 1, "name": "Alice", "email": "alice@example.com"}
+    param = _build_entity_row_param(row, tm, _GRAPH_ID, _CONNECTOR_ID)
+    assert param is not None
+    assert param["id"] == f"{_CONNECTOR_ID}:users:1"
+    assert param["properties"]["name"] == "Alice"
+    assert param["properties"]["email"] == "alice@example.com"
+
+
+def test_build_entity_row_param_missing_pk_returns_none():
+    tm = _make_users_table_mapping()
+    row = {"name": "Alice"}  # no 'id'
+    param = _build_entity_row_param(row, tm, _GRAPH_ID, _CONNECTOR_ID)
+    assert param is None
+
+
+def test_build_entity_row_param_none_pk_returns_none():
+    tm = _make_users_table_mapping()
+    row = {"id": None, "name": "Alice"}
+    param = _build_entity_row_param(row, tm, _GRAPH_ID, _CONNECTOR_ID)
+    assert param is None
+
+
+def test_build_entity_row_param_none_property_excluded():
+    """Properties with None values should not appear in the properties dict."""
+    tm = _make_users_table_mapping()
+    row = {"id": 1, "name": "Alice", "email": None}
+    param = _build_entity_row_param(row, tm, _GRAPH_ID, _CONNECTOR_ID)
+    assert param is not None
+    assert "email" not in param["properties"]
+
+
+def test_build_entity_row_param_extra_columns_ignored():
+    """Columns not in property_columns (e.g. FK columns) are ignored."""
+    tm = _make_users_table_mapping()
+    row = {"id": 1, "name": "Alice", "email": "a@b.com", "role_id": 5}
+    param = _build_entity_row_param(row, tm, _GRAPH_ID, _CONNECTOR_ID)
+    assert "roleId" not in param["properties"]
+    assert "role_id" not in param["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _build_junction_row_param
+# ---------------------------------------------------------------------------
+
+
+def test_build_junction_row_param_basic():
+    rel = _RelationshipMapping(
+        from_table="users",
+        to_table="roles",
+        rel_type="HAS_ROLE",
+        from_fk_column="user_id",
+        to_fk_column="role_id",
+        via_junction="user_roles",
+    )
+    row = {"user_id": 10, "role_id": 20}
+    param = _build_junction_row_param(row, MagicMock(), rel, _GRAPH_ID, _CONNECTOR_ID)
+    assert param["from_id"] == f"{_CONNECTOR_ID}:users:10"
+    assert param["to_id"] == f"{_CONNECTOR_ID}:roles:20"
+
+
+def test_build_junction_row_param_missing_fk_returns_none():
+    rel = _RelationshipMapping(
+        from_table="users",
+        to_table="roles",
+        rel_type="HAS_ROLE",
+        from_fk_column="user_id",
+        to_fk_column="role_id",
+    )
+    row = {"user_id": 10}  # role_id missing
+    param = _build_junction_row_param(row, MagicMock(), rel, _GRAPH_ID, _CONNECTOR_ID)
+    assert param is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _build_self_ref_row_param
+# ---------------------------------------------------------------------------
+
+
+def test_build_self_ref_row_param_basic():
+    tm = _make_employee_self_ref_mapping()
+    rel = tm.relationships[0]
+    row = {"id": 5, "name": "Bob", "manager_id": 3}
+    param = _build_self_ref_row_param(row, tm, rel, _GRAPH_ID, _CONNECTOR_ID)
+    assert param["from_id"] == f"{_CONNECTOR_ID}:employees:5"
+    assert param["to_id"] == f"{_CONNECTOR_ID}:employees:3"
+
+
+def test_build_self_ref_row_param_no_manager_returns_none():
+    """Rows where manager_id is None (top-level employees) produce None."""
+    tm = _make_employee_self_ref_mapping()
+    rel = tm.relationships[0]
+    row = {"id": 1, "name": "CEO", "manager_id": None}
+    param = _build_self_ref_row_param(row, tm, rel, _GRAPH_ID, _CONNECTOR_ID)
+    assert param is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _chunks
+# ---------------------------------------------------------------------------
+
+
+def test_chunks_even_split():
+    chunks = list(_chunks(list(range(10)), 5))
+    assert chunks == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+
+
+def test_chunks_remainder():
+    chunks = list(_chunks(list(range(7)), 3))
+    assert len(chunks) == 3
+    assert chunks[-1] == [6]
+
+
+def test_chunks_empty():
+    assert list(_chunks([], 5)) == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _safe_rel_type
+# ---------------------------------------------------------------------------
+
+
+def test_safe_rel_type_valid():
+    assert _safe_rel_type("REPORTS_TO") is True
+    assert _safe_rel_type("HAS_ROLE") is True
+    assert _safe_rel_type("REFERENCES_USERS") is True
+
+
+def test_safe_rel_type_invalid():
+    assert _safe_rel_type("invalid lower") is False
+    assert _safe_rel_type("INJECT; DROP") is False
+    assert _safe_rel_type("") is False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _coerce_value
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_primitives():
+    assert _coerce_value(42) == 42
+    assert _coerce_value(3.14) == 3.14
+    assert _coerce_value("hello") == "hello"
+    assert _coerce_value(True) is True
+    assert _coerce_value(None) is None
+
+
+def test_coerce_value_date():
+    import datetime
+
+    d = datetime.date(2026, 4, 27)
+    assert _coerce_value(d) == "2026-04-27"
+
+
+def test_coerce_value_datetime():
+    import datetime
+
+    dt = datetime.datetime(2026, 4, 27, 12, 0, 0)
+    result = _coerce_value(dt)
+    assert "2026-04-27" in result
+
+
+def test_coerce_value_unknown_type():
+    class Weird:
+        def __str__(self):
+            return "weird-value"
+
+    assert _coerce_value(Weird()) == "weird-value"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: RowTransformer.transform_table
+# ---------------------------------------------------------------------------
+
+
+def test_transform_table_entity_nodes_written():
+    """transform_table writes one UNWIND batch for ≤500 rows."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    tm = _make_users_table_mapping()
+
+    rows = [{"id": i, "name": f"User{i}", "email": f"u{i}@x.com"} for i in range(1, 4)]
+    count = xfm.transform_table(tm, rows, _GRAPH_ID, _CONNECTOR_ID)
+
+    assert count == 3
+    # One session.run() call for the single batch
+    assert mock_session.run.call_count == 1
+    call_args = mock_session.run.call_args
+    cypher = call_args[0][0]
+    params = call_args[0][1]
+
+    # graph_id present in params
+    assert params["graph_id"] == _GRAPH_ID
+    # table_name present
+    assert params["table_name"] == "users"
+    # neo4j_label present
+    assert params["neo4j_label"] == "Users"
+    # UNWIND batch present with correct entity ids
+    batch = params["batch"]
+    assert len(batch) == 3
+    assert batch[0]["id"] == f"{_CONNECTOR_ID}:users:1"
+
+
+def test_transform_table_id_format():
+    """Entity id must be {connector_id}:{table}:{pk_value}."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    tm = _make_users_table_mapping()
+
+    rows = [{"id": 99, "name": "Test", "email": "t@t.com"}]
+    xfm.transform_table(tm, rows, _GRAPH_ID, _CONNECTOR_ID)
+
+    batch = mock_session.run.call_args[0][1]["batch"]
+    assert batch[0]["id"] == f"{_CONNECTOR_ID}:users:99"
+
+
+def test_transform_table_graph_id_on_every_write():
+    """graph_id must appear in every Cypher call's parameters."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    tm = _make_users_table_mapping()
+
+    rows = [{"id": i, "name": f"U{i}", "email": f"u{i}@x.com"} for i in range(5)]
+    xfm.transform_table(tm, rows, _GRAPH_ID, _CONNECTOR_ID)
+
+    for c in mock_session.run.call_args_list:
+        assert c[0][1]["graph_id"] == _GRAPH_ID
+
+
+def test_transform_table_empty_rows():
+    mock_manager, _, _ = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    tm = _make_users_table_mapping()
+    count = xfm.transform_table(tm, [], _GRAPH_ID, _CONNECTOR_ID)
+    assert count == 0
+
+
+def test_transform_table_batch_processing_1000_rows():
+    """1000 rows → exactly 2 UNWIND calls (batches of 500)."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    tm = _make_users_table_mapping()
+
+    rows = [{"id": i, "name": f"User{i}", "email": f"u{i}@x.com"} for i in range(1000)]
+    count = xfm.transform_table(tm, rows, _GRAPH_ID, _CONNECTOR_ID)
+
+    assert count == 1000
+    assert mock_session.run.call_count == 2
+
+    # Verify each batch has 500 rows
+    first_batch = mock_session.run.call_args_list[0][0][1]["batch"]
+    second_batch = mock_session.run.call_args_list[1][0][1]["batch"]
+    assert len(first_batch) == 500
+    assert len(second_batch) == 500
+
+
+def test_transform_table_properties_mapped():
+    """Non-FK, non-PK columns are written using neo4j_property names."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    tm = _TableMapping(
+        table_name="products",
+        kind="entity_table",
+        neo4j_label="Products",
+        pk_column="product_id",
+        property_columns=[
+            _ColumnMapping("product_name", "productName"),
+            _ColumnMapping("unit_price", "unitPrice"),
+        ],
+        relationships=[],
+    )
+
+    rows = [{"product_id": 1, "product_name": "Widget", "unit_price": 9.99}]
+    xfm.transform_table(tm, rows, _GRAPH_ID, _CONNECTOR_ID)
+
+    batch = mock_session.run.call_args[0][1]["batch"]
+    props = batch[0]["properties"]
+    assert "productName" in props
+    assert props["productName"] == "Widget"
+    assert "unitPrice" in props
+    assert props["unitPrice"] == 9.99
+    # PK column must NOT appear in properties
+    assert "product_id" not in props
+    assert "productId" not in props
+
+
+def test_transform_table_rows_missing_pk_skipped():
+    """Rows without a PK value are silently skipped."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    tm = _make_users_table_mapping()
+
+    rows = [
+        {"id": 1, "name": "Alice", "email": "a@x.com"},
+        {"name": "No-PK", "email": "b@x.com"},  # no 'id'
+    ]
+    count = xfm.transform_table(tm, rows, _GRAPH_ID, _CONNECTOR_ID)
+    assert count == 1
+    batch = mock_session.run.call_args[0][1]["batch"]
+    assert len(batch) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: RowTransformer.transform_junctions — junction tables
+# ---------------------------------------------------------------------------
+
+
+def test_transform_junctions_junction_table():
+    """Junction row → relationship between correct entity node ids."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+
+    rel = _RelationshipMapping(
+        from_table="users",
+        to_table="roles",
+        rel_type="HAS_ROLE",
+        from_fk_column="user_id",
+        to_fk_column="role_id",
+        via_junction="user_roles",
+    )
+    junction_tm = _TableMapping(
+        table_name="user_roles",
+        kind="junction_table",
+        neo4j_label="UserRoles",
+        pk_column="",
+        property_columns=[],
+        relationships=[rel],
+    )
+
+    rows_by_table = {
+        "user_roles": [
+            {"user_id": 1, "role_id": 10},
+            {"user_id": 2, "role_id": 20},
+        ]
+    }
+    total = xfm.transform_junctions(
+        [junction_tm], rows_by_table, _GRAPH_ID, _CONNECTOR_ID
+    )
+
+    assert total == 2
+    assert mock_session.run.call_count == 1  # 2 rows fit in one batch
+    call_args = mock_session.run.call_args
+    cypher = call_args[0][0]
+    params = call_args[0][1]
+
+    # graph_id present
+    assert params["graph_id"] == _GRAPH_ID
+    # source_table present
+    assert params["junction_table"] == "user_roles"
+    # rel_type in Cypher
+    assert "HAS_ROLE" in cypher
+
+    batch = params["batch"]
+    assert batch[0]["from_id"] == f"{_CONNECTOR_ID}:users:1"
+    assert batch[0]["to_id"] == f"{_CONNECTOR_ID}:roles:10"
+    assert batch[1]["from_id"] == f"{_CONNECTOR_ID}:users:2"
+    assert batch[1]["to_id"] == f"{_CONNECTOR_ID}:roles:20"
+
+
+def test_transform_junctions_graph_id_on_relationship():
+    """graph_id must appear in the relationship Cypher and params."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+
+    rel = _RelationshipMapping(
+        from_table="users",
+        to_table="roles",
+        rel_type="HAS_ROLE",
+        from_fk_column="user_id",
+        to_fk_column="role_id",
+    )
+    junction_tm = _TableMapping(
+        table_name="user_roles",
+        kind="junction_table",
+        neo4j_label="UserRoles",
+        pk_column="",
+        property_columns=[],
+        relationships=[rel],
+    )
+
+    rows_by_table = {"user_roles": [{"user_id": 1, "role_id": 10}]}
+    xfm.transform_junctions([junction_tm], rows_by_table, _GRAPH_ID, _CONNECTOR_ID)
+
+    call_args = mock_session.run.call_args
+    cypher = call_args[0][0]
+    params = call_args[0][1]
+    # graph_id in params
+    assert params["graph_id"] == _GRAPH_ID
+    # graph_id appears in the MERGE Cypher (scopes the relationship)
+    assert "graph_id" in cypher
+
+
+def test_transform_junctions_empty_rows():
+    mock_manager, _, _ = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    total = xfm.transform_junctions([], {}, _GRAPH_ID, _CONNECTOR_ID)
+    assert total == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: RowTransformer.transform_junctions — self-referential FK
+# ---------------------------------------------------------------------------
+
+
+def test_transform_junctions_self_ref():
+    """Self-referential FK produces edge where source and target are same table."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+
+    tm = _make_employee_self_ref_mapping()
+    rows_by_table = {
+        "employees": [
+            {"id": 1, "name": "CEO", "manager_id": None},    # no manager — skipped
+            {"id": 2, "name": "VP", "manager_id": 1},
+            {"id": 3, "name": "Manager", "manager_id": 1},
+        ]
+    }
+
+    total = xfm.transform_junctions([tm], rows_by_table, _GRAPH_ID, _CONNECTOR_ID)
+
+    # Only 2 rows produce valid edges (row with manager_id=None is skipped)
+    assert total == 2
+
+    call_args = mock_session.run.call_args
+    batch = call_args[0][1]["batch"]
+    assert len(batch) == 2
+    # VP reports to CEO
+    assert batch[0]["from_id"] == f"{_CONNECTOR_ID}:employees:2"
+    assert batch[0]["to_id"] == f"{_CONNECTOR_ID}:employees:1"
+
+
+def test_transform_junctions_self_ref_rel_type_in_cypher():
+    """REPORTS_TO should appear as the relationship type in the generated Cypher."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+
+    tm = _make_employee_self_ref_mapping()
+    rows_by_table = {
+        "employees": [{"id": 2, "name": "VP", "manager_id": 1}]
+    }
+    xfm.transform_junctions([tm], rows_by_table, _GRAPH_ID, _CONNECTOR_ID)
+
+    cypher = mock_session.run.call_args[0][0]
+    assert "REPORTS_TO" in cypher
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: batch size boundary
+# ---------------------------------------------------------------------------
+
+
+def test_transform_junctions_1000_rows_two_batches():
+    """1000 junction rows → exactly 2 UNWIND calls (batches of 500)."""
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+
+    rel = _RelationshipMapping(
+        from_table="users",
+        to_table="roles",
+        rel_type="HAS_ROLE",
+        from_fk_column="user_id",
+        to_fk_column="role_id",
+    )
+    junction_tm = _TableMapping(
+        table_name="user_roles",
+        kind="junction_table",
+        neo4j_label="UserRoles",
+        pk_column="",
+        property_columns=[],
+        relationships=[rel],
+    )
+
+    rows = [{"user_id": i, "role_id": i + 100} for i in range(1000)]
+    rows_by_table = {"user_roles": rows}
+
+    total = xfm.transform_junctions(
+        [junction_tm], rows_by_table, _GRAPH_ID, _CONNECTOR_ID
+    )
+
+    assert total == 1000
+    assert mock_session.run.call_count == 2
+
+    first_batch = mock_session.run.call_args_list[0][0][1]["batch"]
+    second_batch = mock_session.run.call_args_list[1][0][1]["batch"]
+    assert len(first_batch) == 500
+    assert len(second_batch) == 500
+
+
+# ---------------------------------------------------------------------------
+# Integration: import from schema_mapper works (smoke test)
+# ---------------------------------------------------------------------------
+
+
+def test_import_from_schema_mapper():
+    """Verify RowTransformer can use real TableMapping from schema_mapper."""
+    from app.services.schema_mapper import (
+        ColumnMapping,
+        GraphMappingRules,
+        RelationshipMapping,
+        TableMapping,
+    )
+
+    tm = TableMapping(
+        table_name="orders",
+        kind="entity_table",
+        neo4j_label="Orders",
+        pk_column="order_id",
+        property_columns=[ColumnMapping("status", "status")],
+        relationships=[],
+    )
+    mock_manager, mock_driver, mock_session = _make_neo4j_manager()
+    xfm = RowTransformer(mock_manager)
+    rows = [{"order_id": 1, "status": "shipped"}]
+    count = xfm.transform_table(tm, rows, _GRAPH_ID, _CONNECTOR_ID)
+    assert count == 1
+    batch = mock_session.run.call_args[0][1]["batch"]
+    assert batch[0]["id"] == f"{_CONNECTOR_ID}:orders:1"
+    assert batch[0]["properties"]["status"] == "shipped"

--- a/knowledge-graph-builder/tests/unit/test_schema_mapper.py
+++ b/knowledge-graph-builder/tests/unit/test_schema_mapper.py
@@ -1,0 +1,648 @@
+"""Unit tests for app/services/schema_mapper.py.
+
+All tests are pure Python — no Neo4j, no Docker, no network required.
+
+Covers:
+- entity_table classification
+- junction_table classification (2 FK cols + audit cols)
+- self_ref_table classification
+- composite FK grouping → single RelationshipMapping
+- LLM naming: mock LLM for opaque table name (`t_ep`) → verify call made
+- graph_id present in all output structures
+- camelCase / PascalCase name helpers
+- Validation guard for unsafe rel type strings
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.database_connector_service import (
+    ColumnMeta,
+    DatabaseConnectorType,
+    SchemaSnapshot,
+    TableMeta,
+)
+from app.services.schema_mapper import (
+    GraphMappingRules,
+    SchemaMapper,
+    _call_llm_for_rel_type,
+    _classify_table_kind,
+    _junction_rel_type_from_name,
+    _rel_type_for_fk,
+    _to_camel_case,
+    _to_pascal_case,
+    _validate_rel_type,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CONNECTOR_ID = "conn-abc-123"
+_GRAPH_ID = "graph-tenant-xyz"
+
+
+def _make_snapshot(*tables: TableMeta) -> SchemaSnapshot:
+    return SchemaSnapshot(
+        connector_type=DatabaseConnectorType.POSTGRESQL,
+        database="testdb",
+        tables=list(tables),
+        captured_at=datetime.now(UTC),
+    )
+
+
+def _col(
+    name: str,
+    *,
+    is_pk: bool = False,
+    is_fk: bool = False,
+    fk_table: str | None = None,
+    fk_column: str | None = None,
+    data_type: str = "integer",
+    nullable: bool = True,
+) -> ColumnMeta:
+    return ColumnMeta(
+        name=name,
+        data_type=data_type,
+        nullable=nullable,
+        is_pk=is_pk,
+        is_fk=is_fk,
+        fk_table=fk_table,
+        fk_column=fk_column,
+    )
+
+
+def _table(name: str, *columns: ColumnMeta) -> TableMeta:
+    return TableMeta(name=name, schema_name="public", columns=list(columns))
+
+
+# ---------------------------------------------------------------------------
+# Name helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNameHelpers:
+    def test_camel_case_single_word(self):
+        assert _to_camel_case("id") == "id"
+
+    def test_camel_case_two_words(self):
+        assert _to_camel_case("user_name") == "userName"
+
+    def test_camel_case_three_words(self):
+        assert _to_camel_case("department_id") == "departmentId"
+
+    def test_camel_case_created_at(self):
+        assert _to_camel_case("created_at") == "createdAt"
+
+    def test_pascal_case_simple(self):
+        assert _to_pascal_case("employee") == "Employee"
+
+    def test_pascal_case_multi_word(self):
+        assert _to_pascal_case("employee_project") == "EmployeeProject"
+
+    def test_pascal_case_prefix(self):
+        assert _to_pascal_case("t_emp_proj") == "TEmpProj"
+
+
+# ---------------------------------------------------------------------------
+# Relationship type validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateRelType:
+    def test_valid_type(self):
+        assert _validate_rel_type("WORKS_ON") == "WORKS_ON"
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            _validate_rel_type("works on")
+
+    def test_invalid_type_with_injection_chars(self):
+        with pytest.raises(ValueError):
+            _validate_rel_type("WORKS)-[:HACK")
+
+
+# ---------------------------------------------------------------------------
+# Table classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestClassifyTableKind:
+    def test_entity_table_basic(self):
+        cols = [
+            _col("id", is_pk=True),
+            _col("name", data_type="varchar"),
+            _col("email", data_type="varchar"),
+        ]
+        assert _classify_table_kind("user", cols) == "entity_table"
+
+    def test_entity_table_with_fk_and_payload(self):
+        """Table with FK but also non-FK payload columns → entity_table."""
+        cols = [
+            _col("id", is_pk=True),
+            _col("department_id", is_fk=True, fk_table="department"),
+            _col("name", data_type="varchar"),
+        ]
+        assert _classify_table_kind("employee", cols) == "entity_table"
+
+    def test_junction_table_two_fks(self):
+        """Exactly 2 FK columns + no payload → junction_table."""
+        cols = [
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+        ]
+        assert _classify_table_kind("employee_project", cols) == "junction_table"
+
+    def test_junction_table_two_fks_plus_audit(self):
+        """2 FK cols + audit cols only → still junction_table."""
+        cols = [
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+            _col("created_at", data_type="timestamp"),
+            _col("updated_at", data_type="timestamp"),
+        ]
+        assert _classify_table_kind("employee_project", cols) == "junction_table"
+
+    def test_junction_table_with_surrogate_pk_and_audit(self):
+        """Junction table may have an auto-increment 'id' PK — still junction."""
+        cols = [
+            _col("id", is_pk=True),
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+            _col("created_at", data_type="timestamp"),
+        ]
+        # 'id' is in _AUDIT_COLUMN_NAMES → ignored as non-FK payload
+        assert _classify_table_kind("employee_project", cols) == "junction_table"
+
+    def test_not_junction_with_payload(self):
+        """2 FK cols + real payload col → entity_table, not junction."""
+        cols = [
+            _col("id", is_pk=True),
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+            _col("role", data_type="varchar"),  # real payload
+        ]
+        assert _classify_table_kind("employee_project", cols) == "entity_table"
+
+    def test_self_ref_table(self):
+        """FK pointing to same table's PK → self_ref_table."""
+        cols = [
+            _col("id", is_pk=True),
+            _col("manager_id", is_fk=True, fk_table="employee"),
+            _col("name", data_type="varchar"),
+        ]
+        assert _classify_table_kind("employee", cols) == "self_ref_table"
+
+    def test_self_ref_with_parent_id(self):
+        cols = [
+            _col("id", is_pk=True),
+            _col("parent_id", is_fk=True, fk_table="category"),
+            _col("name", data_type="varchar"),
+        ]
+        assert _classify_table_kind("category", cols) == "self_ref_table"
+
+
+# ---------------------------------------------------------------------------
+# Junction table relationship type derivation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestJunctionRelTypeName:
+    def test_meaningful_verb_extracted(self):
+        # employee_project → strip 'employee' and 'project' → '' → no verb
+        # But 'employee_works_project' → 'works'
+        result = _junction_rel_type_from_name("employee_works_project", "employee", "project")
+        assert result == "WORKS"
+
+    def test_no_verb_returns_none(self):
+        # 'employee_project' → strip names → '' → None
+        result = _junction_rel_type_from_name("employee_project", "employee", "project")
+        assert result is None
+
+    def test_opaque_name_returns_none(self):
+        result = _junction_rel_type_from_name("t_ep", "employee", "project")
+        assert result is None
+
+    def test_opaque_with_rel_prefix_returns_none(self):
+        result = _junction_rel_type_from_name("rel_012", "employee", "project")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# FK → rel type derivation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRelTypeForFk:
+    def test_department_id(self):
+        result = _rel_type_for_fk("department_id", "department", "employee")
+        assert result == "BELONGS_TO"
+
+    def test_manager_id_self_ref(self):
+        result = _rel_type_for_fk("manager_id", "employee", "employee")
+        assert result == "MANAGES"
+
+    def test_parent_id_self_ref(self):
+        result = _rel_type_for_fk("parent_id", "category", "category")
+        assert result == "HAS_CHILD"
+
+    def test_supervisor_id_self_ref(self):
+        result = _rel_type_for_fk("supervisor_id", "employee", "employee")
+        assert result == "SUPERVISES"
+
+    def test_unknown_self_ref(self):
+        result = _rel_type_for_fk("reports_to_id", "employee", "employee")
+        # Doesn't match _SELF_REF_PATTERNS exactly → REFERENCES_SELF fallback
+        assert result == "REFERENCES_SELF"
+
+    def test_generic_fk(self):
+        result = _rel_type_for_fk("company_id", "company", "employee")
+        assert result == "BELONGS_TO"
+
+
+# ---------------------------------------------------------------------------
+# SchemaMapper.map — full integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSchemaMapperEntityTable:
+    def test_basic_entity_table(self):
+        snapshot = _make_snapshot(
+            _table(
+                "employee",
+                _col("id", is_pk=True),
+                _col("name", data_type="varchar"),
+                _col("email", data_type="varchar"),
+            )
+        )
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        assert rules.graph_id == _GRAPH_ID
+        assert rules.connector_id == _CONNECTOR_ID
+        assert len(rules.tables) == 1
+
+        tm = rules.tables[0]
+        assert tm.table_name == "employee"
+        assert tm.kind == "entity_table"
+        assert tm.neo4j_label == "Employee"
+        assert tm.pk_column == "id"
+        assert len(tm.relationships) == 0
+        # Property columns: name, email (not id/pk)
+        prop_names = {cm.column_name for cm in tm.property_columns}
+        assert prop_names == {"name", "email"}
+
+    def test_entity_table_with_fk_produces_relationship(self):
+        dept_table = _table(
+            "department",
+            _col("id", is_pk=True),
+            _col("name", data_type="varchar"),
+        )
+        emp_table = _table(
+            "employee",
+            _col("id", is_pk=True),
+            _col("department_id", is_fk=True, fk_table="department"),
+            _col("name", data_type="varchar"),
+        )
+        snapshot = _make_snapshot(dept_table, emp_table)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        emp_mapping = next(t for t in rules.tables if t.table_name == "employee")
+        assert len(emp_mapping.relationships) == 1
+        rel = emp_mapping.relationships[0]
+        assert rel.from_table == "employee"
+        assert rel.to_table == "department"
+        assert rel.rel_type == "BELONGS_TO"
+        assert rel.from_fk_column == "department_id"
+        assert rel.via_junction is None
+
+    def test_property_column_camel_case(self):
+        snapshot = _make_snapshot(
+            _table(
+                "user_account",
+                _col("id", is_pk=True),
+                _col("first_name", data_type="varchar"),
+                _col("last_login_at", data_type="timestamp"),
+            )
+        )
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+        tm = rules.tables[0]
+
+        prop_map = {cm.column_name: cm.neo4j_property for cm in tm.property_columns}
+        assert prop_map["first_name"] == "firstName"
+        assert prop_map["last_login_at"] == "lastLoginAt"
+
+
+@pytest.mark.unit
+class TestSchemaMapperJunctionTable:
+    def test_junction_two_fks(self):
+        emp = _table("employee", _col("id", is_pk=True), _col("name", data_type="varchar"))
+        proj = _table("project", _col("id", is_pk=True), _col("title", data_type="varchar"))
+        junc = _table(
+            "employee_project",
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+        )
+        snapshot = _make_snapshot(emp, proj, junc)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        junc_mapping = next(t for t in rules.tables if t.table_name == "employee_project")
+        assert junc_mapping.kind == "junction_table"
+        assert len(junc_mapping.relationships) == 1
+        rel = junc_mapping.relationships[0]
+        assert rel.from_table == "employee"
+        assert rel.to_table == "project"
+        assert rel.via_junction == "employee_project"
+
+    def test_junction_with_audit_columns(self):
+        emp = _table("employee", _col("id", is_pk=True))
+        proj = _table("project", _col("id", is_pk=True))
+        junc = _table(
+            "employee_project",
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+            _col("created_at", data_type="timestamp"),
+            _col("updated_at", data_type="timestamp"),
+        )
+        snapshot = _make_snapshot(emp, proj, junc)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        junc_mapping = next(t for t in rules.tables if t.table_name == "employee_project")
+        assert junc_mapping.kind == "junction_table"
+        # Still exactly one relationship
+        assert len(junc_mapping.relationships) == 1
+
+
+@pytest.mark.unit
+class TestSchemaMapperSelfRef:
+    def test_self_ref_table(self):
+        emp = _table(
+            "employee",
+            _col("id", is_pk=True),
+            _col("manager_id", is_fk=True, fk_table="employee"),
+            _col("name", data_type="varchar"),
+        )
+        snapshot = _make_snapshot(emp)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        emp_mapping = rules.tables[0]
+        assert emp_mapping.kind == "self_ref_table"
+        assert len(emp_mapping.relationships) == 1
+        rel = emp_mapping.relationships[0]
+        assert rel.from_table == "employee"
+        assert rel.to_table == "employee"
+        assert rel.rel_type == "MANAGES"
+        assert rel.via_junction is None
+
+    def test_category_parent_self_ref(self):
+        cat = _table(
+            "category",
+            _col("id", is_pk=True),
+            _col("parent_id", is_fk=True, fk_table="category"),
+            _col("name", data_type="varchar"),
+        )
+        snapshot = _make_snapshot(cat)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        cat_mapping = rules.tables[0]
+        assert cat_mapping.kind == "self_ref_table"
+        rel = cat_mapping.relationships[0]
+        assert rel.rel_type == "HAS_CHILD"
+
+
+@pytest.mark.unit
+class TestSchemaMapperCompositeFk:
+    def test_composite_fk_grouped_as_single_relationship(self):
+        """Two FK columns pointing to the same target table → one RelationshipMapping."""
+        order = _table("order", _col("id", is_pk=True), _col("total", data_type="decimal"))
+        # Composite FK: (billing_address_country, billing_address_city) both point to address
+        # but since they have the same fk_table they are grouped into one RelationshipMapping
+        order_detail = _table(
+            "order_detail",
+            _col("id", is_pk=True),
+            _col("order_id", is_fk=True, fk_table="order", fk_column="id"),
+            _col("address_line1", is_fk=True, fk_table="order", fk_column="id"),
+        )
+        snapshot = _make_snapshot(order, order_detail)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        od_mapping = next(t for t in rules.tables if t.table_name == "order_detail")
+        # Even though there are 2 FK columns to the same table, they are grouped
+        # → exactly 1 RelationshipMapping
+        assert len(od_mapping.relationships) == 1
+        rel = od_mapping.relationships[0]
+        assert rel.from_table == "order_detail"
+        assert rel.to_table == "order"
+
+    def test_two_different_fk_targets_produce_two_relationships(self):
+        dept = _table("department", _col("id", is_pk=True))
+        location = _table("location", _col("id", is_pk=True))
+        employee = _table(
+            "employee",
+            _col("id", is_pk=True),
+            _col("department_id", is_fk=True, fk_table="department"),
+            _col("location_id", is_fk=True, fk_table="location"),
+            _col("name", data_type="varchar"),
+        )
+        snapshot = _make_snapshot(dept, location, employee)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        emp_mapping = next(t for t in rules.tables if t.table_name == "employee")
+        assert emp_mapping.kind == "entity_table"
+        assert len(emp_mapping.relationships) == 2
+        targets = {rel.to_table for rel in emp_mapping.relationships}
+        assert targets == {"department", "location"}
+
+
+@pytest.mark.unit
+class TestSchemaMapperLlmNaming:
+    def test_llm_called_for_opaque_junction_name(self):
+        """When the junction table name doesn't yield an obvious verb, LLM is called."""
+        emp = _table("employee", _col("id", is_pk=True))
+        proj = _table("project", _col("id", is_pk=True))
+        # 't_ep' is opaque — no recognizable verb after stripping table names
+        junc = _table(
+            "t_ep",
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+        )
+        snapshot = _make_snapshot(emp, proj, junc)
+        mapper = SchemaMapper()
+
+        with patch(
+            "app.services.schema_mapper._call_llm_for_rel_type",
+            return_value="ASSIGNED_TO",
+        ) as mock_llm:
+            rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        # LLM should have been called exactly once (for the opaque junction)
+        mock_llm.assert_called_once_with("t_ep", "employee", "project")
+
+        junc_mapping = next(t for t in rules.tables if t.table_name == "t_ep")
+        assert junc_mapping.relationships[0].rel_type == "ASSIGNED_TO"
+
+    def test_llm_not_called_for_meaningful_junction_name(self):
+        """When the junction name contains a clear verb, LLM is NOT called."""
+        emp = _table("employee", _col("id", is_pk=True))
+        proj = _table("project", _col("id", is_pk=True))
+        # 'employee_works_project' → verb 'WORKS' extracted without LLM
+        junc = _table(
+            "employee_works_project",
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+        )
+        snapshot = _make_snapshot(emp, proj, junc)
+        mapper = SchemaMapper()
+
+        with patch(
+            "app.services.schema_mapper._call_llm_for_rel_type"
+        ) as mock_llm:
+            rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        mock_llm.assert_not_called()
+
+        junc_mapping = next(t for t in rules.tables if t.table_name == "employee_works_project")
+        assert junc_mapping.relationships[0].rel_type == "WORKS"
+
+    def test_llm_context_sent_correctly(self):
+        """LLM receives the junction name, from_table, and to_table."""
+        emp = _table("employee", _col("id", is_pk=True))
+        proj = _table("project", _col("id", is_pk=True))
+        junc = _table(
+            "rel_012",
+            _col("employee_id", is_fk=True, fk_table="employee"),
+            _col("project_id", is_fk=True, fk_table="project"),
+        )
+        snapshot = _make_snapshot(emp, proj, junc)
+        mapper = SchemaMapper()
+
+        with patch(
+            "app.services.schema_mapper._call_llm_for_rel_type",
+            return_value="WORKS_ON",
+        ) as mock_llm:
+            mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        call_args = mock_llm.call_args
+        assert call_args[0][0] == "rel_012"       # junction table name
+        assert call_args[0][1] == "employee"       # from_table
+        assert call_args[0][2] == "project"        # to_table
+
+
+@pytest.mark.unit
+class TestSchemaMapperGraphIdPresence:
+    """Verify graph_id is threaded through every output structure."""
+
+    def test_graph_id_on_mapping_rules(self):
+        snapshot = _make_snapshot(
+            _table("user", _col("id", is_pk=True), _col("name", data_type="varchar"))
+        )
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        assert rules.graph_id == _GRAPH_ID
+
+    def test_graph_id_on_rules_with_multiple_tables(self):
+        dept = _table("department", _col("id", is_pk=True))
+        emp = _table(
+            "employee",
+            _col("id", is_pk=True),
+            _col("department_id", is_fk=True, fk_table="department"),
+        )
+        snapshot = _make_snapshot(dept, emp)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        assert rules.graph_id == _GRAPH_ID
+        # All tables are present in output
+        assert len(rules.tables) == 2
+
+    def test_connector_id_present(self):
+        snapshot = _make_snapshot(
+            _table("user", _col("id", is_pk=True))
+        )
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        assert rules.connector_id == _CONNECTOR_ID
+
+    def test_generated_at_is_iso_timestamp(self):
+        snapshot = _make_snapshot(
+            _table("user", _col("id", is_pk=True))
+        )
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        # Should parse as ISO 8601 without error
+        parsed = datetime.fromisoformat(rules.generated_at)
+        assert parsed is not None
+
+    def test_different_graph_ids_produce_different_rules(self):
+        snapshot = _make_snapshot(
+            _table("user", _col("id", is_pk=True))
+        )
+        mapper = SchemaMapper()
+        rules_a = mapper.map(snapshot, _CONNECTOR_ID, "graph-A")
+        rules_b = mapper.map(snapshot, _CONNECTOR_ID, "graph-B")
+
+        assert rules_a.graph_id == "graph-A"
+        assert rules_b.graph_id == "graph-B"
+
+
+@pytest.mark.unit
+class TestSchemaMapperEdgeCases:
+    def test_table_with_no_pk_is_skipped(self):
+        """Tables without a PK cannot form entity nodes — they are skipped."""
+        no_pk = _table(
+            "legacy_view",
+            _col("name", data_type="varchar"),
+            _col("value", data_type="varchar"),
+        )
+        snapshot = _make_snapshot(no_pk)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        assert len(rules.tables) == 0
+
+    def test_empty_snapshot(self):
+        snapshot = _make_snapshot()
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        assert rules.graph_id == _GRAPH_ID
+        assert rules.tables == []
+
+    def test_fk_without_matching_pk_table_uses_id_fallback(self):
+        """FK pointing to a table not in the snapshot — target PK defaults to 'id'."""
+        employee = _table(
+            "employee",
+            _col("id", is_pk=True),
+            _col("department_id", is_fk=True, fk_table="department"),
+            _col("name", data_type="varchar"),
+        )
+        # 'department' table is NOT in the snapshot
+        snapshot = _make_snapshot(employee)
+        mapper = SchemaMapper()
+        rules = mapper.map(snapshot, _CONNECTOR_ID, _GRAPH_ID)
+
+        emp_mapping = rules.tables[0]
+        assert len(emp_mapping.relationships) == 1
+        rel = emp_mapping.relationships[0]
+        assert rel.to_fk_column == "id"  # fallback


### PR DESCRIPTION
## Summary

- Adds `app/services/row_transformer.py` with `RowTransformer` class that converts relational rows to Neo4j `__Entity__` nodes and relationship edges using batched UNWIND writes (500 rows/batch)
- Adds `fetch_rows(table_name, schema_snapshot, limit, offset)` to the `DatabaseConnector` ABC with PostgreSQL and MySQL implementations; table names are validated against the `SchemaSnapshot` allowlist before use
- Wires `SchemaMapper` + `RowTransformer` into `_sync_database_connector_async` in `background_jobs.py`: entity tables are written first so FK targets exist before junction/self-ref tables produce relationship edges

## Architecture invariants upheld

- `graph_id` on every MERGE node and relationship — no cross-tenant writes
- `WorkerNeo4jManager` sync driver (NullPool) — no `async_driver` in Celery path
- Parameterized Cypher — table identifiers validated against `SchemaSnapshot` allowlist
- UNWIND batch writes — no per-row round trips
- Entity-before-junction ordering — FK targets always exist before edge MERGE

## Test plan

- [x] 34 unit tests in `tests/unit/test_row_transformer.py` — all pass (`python3 -m pytest tests/unit/test_row_transformer.py -v`)
- [x] Entity row → `__Entity__` node: id format `{connector_id}:{table}:{pk}`, non-FK properties mapped, `graph_id` in params
- [x] Junction row → relationship: from_id/to_id correct entity node ids, rel_type in Cypher, graph_id scoped
- [x] Self-referential FK row → self-ref edge (REPORTS_TO style)
- [x] 1000-row table → exactly 2 UNWIND calls (batches of 500)
- [x] Rows missing PK silently skipped; rows with None FK values silently skipped
- [x] Real `TableMapping` from `schema_mapper` works (smoke test)

## Blocked by

TASK-019 (`agent/STORY-003/TASK-019-schema-mapper`) — branched from that branch; rebase onto `develop` after TASK-019 merges.