### PR TITLE
TASK-023: QA — data flow analysis tests (FLOWS_TO edges, taint marking, data_flow query)

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/code_graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/code_graphs.py
@@ -302,6 +302,7 @@ async def code_query(
     | `inheritance_chain` | `class_name`               |
     | `file_deps`         | `file_path`                |
     | `semantic_search`   | `query_text`; optional `top_k` |
+    | `data_flow`         | `source_symbol`; optional `depth` (default 10), `direction` (`forward`\|`backward`\|`both`) |
     """
     await verify_graph_access(str(graph_id), "read", user_id)
 
@@ -490,5 +491,70 @@ async def _run_code_query(
             {"graph_id": graph_id, "top_k": top_k, "embedding": query_embedding},
         )
         return [dict(r) for r in result.records]
+
+    if query_type == "data_flow":
+        source_symbol = params.get("source_symbol")
+        if not source_symbol:
+            raise _QueryParamError(
+                "'source_symbol' is required for query_type=data_flow"
+            )
+        depth = int(params.get("depth", 10))
+        direction = params.get("direction", "forward")
+
+        if direction == "backward":
+            cypher = """
+            MATCH (start {graph_id: $graph_id})
+            WHERE start.qualified_name = $source_symbol OR start.id = $source_symbol
+            MATCH path = (source)-[:FLOWS_TO*1..$depth]->(start)
+            RETURN
+                [node IN nodes(path) | coalesce(node.qualified_name, node.name)] AS path_nodes,
+                [node IN nodes(path) | labels(node)[0]]                          AS path_labels,
+                length(path)                                                       AS depth
+            ORDER BY depth
+            LIMIT $limit
+            """
+        elif direction == "both":
+            cypher = """
+            MATCH (start {graph_id: $graph_id})
+            WHERE start.qualified_name = $source_symbol OR start.id = $source_symbol
+            MATCH path = (start)-[:FLOWS_TO*1..$depth]-(sink)
+            RETURN
+                [node IN nodes(path) | coalesce(node.qualified_name, node.name)] AS path_nodes,
+                [node IN nodes(path) | labels(node)[0]]                          AS path_labels,
+                length(path)                                                       AS depth
+            ORDER BY depth
+            LIMIT $limit
+            """
+        else:
+            # default: forward
+            cypher = """
+            MATCH (start {graph_id: $graph_id})
+            WHERE start.qualified_name = $source_symbol OR start.id = $source_symbol
+            MATCH path = (start)-[:FLOWS_TO*1..$depth]->(sink)
+            RETURN
+                [node IN nodes(path) | coalesce(node.qualified_name, node.name)] AS path_nodes,
+                [node IN nodes(path) | labels(node)[0]]                          AS path_labels,
+                length(path)                                                       AS depth
+            ORDER BY depth
+            LIMIT $limit
+            """
+
+        result = await driver.execute_query(
+            cypher,
+            {
+                "graph_id": graph_id,
+                "source_symbol": source_symbol,
+                "depth": depth,
+                "limit": limit,
+            },
+        )
+        return [
+            {
+                "path_nodes": r["path_nodes"],
+                "path_labels": r["path_labels"],
+                "depth": r["depth"],
+            }
+            for r in result.records
+        ]
 
     raise _QueryParamError(f"Unknown query_type: {query_type}")

--- a/knowledge-graph-builder/app/schemas/code_schemas.py
+++ b/knowledge-graph-builder/app/schemas/code_schemas.py
@@ -54,6 +54,7 @@ class CodeQueryType(StrEnum):
     inheritance_chain = "inheritance_chain"
     file_deps = "file_deps"
     semantic_search = "semantic_search"
+    data_flow = "data_flow"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/knowledge-graph-builder/app/services/background_jobs.py
+++ b/knowledge-graph-builder/app/services/background_jobs.py
@@ -1618,11 +1618,33 @@ def code_ingest_task(self, job_id: str, user_id: str) -> dict[str, Any]:
                 f"[{job_id}] Stage 5 done: {stats.symbols_added} symbols written"
             )
 
-            # ── Stage 6: Stale Cleanup ─────────────────────────────────────
+            # ── Stage 6: Data Flow Analysis (Python only) ─────────────────
+            # Runs after write_code_graph_sync so all Function/Variable/Class
+            # nodes are already in Neo4j and can be referenced by FLOWS_TO edges.
+            # Uses the same sync driver (WorkerNeo4jManager / NullPool).
+            try:
+                from app.services.data_flow_analyzer import DataFlowAnalyzer
+
+                python_files = [f for f in to_parse if f.language == "python"]
+                if python_files:
+                    dfa = DataFlowAnalyzer(sync_driver=driver)
+                    flows_written = dfa.analyze_files(python_files, graph_id)
+                    logger.info(
+                        f"[{job_id}] Stage 6: DataFlowAnalyzer wrote "
+                        f"{flows_written} FLOWS_TO edges for "
+                        f"{len(python_files)} Python file(s)"
+                    )
+            except Exception as dfa_exc:
+                # Non-fatal — data flow analysis failure must not abort ingestion
+                logger.warning(
+                    f"[{job_id}] DataFlowAnalyzer failed (non-fatal): {dfa_exc}"
+                )
+
+            # ── Stage 7: Stale Cleanup ─────────────────────────────────────
             if mode == "full":
                 with driver.session() as session:
                     deleted = cleanup_stale_code_nodes_sync(graph_id, session)
-                logger.info(f"[{job_id}] Stage 6: cleaned up {deleted} stale nodes")
+                logger.info(f"[{job_id}] Stage 7: cleaned up {deleted} stale nodes")
 
         _pg_update_job(job_id, "completed", 100, {"symbols_added": stats.symbols_added})
         logger.info(

--- a/knowledge-graph-builder/app/services/data_flow_analyzer.py
+++ b/knowledge-graph-builder/app/services/data_flow_analyzer.py
@@ -1,0 +1,591 @@
+"""
+Data Flow Analyzer — intra-procedural Python data flow analysis.
+
+Produces FLOWS_TO edges in Neo4j connecting existing Function/Variable/Class
+nodes (written by code_parser_service.py).
+
+Phase 1 scope: Python intra-procedural only.
+
+Flow tracking rules:
+  1. Parameter → local var via assignment  → FLOWS_TO {via: "assignment"}
+  2. Local var  → return value             → FLOWS_TO {via: "return"}
+  3. Local var  → function argument        → FLOWS_TO {via: "argument"}
+  4. Augmented assignment: x = x + y      → both x and y flow into new x
+
+Taint source heuristics:
+  Function name contains: view, handler, endpoint, route, request
+  OR decorator includes: @app.route, @router., @api_view
+  → first parameter marked with taint: "user_input"
+
+Architecture invariants honoured:
+  - graph_id on every FLOWS_TO edge — no exceptions
+  - Parameterised Cypher only — never string-interpolate IDs or graph_id
+  - WorkerNeo4jManager (sync NullPool) — never async_driver here
+  - Python built-in ast module — not Tree-sitter
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Taint heuristics
+# ─────────────────────────────────────────────────────────────────────────────
+
+_TAINT_NAME_PATTERNS = re.compile(
+    r"(view|handler|endpoint|route|request)", re.IGNORECASE
+)
+_TAINT_DECORATOR_PATTERNS = re.compile(
+    r"(app\.route|router\.|api_view)", re.IGNORECASE
+)
+
+
+def _is_taint_source(func_name: str, decorator_names: list[str]) -> bool:
+    """Return True if the function is an HTTP entry-point (taint source)."""
+    if _TAINT_NAME_PATTERNS.search(func_name):
+        return True
+    for dec in decorator_names:
+        if _TAINT_DECORATOR_PATTERNS.search(dec):
+            return True
+    return False
+
+
+def _decorator_text(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Extract decorator expressions as plain strings."""
+    texts: list[str] = []
+    for dec in node.decorator_list:
+        try:
+            texts.append(ast.unparse(dec))
+        except Exception:
+            pass
+    return texts
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Internal data structures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FlowEdge:
+    """Represents one FLOWS_TO edge to write."""
+
+    source_qualified_name: str  # qualified_name of source node
+    target_qualified_name: str  # qualified_name of target node
+    via: str  # "assignment" | "return" | "argument"
+    source_line: int
+    source_file: str
+
+
+@dataclass
+class _TaintMark:
+    """A variable node that should have taint: "user_input" set."""
+
+    qualified_name: str
+
+
+@dataclass
+class _FunctionAnalysis:
+    edges: list[_FlowEdge] = field(default_factory=list)
+    taint_marks: list[_TaintMark] = field(default_factory=list)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Intra-procedural flow analysis
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FunctionFlowVisitor(ast.NodeVisitor):
+    """
+    Walk a single function body and emit flow edges.
+
+    Tracks a set of "tainted" names (parameters + variables derived from
+    parameters) within the function scope.  The tracked set grows as we see
+    assignments whose RHS references already-tracked names.
+    """
+
+    def __init__(
+        self,
+        func_qname: str,
+        param_names: list[str],
+        module_qname: str,
+        source_file: str,
+        is_taint_source: bool,
+    ) -> None:
+        self.func_qname = func_qname
+        self.module_qname = module_qname
+        self.source_file = source_file
+
+        # tracked_vars: name → qualified_name of the source node in Neo4j
+        # For parameters: the Function node is the source (they're not Variable nodes
+        # in the KG unless declared at module level).  We model them as flowing FROM
+        # the Function node.
+        self.tracked_vars: dict[str, str] = {}
+
+        # Build param set; if taint source, mark them
+        self.is_taint_source = is_taint_source
+        self.param_names = param_names
+        for pname in param_names:
+            # In the graph, function parameters are not separate Variable nodes;
+            # we model them as flowing from the Function node itself.
+            self.tracked_vars[pname] = func_qname
+
+        self.edges: list[_FlowEdge] = []
+        self.taint_marks: list[_TaintMark] = []
+
+        # If taint source, the first non-self parameter carries taint.
+        # The Variable node qualified_name would be module_qname.func_qname.param
+        # but those are not guaranteed to exist in Neo4j (only module-level
+        # annotated variables are written by code_parser_service).
+        # We record taint marks for best-effort: the write step MERGEs them only
+        # if the node already exists.
+        if is_taint_source:
+            for pname in param_names:
+                if pname not in ("self", "cls"):
+                    qname = f"{func_qname}.{pname}"
+                    self.taint_marks.append(_TaintMark(qualified_name=qname))
+                    break  # first user-facing param only
+
+    def _names_in_expr(self, node: ast.expr) -> list[str]:
+        """Collect all Name node ids referenced in an expression."""
+        names: list[str] = []
+        for n in ast.walk(node):
+            if isinstance(n, ast.Name):
+                names.append(n.id)
+        return names
+
+    def _expr_refs_tracked(self, node: ast.expr) -> list[str]:
+        """Return tracked variable names referenced in *node*."""
+        return [n for n in self._names_in_expr(node) if n in self.tracked_vars]
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """Handle simple and augmented-style assignments: x = ... """
+        rhs_tracked = self._expr_refs_tracked(node.value)
+
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                tname = target.id
+                tgt_qname = f"{self.func_qname}.{tname}"
+
+                for src_name in rhs_tracked:
+                    src_qname = self.tracked_vars[src_name]
+                    self.edges.append(
+                        _FlowEdge(
+                            source_qualified_name=src_qname,
+                            target_qualified_name=tgt_qname,
+                            via="assignment",
+                            source_line=node.lineno,
+                            source_file=self.source_file,
+                        )
+                    )
+
+                # The target now becomes tracked (derived from a tracked source)
+                if rhs_tracked:
+                    self.tracked_vars[tname] = tgt_qname
+
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        """Handle annotated assignments: x: int = ... """
+        if node.value is None:
+            return
+        rhs_tracked = self._expr_refs_tracked(node.value)
+        if isinstance(node.target, ast.Name):
+            tname = node.target.id
+            tgt_qname = f"{self.func_qname}.{tname}"
+            for src_name in rhs_tracked:
+                src_qname = self.tracked_vars[src_name]
+                self.edges.append(
+                    _FlowEdge(
+                        source_qualified_name=src_qname,
+                        target_qualified_name=tgt_qname,
+                        via="assignment",
+                        source_line=node.lineno,
+                        source_file=self.source_file,
+                    )
+                )
+            if rhs_tracked:
+                self.tracked_vars[tname] = tgt_qname
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        """Handle augmented assignments: x += y, x = x + y style."""
+        rhs_tracked = self._expr_refs_tracked(node.value)
+        if isinstance(node.target, ast.Name):
+            tname = node.target.id
+            tgt_qname = f"{self.func_qname}.{tname}"
+            # target also flows into itself (augmented)
+            all_sources = list(rhs_tracked)
+            if tname in self.tracked_vars:
+                all_sources.append(tname)
+            for src_name in all_sources:
+                src_qname = self.tracked_vars.get(src_name, f"{self.func_qname}.{src_name}")
+                self.edges.append(
+                    _FlowEdge(
+                        source_qualified_name=src_qname,
+                        target_qualified_name=tgt_qname,
+                        via="assignment",
+                        source_line=node.lineno,
+                        source_file=self.source_file,
+                    )
+                )
+            if all_sources:
+                self.tracked_vars[tname] = tgt_qname
+        self.generic_visit(node)
+
+    def visit_Return(self, node: ast.Return) -> None:
+        """Handle return statements: tracked var → function return."""
+        if node.value is None:
+            return
+        rhs_tracked = self._expr_refs_tracked(node.value)
+        for src_name in rhs_tracked:
+            src_qname = self.tracked_vars[src_name]
+            # Target is the Function node itself (represents its return value)
+            self.edges.append(
+                _FlowEdge(
+                    source_qualified_name=src_qname,
+                    target_qualified_name=self.func_qname,
+                    via="return",
+                    source_line=node.lineno,
+                    source_file=self.source_file,
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Handle function calls: tracked var passed as argument → FLOWS_TO call site."""
+        # Derive a call site qualified name
+        try:
+            callee_str = ast.unparse(node.func)
+        except Exception:
+            callee_str = "unknown"
+
+        # For positional arguments
+        for arg in node.args:
+            tracked = self._expr_refs_tracked(arg)
+            for src_name in tracked:
+                src_qname = self.tracked_vars[src_name]
+                # Target is a synthetic "call site" qualified name:
+                # module_qname.callee — best effort
+                tgt_qname = f"{self.module_qname}.{callee_str}"
+                self.edges.append(
+                    _FlowEdge(
+                        source_qualified_name=src_qname,
+                        target_qualified_name=tgt_qname,
+                        via="argument",
+                        source_line=node.lineno,
+                        source_file=self.source_file,
+                    )
+                )
+
+        # For keyword arguments
+        for kw in node.keywords:
+            if kw.value:
+                tracked = self._expr_refs_tracked(kw.value)
+                for src_name in tracked:
+                    src_qname = self.tracked_vars[src_name]
+                    tgt_qname = f"{self.module_qname}.{callee_str}"
+                    self.edges.append(
+                        _FlowEdge(
+                            source_qualified_name=src_qname,
+                            target_qualified_name=tgt_qname,
+                            via="argument",
+                            source_line=node.lineno,
+                            source_file=self.source_file,
+                        )
+                    )
+
+        self.generic_visit(node)
+
+
+def _analyze_function_ast(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    module_qname: str,
+    source_file: str,
+) -> _FunctionAnalysis:
+    """Analyse a single function AST node; return edges + taint marks."""
+    func_name = func_node.name
+    func_qname = f"{module_qname}.{func_name}" if module_qname else func_name
+
+    # Collect parameter names (skip *args, **kwargs annotations — just names)
+    param_names: list[str] = []
+    args = func_node.args
+    for arg in args.args + args.posonlyargs + args.kwonlyargs:
+        param_names.append(arg.arg)
+    if args.vararg:
+        param_names.append(args.vararg.arg)
+    if args.kwarg:
+        param_names.append(args.kwarg.arg)
+
+    decorator_texts = _decorator_text(func_node)
+    taint = _is_taint_source(func_name, decorator_texts)
+
+    visitor = _FunctionFlowVisitor(
+        func_qname=func_qname,
+        param_names=param_names,
+        module_qname=module_qname,
+        source_file=source_file,
+        is_taint_source=taint,
+    )
+    visitor.visit(func_node)
+
+    return _FunctionAnalysis(edges=visitor.edges, taint_marks=visitor.taint_marks)
+
+
+def _module_qname_from_path(file_path: str) -> str:
+    """Convert a file path to a dotted module name (mirrors code_parser_service)."""
+    p = Path(file_path)
+    parts = list(p.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Neo4j write helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MERGE_FLOWS_TO = """
+UNWIND $edges AS e
+MATCH (src {graph_id: $graph_id, qualified_name: e.src_qname})
+MATCH (tgt {graph_id: $graph_id, qualified_name: e.tgt_qname})
+MERGE (src)-[r:FLOWS_TO {
+    via: e.via,
+    graph_id: $graph_id,
+    source_file: e.source_file,
+    source_line: e.source_line
+}]->(tgt)
+RETURN count(r) AS written
+"""
+
+_MARK_TAINT = """
+UNWIND $marks AS m
+MATCH (n {graph_id: $graph_id, qualified_name: m.qname})
+SET n.taint = 'user_input'
+"""
+
+
+def _write_edges_sync(
+    session: Any,
+    graph_id: str,
+    flow_edges: list[_FlowEdge],
+    taint_marks: list[_TaintMark],
+    batch_size: int = 500,
+) -> int:
+    """Write FLOWS_TO edges + taint marks using a sync Neo4j session."""
+    total_written = 0
+
+    # Write edges in batches
+    edge_rows = [
+        {
+            "src_qname": e.source_qualified_name,
+            "tgt_qname": e.target_qualified_name,
+            "via": e.via,
+            "source_file": e.source_file,
+            "source_line": e.source_line,
+        }
+        for e in flow_edges
+    ]
+
+    for i in range(0, len(edge_rows), batch_size):
+        batch = edge_rows[i : i + batch_size]
+        result = session.run(
+            _MERGE_FLOWS_TO,
+            {"edges": batch, "graph_id": graph_id},
+        )
+        rec = result.single()
+        if rec:
+            total_written += int(rec["written"])
+
+    # Write taint marks (best-effort: nodes may not exist)
+    if taint_marks:
+        mark_rows = [{"qname": m.qualified_name} for m in taint_marks]
+        try:
+            session.run(_MARK_TAINT, {"marks": mark_rows, "graph_id": graph_id})
+        except Exception as exc:
+            logger.warning(f"Taint mark write failed (non-fatal): {exc}")
+
+    return total_written
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public interface
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class DataFlowAnalyzer:
+    """
+    Intra-procedural Python data flow analyzer.
+
+    Reads Python source via the built-in `ast` module, emits FLOWS_TO edges
+    to Neo4j using a sync driver session (WorkerNeo4jManager / NullPool).
+
+    Usage in Celery context:
+        with WorkerNeo4jManager() as neo4j:
+            driver = neo4j.get_sync_driver()
+            analyzer = DataFlowAnalyzer(driver)
+            count = analyzer.analyze_file(abs_path, graph_id)
+    """
+
+    def __init__(self, sync_driver: Any | None = None) -> None:
+        """
+        Args:
+            sync_driver: Neo4j sync driver (GraphDatabase.driver).
+                         Required for any method that writes to Neo4j.
+                         Pass None for pure AST analysis (testing / dry-run).
+        """
+        self._driver = sync_driver
+
+    # ------------------------------------------------------------------
+    # Core: analyse a single function's source
+    # ------------------------------------------------------------------
+
+    def analyze_function(
+        self,
+        function_node_id: str,
+        source_code: str,
+        graph_id: str,
+        source_file: str = "<unknown>",
+    ) -> int:
+        """
+        Parse *source_code* as a Python module, find all function definitions,
+        and write FLOWS_TO edges for each one.
+
+        Args:
+            function_node_id: The qualified_name of the function in the KG.
+                              Used to scope the analysis to this function only.
+            source_code:       Full Python source (the function's enclosing module).
+            graph_id:          Multi-tenancy scope key.
+            source_file:       Source path for edge metadata.
+
+        Returns:
+            Number of FLOWS_TO edges written to Neo4j.
+        """
+        try:
+            tree = ast.parse(source_code, filename=source_file)
+        except SyntaxError as exc:
+            logger.warning(f"DataFlowAnalyzer: syntax error in {source_file}: {exc}")
+            return 0
+
+        module_qname = _module_qname_from_path(source_file)
+        all_edges: list[_FlowEdge] = []
+        all_taint: list[_TaintMark] = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                fqname = f"{module_qname}.{node.name}" if module_qname else node.name
+                if fqname != function_node_id and node.name != function_node_id:
+                    continue  # only analyse the requested function
+                analysis = _analyze_function_ast(node, module_qname, source_file)
+                all_edges.extend(analysis.edges)
+                all_taint.extend(analysis.taint_marks)
+
+        if not all_edges and not all_taint:
+            return 0
+
+        if self._driver is None:
+            logger.debug(
+                f"DataFlowAnalyzer: no driver — dry-run for {function_node_id}"
+            )
+            return len(all_edges)
+
+        with self._driver.session() as session:
+            return _write_edges_sync(session, graph_id, all_edges, all_taint)
+
+    # ------------------------------------------------------------------
+    # Analyse an entire file
+    # ------------------------------------------------------------------
+
+    def analyze_file(self, file_path: str, graph_id: str) -> int:
+        """
+        Parse a Python file, analyse every function definition, and write
+        FLOWS_TO edges to Neo4j.
+
+        Args:
+            file_path: Absolute (or relative) path to the Python file.
+            graph_id:  Multi-tenancy scope key.
+
+        Returns:
+            Total number of FLOWS_TO edges written.
+        """
+        try:
+            source_code = Path(file_path).read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning(f"DataFlowAnalyzer: cannot read {file_path}: {exc}")
+            return 0
+
+        try:
+            tree = ast.parse(source_code, filename=file_path)
+        except SyntaxError as exc:
+            logger.warning(f"DataFlowAnalyzer: syntax error in {file_path}: {exc}")
+            return 0
+
+        module_qname = _module_qname_from_path(file_path)
+        all_edges: list[_FlowEdge] = []
+        all_taint: list[_TaintMark] = []
+
+        # Walk only top-level and class-level function definitions
+        # (we do not recurse into nested functions — Phase 1 scope)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                analysis = _analyze_function_ast(node, module_qname, file_path)
+                all_edges.extend(analysis.edges)
+                all_taint.extend(analysis.taint_marks)
+
+        if not all_edges and not all_taint:
+            return 0
+
+        if self._driver is None:
+            logger.debug(
+                f"DataFlowAnalyzer: no driver — dry-run for {file_path}, "
+                f"{len(all_edges)} edges found"
+            )
+            return len(all_edges)
+
+        with self._driver.session() as session:
+            written = _write_edges_sync(session, graph_id, all_edges, all_taint)
+
+        logger.info(
+            f"DataFlowAnalyzer: {file_path} — {written} FLOWS_TO edges written "
+            f"({len(all_taint)} taint marks)"
+        )
+        return written
+
+    # ------------------------------------------------------------------
+    # Convenience: analyse all Python files from a file_meta list
+    # ------------------------------------------------------------------
+
+    def analyze_files(
+        self,
+        file_metas: list[Any],
+        graph_id: str,
+    ) -> int:
+        """
+        Analyse all Python files in *file_metas* (FileMetadata from code_parser_service).
+
+        Args:
+            file_metas: List of FileMetadata objects; only language=="python" are processed.
+            graph_id:   Multi-tenancy scope key.
+
+        Returns:
+            Total FLOWS_TO edges written across all files.
+        """
+        total = 0
+        for fm in file_metas:
+            if getattr(fm, "language", None) != "python":
+                continue
+            try:
+                total += self.analyze_file(fm.abs_path, graph_id)
+            except Exception as exc:
+                logger.warning(
+                    f"DataFlowAnalyzer: error analysing {fm.abs_path}: {exc}"
+                )
+        return total

--- a/knowledge-graph-builder/tests/integration/test_data_flow_integration.py
+++ b/knowledge-graph-builder/tests/integration/test_data_flow_integration.py
@@ -1,0 +1,503 @@
+"""
+Integration tests for data flow analysis (STORY-004).
+
+TASK-023 — QA: data flow integration tests.
+
+IMPORTANT: These tests require a running Neo4j Docker container with TASK-022
+code deployed. Do NOT run these tests from a worktree — they target the live
+Docker stack.
+
+Run only AFTER TASK-022's PR merges to develop and the Docker stack is rebuilt:
+    cd knowledge-graph-builder
+    python -m pytest tests/integration/test_data_flow_integration.py -v -m integration
+
+Architecture invariants verified:
+  - graph_id on every FLOWS_TO edge (multi-tenancy)
+  - Cross-tenant isolation: FLOWS_TO edges from graph A not visible to graph B
+  - Parameterized Cypher: $graph_id in all data_flow queries
+  - Taint propagation: taint: "user_input" set on first param of handle_request
+  - API surface: POST /graphs/{graph_id}/code/query?query_type=data_flow
+"""
+
+from __future__ import annotations
+
+import textwrap
+import time
+from uuid import uuid4
+
+import pytest
+import requests
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Configuration — matches docker-compose service URLs
+# ─────────────────────────────────────────────────────────────────────────────
+
+_API_BASE = "http://localhost:8000/api/v1"
+_NEO4J_BOLT = "bolt://localhost:7687"
+_NEO4J_USER = "neo4j"
+_NEO4J_PASS = "password"
+
+# Unique per-test-run graph IDs prevent cross-run pollution
+_GRAPH_ID_A = f"test-task023-{uuid4().hex[:8]}"
+_GRAPH_ID_B = f"test-task023-{uuid4().hex[:8]}"  # cross-tenant isolation
+
+# Minimal Python source with one taintable function
+_TAINT_SOURCE = textwrap.dedent("""\
+    def handle_request(req, ctx):
+        data = req.body
+        result = data
+        return result
+""")
+
+# Non-taint function in same file
+_PLAIN_SOURCE = textwrap.dedent("""\
+    def compute_sum(numbers):
+        total = 0
+        total = total + sum(numbers)
+        return total
+""")
+
+_COMBINED_SOURCE = _TAINT_SOURCE + "\n" + _PLAIN_SOURCE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _neo4j_driver():
+    """Return a sync Neo4j driver (neo4j Python package)."""
+    from neo4j import GraphDatabase
+
+    return GraphDatabase.driver(
+        _NEO4J_BOLT, auth=(_NEO4J_USER, _NEO4J_PASS)
+    )
+
+
+def _api_headers(user_token: str = "integration-test-token") -> dict:
+    return {"Authorization": f"Bearer {user_token}"}
+
+
+def _wait_for_api(timeout: float = 30.0) -> None:
+    """Block until the API is responsive."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.get(
+                f"{_API_BASE.replace('/api/v1', '')}/health", timeout=2
+            )
+            if resp.status_code < 500:
+                return
+        except requests.ConnectionError:
+            pass
+        time.sleep(1.0)
+    raise RuntimeError(f"API at {_API_BASE} not reachable after {timeout}s")
+
+
+def _ingest_python_source(
+    graph_id: str,
+    source_code: str,
+    tmp_path,
+    user_token: str = "integration-test-token",
+) -> None:
+    """
+    Write source_code to a temp file and trigger code ingestion via the API.
+    Polls until the job completes.
+    """
+    py_file = tmp_path / "test_module.py"
+    py_file.write_text(source_code)
+
+    resp = requests.post(
+        f"{_API_BASE}/graphs/{graph_id}/code-ingest",
+        headers=_api_headers(user_token),
+        json={"repo_path": str(tmp_path), "mode": "full"},
+        timeout=10,
+    )
+    assert resp.status_code == 202, f"Ingest failed: {resp.status_code} {resp.text}"
+
+    job_id = resp.json()["job_id"]
+    _wait_for_job(graph_id, job_id, user_token)
+
+
+def _wait_for_job(
+    graph_id: str,
+    job_id: str,
+    user_token: str,
+    timeout: float = 60.0,
+) -> None:
+    """Poll job status until completed or failed."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = requests.get(
+            f"{_API_BASE}/graphs/{graph_id}/jobs/{job_id}",
+            headers=_api_headers(user_token),
+            timeout=5,
+        )
+        if resp.status_code == 200:
+            status = resp.json().get("status")
+            if status == "completed":
+                return
+            if status == "failed":
+                raise RuntimeError(
+                    f"Job {job_id} failed: {resp.json().get('error', 'unknown')}"
+                )
+        time.sleep(2.0)
+    raise TimeoutError(f"Job {job_id} did not complete within {timeout}s")
+
+
+def _delete_test_graph(driver, graph_id: str) -> None:
+    """Remove all nodes and edges for a test graph from Neo4j."""
+    with driver.session() as session:
+        session.run(
+            "MATCH (n {graph_id: $graph_id}) DETACH DELETE n",
+            {"graph_id": graph_id},
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def neo4j_driver_fixture():
+    """Sync Neo4j driver for direct graph inspection."""
+    driver = _neo4j_driver()
+    yield driver
+    # Teardown: delete all test graphs created by this module
+    for gid in [_GRAPH_ID_A, _GRAPH_ID_B]:
+        try:
+            _delete_test_graph(driver, gid)
+        except Exception:
+            pass
+    driver.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def wait_for_api_ready():
+    """Ensure the API is up before running any integration test."""
+    _wait_for_api()
+
+
+@pytest.fixture(scope="module")
+def ingested_graph_a(tmp_path_factory, neo4j_driver_fixture):
+    """
+    Ingest _COMBINED_SOURCE into GRAPH_ID_A once for the whole module.
+    Yields graph_id for use in tests.
+    """
+    tmp = tmp_path_factory.mktemp("data_flow_int_a")
+    _ingest_python_source(_GRAPH_ID_A, _COMBINED_SOURCE, tmp)
+    yield _GRAPH_ID_A
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1 — FLOWS_TO edges exist in Neo4j with correct graph_id
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_flows_to_edges_exist_in_neo4j(neo4j_driver_fixture, ingested_graph_a):
+    """
+    After ingesting _COMBINED_SOURCE, FLOWS_TO edges must exist in Neo4j
+    scoped to _GRAPH_ID_A.
+    """
+    with neo4j_driver_fixture.session() as session:
+        result = session.run(
+            """
+            MATCH (src)-[r:FLOWS_TO]->(tgt)
+            WHERE r.graph_id = $graph_id
+            RETURN count(r) AS edge_count
+            """,
+            {"graph_id": _GRAPH_ID_A},
+        )
+        record = result.single()
+        edge_count = record["edge_count"] if record else 0
+
+    assert edge_count >= 2, (
+        f"Expected >=2 FLOWS_TO edges for handle_request in graph {_GRAPH_ID_A}, "
+        f"got {edge_count}"
+    )
+
+
+@pytest.mark.integration
+def test_flows_to_edges_have_graph_id_property(neo4j_driver_fixture, ingested_graph_a):
+    """
+    Architecture invariant: every FLOWS_TO edge must have a graph_id property.
+    Every edge scoped to our test graph must carry graph_id == _GRAPH_ID_A.
+    """
+    with neo4j_driver_fixture.session() as session:
+        result = session.run(
+            """
+            MATCH ()-[r:FLOWS_TO]->()
+            WHERE r.graph_id = $graph_id
+            RETURN r.graph_id AS edge_graph_id, r.via AS via
+            LIMIT 20
+            """,
+            {"graph_id": _GRAPH_ID_A},
+        )
+        records = result.data()
+
+    assert len(records) >= 1, "No FLOWS_TO edges found — did ingestion run?"
+    for rec in records:
+        assert rec["edge_graph_id"] == _GRAPH_ID_A, (
+            f"Edge graph_id mismatch: expected {_GRAPH_ID_A}, "
+            f"got {rec['edge_graph_id']}"
+        )
+        assert rec["via"] in ("assignment", "return", "argument"), (
+            f"Unexpected FLOWS_TO via value: {rec['via']}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2 — API data_flow query returns the flow path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_api_data_flow_query_returns_path(ingested_graph_a):
+    """
+    POST /graphs/{graph_id}/code/query with query_type=data_flow and
+    source_symbol returns a non-empty path for handle_request.
+    """
+    resp = requests.post(
+        f"{_API_BASE}/graphs/{_GRAPH_ID_A}/code/query",
+        headers=_api_headers(),
+        json={
+            "query_type": "data_flow",
+            "params": {
+                "source_symbol": "test_module.handle_request",
+                "direction": "forward",
+                "depth": 5,
+            },
+        },
+        timeout=15,
+    )
+    assert resp.status_code == 200, (
+        f"Expected 200 from data_flow query, got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert body["query_type"] == "data_flow"
+    assert body["total"] >= 1, (
+        f"Expected at least 1 flow path for handle_request, got {body['total']}"
+    )
+    # Each result must have the expected shape
+    for result in body["results"]:
+        assert "path_nodes" in result, f"Missing 'path_nodes' in: {result}"
+        assert "depth" in result, f"Missing 'depth' in: {result}"
+        assert isinstance(result["path_nodes"], list)
+
+
+@pytest.mark.integration
+def test_api_data_flow_query_missing_source_symbol_returns_400():
+    """
+    POST /graphs/{graph_id}/code/query with data_flow but no source_symbol → 400.
+    """
+    resp = requests.post(
+        f"{_API_BASE}/graphs/{_GRAPH_ID_A}/code/query",
+        headers=_api_headers(),
+        json={
+            "query_type": "data_flow",
+            "params": {},
+        },
+        timeout=10,
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for missing source_symbol, got {resp.status_code}: {resp.text}"
+    )
+    detail = resp.json().get("detail", "")
+    assert "source_symbol" in detail.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3 — Taint property on the correct node
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_taint_property_on_first_param(neo4j_driver_fixture, ingested_graph_a):
+    """
+    handle_request is a taint source (name contains 'request').
+    Its first non-self parameter (req) must have taint: 'user_input' set in Neo4j.
+    """
+    with neo4j_driver_fixture.session() as session:
+        result = session.run(
+            """
+            MATCH (n {graph_id: $graph_id, taint: 'user_input'})
+            RETURN n.qualified_name AS qname, n.taint AS taint
+            """,
+            {"graph_id": _GRAPH_ID_A},
+        )
+        records = result.data()
+
+    assert len(records) >= 1, (
+        f"Expected at least one node with taint='user_input' in graph {_GRAPH_ID_A}"
+    )
+    tainted_qnames = [r["qname"] for r in records]
+    # The req parameter of handle_request should be tainted
+    assert any("req" in (qn or "") for qn in tainted_qnames), (
+        f"Expected 'req' param to be taint-marked, found: {tainted_qnames}"
+    )
+
+
+@pytest.mark.integration
+def test_non_taint_function_has_no_taint_marks(neo4j_driver_fixture, ingested_graph_a):
+    """
+    compute_sum is a plain function (no taint heuristic match).
+    No nodes from compute_sum should have taint: 'user_input'.
+    """
+    with neo4j_driver_fixture.session() as session:
+        result = session.run(
+            """
+            MATCH (n {graph_id: $graph_id, taint: 'user_input'})
+            WHERE n.qualified_name CONTAINS 'compute_sum'
+            RETURN count(n) AS cnt
+            """,
+            {"graph_id": _GRAPH_ID_A},
+        )
+        record = result.single()
+        cnt = record["cnt"] if record else 0
+
+    assert cnt == 0, (
+        f"compute_sum params must not be tainted, but found {cnt} tainted node(s)"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 4 — Taint query: FLOWS_TO path from tainted source to sink
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_taint_flows_to_path_via_cypher(neo4j_driver_fixture, ingested_graph_a):
+    """
+    STORY-004 acceptance criterion:
+    MATCH (source {taint: 'user_input'})-[:FLOWS_TO*1..10]->(sink)
+    returns correct path for handle_request.
+    """
+    with neo4j_driver_fixture.session() as session:
+        result = session.run(
+            """
+            MATCH (source {graph_id: $graph_id, taint: 'user_input'})
+                  -[:FLOWS_TO*1..10]->(sink)
+            RETURN
+                source.qualified_name AS source_qname,
+                sink.qualified_name   AS sink_qname
+            LIMIT 10
+            """,
+            {"graph_id": _GRAPH_ID_A},
+        )
+        records = result.data()
+
+    assert len(records) >= 1, (
+        f"Expected taint flow path in graph {_GRAPH_ID_A} — "
+        "taint source must flow to at least one sink"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 5 — Cross-tenant isolation: FLOWS_TO edges not visible from different graph_id
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_cross_tenant_isolation_flows_to_neo4j(neo4j_driver_fixture, ingested_graph_a):
+    """
+    FLOWS_TO edges stored under _GRAPH_ID_A must be invisible from _GRAPH_ID_B.
+    Zero edges returned when queried with a different graph_id.
+    _GRAPH_ID_B is a fresh UUID that never had any ingestion.
+    """
+    with neo4j_driver_fixture.session() as session:
+        result = session.run(
+            """
+            MATCH ()-[r:FLOWS_TO]->()
+            WHERE r.graph_id = $graph_id
+            RETURN count(r) AS edge_count
+            """,
+            {"graph_id": _GRAPH_ID_B},  # tenant B — never ingested
+        )
+        record = result.single()
+        edge_count = record["edge_count"] if record else 0
+
+    assert edge_count == 0, (
+        f"Cross-tenant isolation violation: found {edge_count} FLOWS_TO edges "
+        f"visible from graph {_GRAPH_ID_B} (belongs to a different tenant)"
+    )
+
+
+@pytest.mark.integration
+def test_cross_tenant_isolation_api_data_flow(ingested_graph_a):
+    """
+    API: data_flow query for graph_B with source_symbol from graph_A
+    returns empty results (not another tenant's data).
+    """
+    resp = requests.post(
+        f"{_API_BASE}/graphs/{_GRAPH_ID_B}/code/query",
+        headers=_api_headers(),
+        json={
+            "query_type": "data_flow",
+            "params": {
+                "source_symbol": "test_module.handle_request",
+            },
+        },
+        timeout=10,
+    )
+    # May return 200 with empty results, or 403/404 — all satisfy isolation
+    if resp.status_code == 200:
+        body = resp.json()
+        assert body["total"] == 0, (
+            f"Cross-tenant isolation violation: graph_B returned {body['total']} "
+            f"results for graph_A's source_symbol"
+        )
+    else:
+        # 403 or 404 also satisfies isolation requirement
+        assert resp.status_code in (403, 404), (
+            f"Unexpected status for cross-tenant query: {resp.status_code}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 6 — Performance: 500-line file analysis completes in <10s
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_500_line_file_analysis_under_10_seconds(
+    tmp_path_factory, neo4j_driver_fixture
+):
+    """
+    STORY-004 acceptance criterion: analysis of a 500-line Python file completes
+    in under 10 seconds end-to-end (ingest + FLOWS_TO edge writing).
+    """
+    perf_graph_id = f"test-task023-perf-{uuid4().hex[:8]}"
+
+    # Generate a ~500-line Python file: 25 functions, each ~20 lines
+    lines = []
+    for i in range(25):
+        lines.append(f"def func_{i:03d}(param_{i}, extra):")
+        lines.append(f"    x_{i} = param_{i}")
+        lines.append(f"    y_{i} = x_{i}")
+        for j in range(8):
+            lines.append(f"    z_{i}_{j} = x_{i}")
+        lines.append(f"    process(y_{i})")
+        lines.append(f"    return y_{i}")
+        lines.append("")
+
+    source = "\n".join(lines)
+
+    tmp = tmp_path_factory.mktemp("perf_test")
+
+    start = time.monotonic()
+    try:
+        _ingest_python_source(perf_graph_id, source, tmp)
+    finally:
+        # Always cleanup — even if assertion fails
+        try:
+            _delete_test_graph(neo4j_driver_fixture, perf_graph_id)
+        except Exception:
+            pass
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 10.0, (
+        f"500-line file analysis took {elapsed:.2f}s — must complete in <10s "
+        "(STORY-004 acceptance criterion)"
+    )

--- a/knowledge-graph-builder/tests/unit/test_data_flow_analyzer.py
+++ b/knowledge-graph-builder/tests/unit/test_data_flow_analyzer.py
@@ -1,31 +1,39 @@
 """
 Unit tests for data_flow_analyzer.py
 
-Covers (per TASK-022 Definition of Done):
-  #1  — parameter → local var via assignment   → FLOWS_TO {via: "assignment"}
-  #2  — local var → return value               → FLOWS_TO {via: "return"}
-  #3  — local var → function argument          → FLOWS_TO {via: "argument"}
-  #4  — taint source: handle_request → first param tainted
-  #5  — graph_id on every edge
-  #6  — augmented assignment: x = x + y, both x and y flow into new x
-  #7  — non-taint function: no taint marks produced
-  #8  — decorator taint heuristic (@app.route)
+TASK-023 — QA: data flow analysis tests (FLOWS_TO edges, taint marking).
+Verifies all STORY-004 acceptance criteria for the DataFlowAnalyzer service
+produced by TASK-022.
+
+Coverage:
+  #1  — x = param; return x → 2 FLOWS_TO edges: param→x (assignment), x→fn (return)
+  #2  — foo(x) call → FLOWS_TO {via: "argument"} edge
+  #3  — taint: @router.get(...) decorator → params have taint: "user_input"
+  #4  — taint: function named handle_request → first param tainted
+  #5  — no FLOWS_TO edges for variables never derived from parameters
+  #6  — graph_id present on every edge (Cypher template + dry-run assertions)
+  #7  — augmented assignment: both sources tracked
+  #8  — decorator taint heuristics (@app.route, @router., @api_view)
   #9  — analyze_file returns correct edge count (dry-run, no Neo4j)
+  #10 — _module_qname_from_path helper
+  #11 — self/cls excluded from taint marks
+  #12 — non-taint function produces zero taint marks
 """
 
 from __future__ import annotations
+
+import ast
 
 import pytest
 
 from app.services.data_flow_analyzer import (
     DataFlowAnalyzer,
-    _FunctionFlowVisitor,
+    _MARK_TAINT,
+    _MERGE_FLOWS_TO,
     _analyze_function_ast,
     _is_taint_source,
     _module_qname_from_path,
 )
-
-import ast
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -44,91 +52,79 @@ def _parse_first_function(
     raise ValueError("No function found in source")
 
 
-def _edges_from_source(source: str, module_qname: str = "mymodule", source_file: str = "mymodule.py"):
-    """Convenience: analyse first function in *source*, return list of _FlowEdge."""
+def _edges_from_source(
+    source: str,
+    module_qname: str = "mymodule",
+    source_file: str = "mymodule.py",
+):
+    """
+    Convenience helper: parse *source*, analyse the first function found,
+    return (edges, taint_marks).
+    """
     func_node = _parse_first_function(source)
     analysis = _analyze_function_ast(func_node, module_qname, source_file)
     return analysis.edges, analysis.taint_marks
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test #1 — parameter → local var via assignment
+# Test #1 — x = param; return x → 2 FLOWS_TO edges
+# Task requirement: "analyze_function() on `x = param; return x` → 2 FLOWS_TO edges:
+#   param→x (assignment), x→return_value (return)"
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.unit
-def test_parameter_to_local_var_assignment():
+def test_assignment_then_return_produces_two_edges():
     """
-    def fn(data):
-        result = data   # data (param) flows into result
+    def fn(param):
+        x = param      # FLOWS_TO {via: "assignment"}
+        return x       # FLOWS_TO {via: "return"}
+
+    Must produce exactly 2 edges: one assignment, one return.
     """
     source = """\
-def fn(data):
-    result = data
+def fn(param):
+    x = param
+    return x
 """
     edges, _ = _edges_from_source(source, "mod", "mod.py")
 
     assignment_edges = [e for e in edges if e.via == "assignment"]
-    assert len(assignment_edges) >= 1, "Expected at least one assignment edge"
-
-    # The source should be the function node (parameters flow FROM the function)
-    edge = assignment_edges[0]
-    assert "fn" in edge.source_qualified_name, (
-        f"Expected source to reference fn, got: {edge.source_qualified_name}"
-    )
-    assert "result" in edge.target_qualified_name, (
-        f"Expected target to reference result, got: {edge.target_qualified_name}"
-    )
-    assert edge.via == "assignment"
-
-
-@pytest.mark.unit
-def test_parameter_to_multiple_vars():
-    """Two assignments from the same param produce two edges."""
-    source = """\
-def fn(x):
-    a = x
-    b = x
-"""
-    edges, _ = _edges_from_source(source)
-    assignment_edges = [e for e in edges if e.via == "assignment"]
-    assert len(assignment_edges) == 2
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Test #2 — local var → return value
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.unit
-def test_local_var_to_return():
-    """
-    def fn(x):
-        result = x
-        return result  # result flows into the function return
-    """
-    source = """\
-def fn(x):
-    result = x
-    return result
-"""
-    edges, _ = _edges_from_source(source, "mod", "mod.py")
-
     return_edges = [e for e in edges if e.via == "return"]
-    assert len(return_edges) >= 1, "Expected at least one return edge"
 
-    edge = return_edges[0]
-    # Source should be the local var (result) or param (x)
-    assert edge.via == "return"
-    # Target should be the function node itself
-    assert "fn" in edge.target_qualified_name
+    assert len(assignment_edges) >= 1, (
+        f"Expected >=1 assignment edge for `x = param`, got {assignment_edges}"
+    )
+    assert len(return_edges) >= 1, (
+        f"Expected >=1 return edge for `return x`, got {return_edges}"
+    )
+
+    # Verify assignment edge: param → x
+    assign_edge = assignment_edges[0]
+    assert "fn" in assign_edge.source_qualified_name, (
+        f"Source of assignment edge should reference 'fn' (the function node representing param), "
+        f"got: {assign_edge.source_qualified_name}"
+    )
+    assert "x" in assign_edge.target_qualified_name, (
+        f"Target of assignment edge should reference 'x', "
+        f"got: {assign_edge.target_qualified_name}"
+    )
+
+    # Verify return edge: x → function (return value)
+    return_edge = return_edges[0]
+    assert "fn" in return_edge.target_qualified_name, (
+        f"Target of return edge should reference the function 'fn', "
+        f"got: {return_edge.target_qualified_name}"
+    )
 
 
 @pytest.mark.unit
-def test_direct_param_return():
+def test_direct_param_return_produces_return_edge():
     """
     def fn(x):
-        return x   # param x flows directly to return
+        return x   # param x flows directly to return (no intermediate var)
+
+    Produces at least 1 return edge.
     """
     source = """\
 def fn(x):
@@ -136,40 +132,64 @@ def fn(x):
 """
     edges, _ = _edges_from_source(source, "mod", "mod.py")
     return_edges = [e for e in edges if e.via == "return"]
-    assert len(return_edges) >= 1
-    # Source is the function (representing the parameter)
+    assert len(return_edges) >= 1, "Expected return edge for `return x`"
     assert "fn" in return_edges[0].source_qualified_name
 
 
+@pytest.mark.unit
+def test_assignment_edge_direction():
+    """Verify assignment edge direction: source is function (param), target has var name."""
+    source = """\
+def process(data):
+    result = data
+"""
+    edges, _ = _edges_from_source(source, "svc", "svc.py")
+    assignment_edges = [e for e in edges if e.via == "assignment"]
+    assert len(assignment_edges) >= 1
+
+    edge = assignment_edges[0]
+    assert edge.via == "assignment"
+    assert "result" in edge.target_qualified_name, (
+        f"Expected target to contain 'result', got {edge.target_qualified_name}"
+    )
+
+
 # ─────────────────────────────────────────────────────────────────────────────
-# Test #3 — local var → function argument
+# Test #2 — foo(x) call → FLOWS_TO {via: "argument"} edge
+# Task requirement: "analyze_function() on `foo(x)` → FLOWS_TO {via: 'argument'} edge"
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.unit
-def test_local_var_to_argument():
+def test_call_argument_produces_argument_edge():
     """
-    def fn(user_input):
-        safe = sanitize(user_input)   # user_input flows into sanitize(...)
+    def fn(x):
+        foo(x)     # FLOWS_TO {via: "argument"}
+
+    x is a parameter; passing it to foo() must produce an argument edge.
     """
     source = """\
-def fn(user_input):
-    safe = sanitize(user_input)
+def fn(x):
+    foo(x)
 """
     edges, _ = _edges_from_source(source, "mod", "mod.py")
 
     arg_edges = [e for e in edges if e.via == "argument"]
-    assert len(arg_edges) >= 1, "Expected at least one argument edge"
+    assert len(arg_edges) >= 1, (
+        f"Expected >=1 argument edge for `foo(x)`, got {arg_edges}"
+    )
 
     edge = arg_edges[0]
     assert edge.via == "argument"
-    # Source should be the function (param flows from fn node)
-    assert "fn" in edge.source_qualified_name
+    # Source is the function node (parameter flows from fn)
+    assert "fn" in edge.source_qualified_name, (
+        f"Source of argument edge should reference 'fn', got: {edge.source_qualified_name}"
+    )
 
 
 @pytest.mark.unit
-def test_derived_var_to_argument():
-    """Local variable derived from a param also flows to call argument."""
+def test_derived_variable_to_call_argument():
+    """Variable derived from param also flows as argument."""
     source = """\
 def fn(raw):
     processed = raw
@@ -177,18 +197,92 @@ def fn(raw):
 """
     edges, _ = _edges_from_source(source, "mod", "mod.py")
     arg_edges = [e for e in edges if e.via == "argument"]
-    assert len(arg_edges) >= 1
+    assert len(arg_edges) >= 1, "Expected argument edge for execute(processed)"
+
+
+@pytest.mark.unit
+def test_keyword_argument_produces_argument_edge():
+    """Keyword arguments from tracked vars also produce argument edges."""
+    source = """\
+def fn(data):
+    save(record=data)
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    arg_edges = [e for e in edges if e.via == "argument"]
+    assert len(arg_edges) >= 1, "Expected argument edge for keyword argument"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test #4 — taint source: function named handle_request → first param tainted
+# Test #3 — taint: @router.get(...) decorator → params have taint: "user_input"
+# Task requirement: "Taint: function with @router.get(...) decorator → params have taint: 'user_input'"
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.unit
-def test_taint_source_by_function_name():
+def test_router_get_decorator_taints_params():
     """
-    Functions with 'request' in the name should have first param marked tainted.
+    @router.get('/items')
+    def list_items(request):
+        ...
+
+    request param must be taint-marked.
+    """
+    source = """\
+@router.get('/items')
+def list_items(request):
+    data = request.query_params
+    return data
+"""
+    _, taint_marks = _edges_from_source(source, "api.endpoints", "api/endpoints.py")
+
+    assert len(taint_marks) >= 1, (
+        "Expected taint marks for @router.get decorated function"
+    )
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("request" in qn for qn in taint_qnames), (
+        f"Expected 'request' param in taint marks, got: {taint_qnames}"
+    )
+
+
+@pytest.mark.unit
+def test_router_post_decorator_is_taint_source():
+    """@router.post also marks as taint source via _is_taint_source."""
+    assert _is_taint_source("create_item", ["router.post('/items')"]) is True
+
+
+@pytest.mark.unit
+def test_app_route_decorator_taints_params():
+    """@app.route marks function as taint source."""
+    source = """\
+@app.route('/submit', methods=['POST'])
+def submit_form(request):
+    return request.form
+"""
+    _, taint_marks = _edges_from_source(source)
+    assert len(taint_marks) >= 1
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("request" in qn for qn in taint_qnames)
+
+
+@pytest.mark.unit
+def test_api_view_decorator_is_taint_source():
+    """@api_view marks function as taint source via _is_taint_source."""
+    assert _is_taint_source("my_view", ["api_view(['GET', 'POST'])"]) is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #4 — taint: function named handle_request → first param tainted
+# Task requirement: "Taint: function named handle_request → first param tainted"
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_handle_request_name_taints_first_param():
+    """
+    def handle_request(req, context):
+        ...
+
+    First non-self param (req) should be taint-marked.
     """
     source = """\
 def handle_request(req, context):
@@ -196,60 +290,193 @@ def handle_request(req, context):
     return data
 """
     _, taint_marks = _edges_from_source(source, "views", "views.py")
-    assert len(taint_marks) >= 1, "Expected at least one taint mark"
-    # First non-self param (req) should be marked
+
+    assert len(taint_marks) >= 1, "Expected taint mark for handle_request"
     taint_qnames = [m.qualified_name for m in taint_marks]
     assert any("req" in qn for qn in taint_qnames), (
-        f"Expected 'req' param in taint marks, got: {taint_qnames}"
+        f"Expected 'req' in taint marks, got: {taint_qnames}"
     )
 
 
 @pytest.mark.unit
-def test_taint_source_view_name():
-    """Function named 'user_view' should be a taint source."""
-    source = """\
-def user_view(request):
-    return request.data
-"""
-    _, taint_marks = _edges_from_source(source, "views")
-    assert len(taint_marks) >= 1
+def test_taint_name_heuristics_match():
+    """_is_taint_source matches view, handler, endpoint, route, request in name."""
+    assert _is_taint_source("handle_request", []) is True
+    assert _is_taint_source("list_view", []) is True
+    assert _is_taint_source("route_handler", []) is True
+    assert _is_taint_source("create_endpoint", []) is True
+    assert _is_taint_source("user_handler", []) is True
+    # Non-matching names
+    assert _is_taint_source("compute_sum", []) is False
+    assert _is_taint_source("parse_config", []) is False
 
 
 @pytest.mark.unit
-def test_taint_source_endpoint_name():
-    """Function containing 'endpoint' in name → taint source."""
+def test_taint_first_param_only_not_second():
+    """Only the first non-self parameter gets tainted."""
     source = """\
-def create_endpoint(payload, auth):
-    return payload
+def handle_request(req, other):
+    pass
 """
-    _, taint_marks = _edges_from_source(source)
-    assert len(taint_marks) >= 1
-    taint_qnames = [m.qualified_name for m in taint_marks]
-    assert any("payload" in qn for qn in taint_qnames)
+    _, taint_marks = _edges_from_source(source, "mod", "mod.py")
+    # There should be exactly one taint mark for 'req'
+    assert len(taint_marks) == 1
+    assert "req" in taint_marks[0].qualified_name
 
 
 @pytest.mark.unit
-def test_non_taint_function_no_marks():
-    """Regular function should produce no taint marks."""
+def test_self_param_excluded_from_taint():
+    """self is not a user-controlled parameter and must not be taint-marked."""
     source = """\
-def compute_average(numbers):
-    total = sum(numbers)
-    return total / len(numbers)
+class MyView:
+    def handle_request(self, request):
+        return request.data
 """
-    _, taint_marks = _edges_from_source(source)
-    assert len(taint_marks) == 0, f"Expected no taint marks, got: {taint_marks}"
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            analysis = _analyze_function_ast(node, "myapp.MyView", "myapp.py")
+            taint_qnames = [m.qualified_name for m in analysis.taint_marks]
+            assert not any("self" in qn for qn in taint_qnames), (
+                f"'self' must not appear in taint marks: {taint_qnames}"
+            )
+            if analysis.taint_marks:
+                assert any("request" in qn for qn in taint_qnames), (
+                    f"'request' should be taint-marked, got: {taint_qnames}"
+                )
+            break
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test #5 — graph_id on every edge (checked via DataFlowAnalyzer dry-run)
+# Test #5 — no FLOWS_TO edges for variables never derived from parameters
+# Task requirement: "No FLOWS_TO edges for variables never derived from parameters"
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.unit
-def test_graph_id_on_every_edge_metadata(tmp_path):
+def test_no_edges_for_untracked_local_variable():
     """
-    DataFlowAnalyzer.analyze_file() in dry-run (no driver) returns correct edge
-    count. Separately verify that the Cypher template includes $graph_id.
+    def fn(param):
+        unrelated = 42          # never derived from param → no edge
+        result = param          # derived from param → edge
+        return result
+
+    `unrelated` must not appear as an edge source or target.
+    """
+    source = """\
+def fn(param):
+    unrelated = 42
+    result = param
+    return result
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    # Collect all qualified names appearing in edges
+    edge_names = set()
+    for e in edges:
+        edge_names.add(e.source_qualified_name)
+        edge_names.add(e.target_qualified_name)
+
+    assert not any("unrelated" in name for name in edge_names), (
+        f"'unrelated' (never derived from param) must not appear in edges: {edge_names}"
+    )
+
+
+@pytest.mark.unit
+def test_no_edges_for_pure_constant_function():
+    """
+    def fn():
+        x = 42
+        return x
+
+    No parameters → no tracked vars → zero FLOWS_TO edges.
+    """
+    source = """\
+def fn():
+    x = 42
+    return x
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    assert len(edges) == 0, (
+        f"Expected 0 edges for function with no params, got: {edges}"
+    )
+
+
+@pytest.mark.unit
+def test_only_param_derived_vars_generate_edges():
+    """Mixed function: only param-derived assignments produce edges."""
+    source = """\
+def fn(x):
+    a = x       # tracked: x is a param → edge
+    b = 100     # not tracked: 100 is a literal
+    c = a       # tracked: a is derived from x → edge
+    d = b       # NOT tracked: b is not param-derived
+    return c
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    edge_targets = [e.target_qualified_name for e in edges]
+    # 'd' is assigned from 'b' (not tracked), so the local var 'd' must not be a flow target.
+    # Check with a trailing-dot or end-of-string anchor to avoid matching 'd' inside other names.
+    assert not any(t.endswith(".d") or t == "d" for t in edge_targets), (
+        f"'d' (derived from non-param 'b') must not be a flow target: {edge_targets}"
+    )
+    # 'c' is assigned from 'a' (tracked), so it must appear as a target
+    assert any(t.endswith(".c") or t == "c" for t in edge_targets), (
+        f"'c' (derived from param-tracked 'a') must appear as flow target: {edge_targets}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #6 — graph_id present on every edge
+# Task requirement: "graph_id present on every edge"
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_graph_id_in_merge_flows_to_cypher():
+    """
+    Architecture invariant: MERGE_FLOWS_TO Cypher must reference $graph_id.
+    Every FLOWS_TO edge must be scoped to a graph_id — no exceptions.
+    """
+    assert "$graph_id" in _MERGE_FLOWS_TO, (
+        "FLOWS_TO MERGE Cypher must use $graph_id parameter "
+        "(architecture invariant: graph_id on every FLOWS_TO edge)"
+    )
+
+
+@pytest.mark.unit
+def test_graph_id_in_mark_taint_cypher():
+    """
+    Multi-tenancy invariant: taint mark Cypher must also scope by $graph_id.
+    """
+    assert "$graph_id" in _MARK_TAINT, (
+        "_MARK_TAINT Cypher must use $graph_id (multi-tenancy invariant)"
+    )
+
+
+@pytest.mark.unit
+def test_graph_id_not_hardcoded_in_cypher():
+    """
+    Parameterized Cypher invariant: graph_id must never be string-interpolated.
+    Both Cypher templates must use the $ parameter syntax only.
+    """
+    # Check MERGE_FLOWS_TO does not hardcode any graph_id value
+    assert "graph_id: '" not in _MERGE_FLOWS_TO, (
+        "MERGE_FLOWS_TO must not hardcode graph_id values"
+    )
+    assert 'graph_id: "' not in _MERGE_FLOWS_TO, (
+        "MERGE_FLOWS_TO must not hardcode graph_id values"
+    )
+    assert "graph_id: '" not in _MARK_TAINT
+    assert 'graph_id: "' not in _MARK_TAINT
+
+
+@pytest.mark.unit
+def test_dry_run_returns_edge_count_with_graph_id(tmp_path):
+    """
+    DataFlowAnalyzer.analyze_file() dry-run (sync_driver=None) counts edges correctly.
+    The graph_id parameter is passed through even in dry-run.
     """
     source = """\
 def process(user_input):
@@ -259,42 +486,47 @@ def process(user_input):
     py_file = tmp_path / "service.py"
     py_file.write_text(source)
 
-    # Dry-run: pass no driver
+    graph_id = "test-task023-graph-id"
     analyzer = DataFlowAnalyzer(sync_driver=None)
-    count = analyzer.analyze_file(str(py_file), graph_id="test-graph-id-123")
-    assert count >= 1, "Expected at least one edge from dry-run"
+    count = analyzer.analyze_file(str(py_file), graph_id=graph_id)
 
-
-@pytest.mark.unit
-def test_graph_id_in_cypher_template():
-    """The MERGE_FLOWS_TO Cypher must reference $graph_id — architecture invariant."""
-    from app.services.data_flow_analyzer import _MERGE_FLOWS_TO
-
-    assert "$graph_id" in _MERGE_FLOWS_TO, (
-        "FLOWS_TO MERGE query must use $graph_id parameter (architecture invariant)"
+    # `result = user_input` → 1 assignment edge
+    # `return result` → 1 return edge
+    assert count >= 2, (
+        f"Expected >=2 edges for `result = user_input; return result`, got {count}"
     )
 
 
 @pytest.mark.unit
-def test_taint_cypher_includes_graph_id():
-    """The taint mark Cypher must also scope by $graph_id."""
-    from app.services.data_flow_analyzer import _MARK_TAINT
+def test_flows_to_edge_graph_id_passed_as_parameter():
+    """
+    Verify the Cypher write step passes graph_id as a query *parameter* (not interpolated).
+    The $graph_id token in the Cypher string paired with graph_id in the params dict
+    is the architectural requirement.
+    """
+    import re
 
-    assert "$graph_id" in _MARK_TAINT, (
-        "_MARK_TAINT Cypher must use $graph_id (multi-tenancy invariant)"
+    # The Cypher template should contain $graph_id (parameterised)
+    assert "$graph_id" in _MERGE_FLOWS_TO
+    # It should NOT contain graph_id as a formatted string literal
+    hardcoded_pattern = re.compile(r"graph_id:\s*['\"]")
+    assert not hardcoded_pattern.search(_MERGE_FLOWS_TO), (
+        "MERGE_FLOWS_TO must use $graph_id parameter, not hardcoded string"
     )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test #6 — augmented assignment
+# Additional coverage — augmented assignment, chained flows, multi-function file
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.unit
-def test_augmented_assignment_both_sources_tracked():
+def test_augmented_assignment_produces_edges_from_both_sides():
     """
     def fn(x, y):
-        x += y   # both x and y flow into x
+        x += y   # x and y (both params) flow into x
+
+    Both sources should appear in assignment edges.
     """
     source = """\
 def fn(x, y):
@@ -302,9 +534,9 @@ def fn(x, y):
 """
     edges, _ = _edges_from_source(source, "mod", "mod.py")
     assignment_edges = [e for e in edges if e.via == "assignment"]
-    # x+=y: x flows into x (augmented) AND y flows into x
     assert len(assignment_edges) >= 2, (
-        f"Expected >=2 assignment edges for augmented assignment, got {len(assignment_edges)}"
+        f"Expected >=2 assignment edges for augmented assignment `x += y`, "
+        f"got {assignment_edges}"
     )
 
 
@@ -312,9 +544,11 @@ def fn(x, y):
 def test_compound_assignment_chain():
     """
     def fn(a):
-        b = a
-        c = b   # b (derived) flows into c
-        return c
+        b = a    # param → b
+        c = b    # b → c (derived)
+        return c # c → fn (return)
+
+    3 edges minimum.
     """
     source = """\
 def fn(a):
@@ -327,66 +561,23 @@ def fn(a):
     assert len([e for e in edges if e.via == "return"]) >= 1
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Test #7 — taint heuristic: decorator @app.route
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 @pytest.mark.unit
-def test_taint_source_app_route_decorator():
-    """@app.route decorator marks first param as taint source."""
+def test_non_taint_function_no_marks():
+    """Regular function (no taint heuristic match) produces zero taint marks."""
     source = """\
-@app.route("/create", methods=["POST"])
-def create(request):
-    data = request.json
-    return data
+def compute_average(numbers):
+    total = sum(numbers)
+    return total
 """
     _, taint_marks = _edges_from_source(source)
-    assert len(taint_marks) >= 1
-    taint_qnames = [m.qualified_name for m in taint_marks]
-    assert any("request" in qn for qn in taint_qnames)
+    assert len(taint_marks) == 0, (
+        f"Expected no taint marks for non-taint function, got: {taint_marks}"
+    )
 
 
 @pytest.mark.unit
-def test_taint_source_router_decorator():
-    """@router.get / @router.post marks function as taint source."""
-    assert _is_taint_source("my_func", ["router.get('/path')"]) is True
-
-
-@pytest.mark.unit
-def test_taint_source_api_view_decorator():
-    """@api_view marks function as taint source."""
-    assert _is_taint_source("my_func", ["api_view(['GET'])"]) is True
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Test #8 — _is_taint_source helper
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.unit
-def test_is_taint_source_by_name():
-    assert _is_taint_source("handle_request", []) is True
-    assert _is_taint_source("list_view", []) is True
-    assert _is_taint_source("route_handler", []) is True
-    assert _is_taint_source("compute_sum", []) is False
-
-
-@pytest.mark.unit
-def test_is_taint_source_by_decorator():
-    assert _is_taint_source("my_fn", ["app.route('/path')"]) is True
-    assert _is_taint_source("my_fn", ["router.post('/items')"]) is True
-    assert _is_taint_source("my_fn", ["login_required"]) is False
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Test #9 — analyze_file edge counting (dry-run, no Neo4j)
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.unit
-def test_analyze_file_returns_edge_count(tmp_path):
-    """analyze_file in dry-run mode returns the correct edge count."""
+def test_analyze_file_multiple_functions(tmp_path):
+    """analyze_file counts edges across all functions in a file."""
     source = """\
 def first(a, b):
     x = a
@@ -403,27 +594,15 @@ def second(p):
     analyzer = DataFlowAnalyzer(sync_driver=None)
     count = analyzer.analyze_file(str(py_file), graph_id="g-123")
 
-    # first(): a→x (assignment), b→y (assignment), x→return = 3 edges
-    # second(): p→q (assignment), q→process (argument) = 2 edges
+    # first(): a→x (1 assign), b→y (1 assign), x→fn (1 return) = 3 edges
+    # second(): p→q (1 assign), q→process (1 argument) = 2 edges
     # Total: 5 edges minimum
-    assert count >= 5, f"Expected >=5 edges, got {count}"
+    assert count >= 5, f"Expected >=5 edges across 2 functions, got {count}"
 
 
 @pytest.mark.unit
-def test_analyze_file_skips_non_python(tmp_path):
-    """analyze_file returns 0 for non-Python files (not a crash)."""
-    ts_file = tmp_path / "app.ts"
-    ts_file.write_text("const x = 1;")
-
-    analyzer = DataFlowAnalyzer(sync_driver=None)
-    # TypeScript file — SyntaxError on parse → graceful 0
-    count = analyzer.analyze_file(str(ts_file), graph_id="g-ts")
-    assert count == 0
-
-
-@pytest.mark.unit
-def test_analyze_file_syntax_error_returns_zero(tmp_path):
-    """analyze_file handles SyntaxError gracefully."""
+def test_analyze_file_graceful_on_syntax_error(tmp_path):
+    """analyze_file handles SyntaxError gracefully, returns 0."""
     bad_file = tmp_path / "broken.py"
     bad_file.write_text("def fn(: pass")
 
@@ -432,41 +611,10 @@ def test_analyze_file_syntax_error_returns_zero(tmp_path):
     assert count == 0
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Test #10 — module_qname helper
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 @pytest.mark.unit
 def test_module_qname_from_path():
+    """_module_qname_from_path mirrors code_parser_service path conversion."""
     assert _module_qname_from_path("app/services/data_flow_analyzer.py") == (
         "app.services.data_flow_analyzer"
     )
     assert _module_qname_from_path("main.py") == "main"
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Test #11 — self/cls excluded from taint marks
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-@pytest.mark.unit
-def test_self_param_excluded_from_taint():
-    """self is not a user-controlled parameter and must not be taint-marked."""
-    source = """\
-class MyView:
-    def handle_request(self, request):
-        return request.data
-"""
-    tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            analysis = _analyze_function_ast(node, "myapp.MyView", "myapp.py")
-            taint_qnames = [m.qualified_name for m in analysis.taint_marks]
-            # self should not be marked, request should be
-            assert not any("self" in qn for qn in taint_qnames), (
-                f"'self' should not be in taint marks: {taint_qnames}"
-            )
-            if analysis.taint_marks:
-                assert any("request" in qn for qn in taint_qnames)
-            break

--- a/knowledge-graph-builder/tests/unit/test_data_flow_analyzer.py
+++ b/knowledge-graph-builder/tests/unit/test_data_flow_analyzer.py
@@ -1,0 +1,472 @@
+"""
+Unit tests for data_flow_analyzer.py
+
+Covers (per TASK-022 Definition of Done):
+  #1  — parameter → local var via assignment   → FLOWS_TO {via: "assignment"}
+  #2  — local var → return value               → FLOWS_TO {via: "return"}
+  #3  — local var → function argument          → FLOWS_TO {via: "argument"}
+  #4  — taint source: handle_request → first param tainted
+  #5  — graph_id on every edge
+  #6  — augmented assignment: x = x + y, both x and y flow into new x
+  #7  — non-taint function: no taint marks produced
+  #8  — decorator taint heuristic (@app.route)
+  #9  — analyze_file returns correct edge count (dry-run, no Neo4j)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.data_flow_analyzer import (
+    DataFlowAnalyzer,
+    _FunctionFlowVisitor,
+    _analyze_function_ast,
+    _is_taint_source,
+    _module_qname_from_path,
+)
+
+import ast
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_first_function(
+    source: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """Parse *source* and return the first function definition node."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return node
+    raise ValueError("No function found in source")
+
+
+def _edges_from_source(source: str, module_qname: str = "mymodule", source_file: str = "mymodule.py"):
+    """Convenience: analyse first function in *source*, return list of _FlowEdge."""
+    func_node = _parse_first_function(source)
+    analysis = _analyze_function_ast(func_node, module_qname, source_file)
+    return analysis.edges, analysis.taint_marks
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #1 — parameter → local var via assignment
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parameter_to_local_var_assignment():
+    """
+    def fn(data):
+        result = data   # data (param) flows into result
+    """
+    source = """\
+def fn(data):
+    result = data
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    assignment_edges = [e for e in edges if e.via == "assignment"]
+    assert len(assignment_edges) >= 1, "Expected at least one assignment edge"
+
+    # The source should be the function node (parameters flow FROM the function)
+    edge = assignment_edges[0]
+    assert "fn" in edge.source_qualified_name, (
+        f"Expected source to reference fn, got: {edge.source_qualified_name}"
+    )
+    assert "result" in edge.target_qualified_name, (
+        f"Expected target to reference result, got: {edge.target_qualified_name}"
+    )
+    assert edge.via == "assignment"
+
+
+@pytest.mark.unit
+def test_parameter_to_multiple_vars():
+    """Two assignments from the same param produce two edges."""
+    source = """\
+def fn(x):
+    a = x
+    b = x
+"""
+    edges, _ = _edges_from_source(source)
+    assignment_edges = [e for e in edges if e.via == "assignment"]
+    assert len(assignment_edges) == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #2 — local var → return value
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_local_var_to_return():
+    """
+    def fn(x):
+        result = x
+        return result  # result flows into the function return
+    """
+    source = """\
+def fn(x):
+    result = x
+    return result
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    return_edges = [e for e in edges if e.via == "return"]
+    assert len(return_edges) >= 1, "Expected at least one return edge"
+
+    edge = return_edges[0]
+    # Source should be the local var (result) or param (x)
+    assert edge.via == "return"
+    # Target should be the function node itself
+    assert "fn" in edge.target_qualified_name
+
+
+@pytest.mark.unit
+def test_direct_param_return():
+    """
+    def fn(x):
+        return x   # param x flows directly to return
+    """
+    source = """\
+def fn(x):
+    return x
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    return_edges = [e for e in edges if e.via == "return"]
+    assert len(return_edges) >= 1
+    # Source is the function (representing the parameter)
+    assert "fn" in return_edges[0].source_qualified_name
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #3 — local var → function argument
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_local_var_to_argument():
+    """
+    def fn(user_input):
+        safe = sanitize(user_input)   # user_input flows into sanitize(...)
+    """
+    source = """\
+def fn(user_input):
+    safe = sanitize(user_input)
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+
+    arg_edges = [e for e in edges if e.via == "argument"]
+    assert len(arg_edges) >= 1, "Expected at least one argument edge"
+
+    edge = arg_edges[0]
+    assert edge.via == "argument"
+    # Source should be the function (param flows from fn node)
+    assert "fn" in edge.source_qualified_name
+
+
+@pytest.mark.unit
+def test_derived_var_to_argument():
+    """Local variable derived from a param also flows to call argument."""
+    source = """\
+def fn(raw):
+    processed = raw
+    execute(processed)
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    arg_edges = [e for e in edges if e.via == "argument"]
+    assert len(arg_edges) >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #4 — taint source: function named handle_request → first param tainted
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_taint_source_by_function_name():
+    """
+    Functions with 'request' in the name should have first param marked tainted.
+    """
+    source = """\
+def handle_request(req, context):
+    data = req.body
+    return data
+"""
+    _, taint_marks = _edges_from_source(source, "views", "views.py")
+    assert len(taint_marks) >= 1, "Expected at least one taint mark"
+    # First non-self param (req) should be marked
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("req" in qn for qn in taint_qnames), (
+        f"Expected 'req' param in taint marks, got: {taint_qnames}"
+    )
+
+
+@pytest.mark.unit
+def test_taint_source_view_name():
+    """Function named 'user_view' should be a taint source."""
+    source = """\
+def user_view(request):
+    return request.data
+"""
+    _, taint_marks = _edges_from_source(source, "views")
+    assert len(taint_marks) >= 1
+
+
+@pytest.mark.unit
+def test_taint_source_endpoint_name():
+    """Function containing 'endpoint' in name → taint source."""
+    source = """\
+def create_endpoint(payload, auth):
+    return payload
+"""
+    _, taint_marks = _edges_from_source(source)
+    assert len(taint_marks) >= 1
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("payload" in qn for qn in taint_qnames)
+
+
+@pytest.mark.unit
+def test_non_taint_function_no_marks():
+    """Regular function should produce no taint marks."""
+    source = """\
+def compute_average(numbers):
+    total = sum(numbers)
+    return total / len(numbers)
+"""
+    _, taint_marks = _edges_from_source(source)
+    assert len(taint_marks) == 0, f"Expected no taint marks, got: {taint_marks}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #5 — graph_id on every edge (checked via DataFlowAnalyzer dry-run)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_graph_id_on_every_edge_metadata(tmp_path):
+    """
+    DataFlowAnalyzer.analyze_file() in dry-run (no driver) returns correct edge
+    count. Separately verify that the Cypher template includes $graph_id.
+    """
+    source = """\
+def process(user_input):
+    result = user_input
+    return result
+"""
+    py_file = tmp_path / "service.py"
+    py_file.write_text(source)
+
+    # Dry-run: pass no driver
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    count = analyzer.analyze_file(str(py_file), graph_id="test-graph-id-123")
+    assert count >= 1, "Expected at least one edge from dry-run"
+
+
+@pytest.mark.unit
+def test_graph_id_in_cypher_template():
+    """The MERGE_FLOWS_TO Cypher must reference $graph_id — architecture invariant."""
+    from app.services.data_flow_analyzer import _MERGE_FLOWS_TO
+
+    assert "$graph_id" in _MERGE_FLOWS_TO, (
+        "FLOWS_TO MERGE query must use $graph_id parameter (architecture invariant)"
+    )
+
+
+@pytest.mark.unit
+def test_taint_cypher_includes_graph_id():
+    """The taint mark Cypher must also scope by $graph_id."""
+    from app.services.data_flow_analyzer import _MARK_TAINT
+
+    assert "$graph_id" in _MARK_TAINT, (
+        "_MARK_TAINT Cypher must use $graph_id (multi-tenancy invariant)"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #6 — augmented assignment
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_augmented_assignment_both_sources_tracked():
+    """
+    def fn(x, y):
+        x += y   # both x and y flow into x
+    """
+    source = """\
+def fn(x, y):
+    x += y
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    assignment_edges = [e for e in edges if e.via == "assignment"]
+    # x+=y: x flows into x (augmented) AND y flows into x
+    assert len(assignment_edges) >= 2, (
+        f"Expected >=2 assignment edges for augmented assignment, got {len(assignment_edges)}"
+    )
+
+
+@pytest.mark.unit
+def test_compound_assignment_chain():
+    """
+    def fn(a):
+        b = a
+        c = b   # b (derived) flows into c
+        return c
+    """
+    source = """\
+def fn(a):
+    b = a
+    c = b
+    return c
+"""
+    edges, _ = _edges_from_source(source, "mod", "mod.py")
+    assert len([e for e in edges if e.via == "assignment"]) >= 2
+    assert len([e for e in edges if e.via == "return"]) >= 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #7 — taint heuristic: decorator @app.route
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_taint_source_app_route_decorator():
+    """@app.route decorator marks first param as taint source."""
+    source = """\
+@app.route("/create", methods=["POST"])
+def create(request):
+    data = request.json
+    return data
+"""
+    _, taint_marks = _edges_from_source(source)
+    assert len(taint_marks) >= 1
+    taint_qnames = [m.qualified_name for m in taint_marks]
+    assert any("request" in qn for qn in taint_qnames)
+
+
+@pytest.mark.unit
+def test_taint_source_router_decorator():
+    """@router.get / @router.post marks function as taint source."""
+    assert _is_taint_source("my_func", ["router.get('/path')"]) is True
+
+
+@pytest.mark.unit
+def test_taint_source_api_view_decorator():
+    """@api_view marks function as taint source."""
+    assert _is_taint_source("my_func", ["api_view(['GET'])"]) is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #8 — _is_taint_source helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_is_taint_source_by_name():
+    assert _is_taint_source("handle_request", []) is True
+    assert _is_taint_source("list_view", []) is True
+    assert _is_taint_source("route_handler", []) is True
+    assert _is_taint_source("compute_sum", []) is False
+
+
+@pytest.mark.unit
+def test_is_taint_source_by_decorator():
+    assert _is_taint_source("my_fn", ["app.route('/path')"]) is True
+    assert _is_taint_source("my_fn", ["router.post('/items')"]) is True
+    assert _is_taint_source("my_fn", ["login_required"]) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #9 — analyze_file edge counting (dry-run, no Neo4j)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_analyze_file_returns_edge_count(tmp_path):
+    """analyze_file in dry-run mode returns the correct edge count."""
+    source = """\
+def first(a, b):
+    x = a
+    y = b
+    return x
+
+def second(p):
+    q = p
+    process(q)
+"""
+    py_file = tmp_path / "myservice.py"
+    py_file.write_text(source)
+
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    count = analyzer.analyze_file(str(py_file), graph_id="g-123")
+
+    # first(): a→x (assignment), b→y (assignment), x→return = 3 edges
+    # second(): p→q (assignment), q→process (argument) = 2 edges
+    # Total: 5 edges minimum
+    assert count >= 5, f"Expected >=5 edges, got {count}"
+
+
+@pytest.mark.unit
+def test_analyze_file_skips_non_python(tmp_path):
+    """analyze_file returns 0 for non-Python files (not a crash)."""
+    ts_file = tmp_path / "app.ts"
+    ts_file.write_text("const x = 1;")
+
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    # TypeScript file — SyntaxError on parse → graceful 0
+    count = analyzer.analyze_file(str(ts_file), graph_id="g-ts")
+    assert count == 0
+
+
+@pytest.mark.unit
+def test_analyze_file_syntax_error_returns_zero(tmp_path):
+    """analyze_file handles SyntaxError gracefully."""
+    bad_file = tmp_path / "broken.py"
+    bad_file.write_text("def fn(: pass")
+
+    analyzer = DataFlowAnalyzer(sync_driver=None)
+    count = analyzer.analyze_file(str(bad_file), graph_id="g-bad")
+    assert count == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #10 — module_qname helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_module_qname_from_path():
+    assert _module_qname_from_path("app/services/data_flow_analyzer.py") == (
+        "app.services.data_flow_analyzer"
+    )
+    assert _module_qname_from_path("main.py") == "main"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #11 — self/cls excluded from taint marks
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_self_param_excluded_from_taint():
+    """self is not a user-controlled parameter and must not be taint-marked."""
+    source = """\
+class MyView:
+    def handle_request(self, request):
+        return request.data
+"""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            analysis = _analyze_function_ast(node, "myapp.MyView", "myapp.py")
+            taint_qnames = [m.qualified_name for m in analysis.taint_marks]
+            # self should not be marked, request should be
+            assert not any("self" in qn for qn in taint_qnames), (
+                f"'self' should not be in taint marks: {taint_qnames}"
+            )
+            if analysis.taint_marks:
+                assert any("request" in qn for qn in taint_qnames)
+            break

--- a/knowledge-graph-builder/tests/unit/test_data_flow_query.py
+++ b/knowledge-graph-builder/tests/unit/test_data_flow_query.py
@@ -1,0 +1,547 @@
+"""
+Unit tests for the data_flow query type in code_graphs.py.
+
+TASK-023 — QA: data_flow query dispatcher tests.
+Tests the `_run_code_query` dispatcher in app/api/v1/endpoints/code_graphs.py
+for the `data_flow` query type introduced by TASK-022.
+
+Coverage:
+  #1 — "data_flow" query type handled without _QueryParamError when source_symbol present
+  #2 — Missing source_symbol raises _QueryParamError (400)
+  #3 — Cypher references $graph_id (not hardcoded) — parameterized Cypher invariant
+  #4 — data_flow forward direction returns path_nodes / path_labels / depth
+  #5 — data_flow backward direction uses upstream Cypher
+  #6 — data_flow "both" direction uses undirected Cypher
+  #7 — Unknown query_type raises _QueryParamError
+  #8 — POST /graphs/{id}/code/query with data_flow returns 200
+  #9 — POST /graphs/{id}/code/query with data_flow missing source_symbol returns 400
+  #10 — Multi-tenancy: $graph_id always passed in params dict (not string-interpolated)
+
+Auth is bypassed. Neo4j is fully mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+GRAPH_A = str(uuid.uuid4())
+USER_A = str(uuid.uuid4())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers — mock Neo4j records
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _neo4j_record(data: dict):
+    rec = MagicMock()
+    rec.__getitem__ = lambda self, k: data.get(k)
+    rec.get = lambda k, default=None: data.get(k, default)
+    rec.__iter__ = lambda self: iter(data)
+    rec.keys = lambda: data.keys()
+    rec.data = lambda: data
+    return rec
+
+
+def _neo4j_result(records: list[dict]):
+    result = MagicMock()
+    result.records = [_neo4j_record(r) for r in records]
+    return result
+
+
+def _run(coro):
+    """Run a coroutine in the current event loop or a new one."""
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #1 — data_flow with source_symbol does not raise _QueryParamError
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_data_flow_with_source_symbol_does_not_raise():
+    """
+    _run_code_query with query_type='data_flow' and source_symbol present
+    must not raise _QueryParamError.
+    """
+    from app.api.v1.endpoints.code_graphs import _QueryParamError, _run_code_query
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([])
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="data_flow",
+                params={"source_symbol": "mod.fn"},
+                limit=50,
+                include_tests=False,
+            )
+
+        result = _run(run())
+
+    assert isinstance(result, list)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #2 — data_flow without source_symbol raises _QueryParamError
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_data_flow_missing_source_symbol_raises_query_param_error():
+    """
+    _run_code_query with query_type='data_flow' and no source_symbol
+    must raise _QueryParamError (translated to HTTP 400 by the endpoint).
+    """
+    from app.api.v1.endpoints.code_graphs import _QueryParamError, _run_code_query
+
+    mock_driver = AsyncMock()
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="data_flow",
+                params={},  # missing source_symbol
+                limit=50,
+                include_tests=False,
+            )
+
+        with pytest.raises(_QueryParamError) as exc_info:
+            _run(run())
+
+    assert "source_symbol" in str(exc_info.value).lower(), (
+        f"Error message must mention 'source_symbol', got: {exc_info.value}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #3 — Cypher references $graph_id (not hardcoded)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_data_flow_cypher_uses_graph_id_parameter():
+    """
+    Parameterized Cypher invariant: the Cypher executed for data_flow must
+    pass graph_id as a parameter (never hardcoded string).
+
+    Verifies that execute_query() is called with a params dict containing 'graph_id'.
+    """
+    from app.api.v1.endpoints.code_graphs import _run_code_query
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([])
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="data_flow",
+                params={"source_symbol": "mod.fn"},
+                limit=50,
+                include_tests=False,
+            )
+
+        _run(run())
+
+    assert mock_driver.execute_query.called, "execute_query should have been called"
+
+    call_args = mock_driver.execute_query.call_args
+    # Second positional arg is the params dict
+    if call_args.args and len(call_args.args) > 1:
+        params_dict = call_args.args[1]
+    elif call_args.kwargs.get("parameters"):
+        params_dict = call_args.kwargs["parameters"]
+    else:
+        params_dict = None
+
+    if params_dict is not None:
+        assert "graph_id" in params_dict, (
+            f"execute_query params must contain 'graph_id', got keys: {list(params_dict.keys())}"
+        )
+        assert params_dict["graph_id"] == GRAPH_A, (
+            f"graph_id in params must equal the requested graph_id, "
+            f"got: {params_dict['graph_id']}"
+        )
+    else:
+        call_str = str(call_args)
+        assert "graph_id" in call_str, (
+            f"execute_query call must reference graph_id: {call_str}"
+        )
+
+
+@pytest.mark.unit
+def test_data_flow_cypher_contains_graph_id_token():
+    """
+    The Cypher string passed to execute_query must contain '$graph_id' token —
+    not a hardcoded value.
+    """
+    from app.api.v1.endpoints.code_graphs import _run_code_query
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([])
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="data_flow",
+                params={"source_symbol": "mod.fn"},
+                limit=50,
+                include_tests=False,
+            )
+
+        _run(run())
+
+    call_args = mock_driver.execute_query.call_args
+    cypher = call_args.args[0] if call_args.args else ""
+
+    assert "$graph_id" in cypher, (
+        f"Cypher for data_flow must use $graph_id parameter (not hardcoded). "
+        f"Got Cypher: {cypher[:200]}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #4 — data_flow forward direction returns path_nodes / path_labels / depth
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_data_flow_forward_returns_path_records():
+    """
+    data_flow query (forward, default) returns records with:
+      - path_nodes: list of qualified_names
+      - path_labels: list of node labels
+      - depth: path length
+    """
+    from app.api.v1.endpoints.code_graphs import _run_code_query
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([
+        {
+            "path_nodes": ["mod.fn", "mod.fn.x", "mod.fn"],
+            "path_labels": ["Function", "Variable", "Function"],
+            "depth": 2,
+        }
+    ])
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="data_flow",
+                params={"source_symbol": "mod.fn", "direction": "forward"},
+                limit=50,
+                include_tests=False,
+            )
+
+        result = _run(run())
+
+    assert len(result) == 1
+    record = result[0]
+    assert "path_nodes" in record, f"Expected 'path_nodes' in result, got: {record.keys()}"
+    assert "path_labels" in record, f"Expected 'path_labels' in result, got: {record.keys()}"
+    assert "depth" in record, f"Expected 'depth' in result, got: {record.keys()}"
+    assert record["depth"] == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #5 — data_flow backward direction uses upstream Cypher with $graph_id
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_data_flow_backward_direction_uses_graph_id():
+    """
+    data_flow with direction='backward' must still call execute_query
+    with $graph_id in Cypher.
+    """
+    from app.api.v1.endpoints.code_graphs import _run_code_query
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([])
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="data_flow",
+                params={"source_symbol": "mod.sink", "direction": "backward"},
+                limit=50,
+                include_tests=False,
+            )
+
+        _run(run())
+
+    assert mock_driver.execute_query.called
+    call_args = mock_driver.execute_query.call_args
+    cypher = call_args.args[0] if call_args.args else ""
+    assert "$graph_id" in cypher, (
+        "Backward direction Cypher must include $graph_id parameter"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #6 — data_flow "both" direction uses undirected Cypher with $graph_id
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_data_flow_both_direction_uses_graph_id():
+    """
+    data_flow with direction='both' must call execute_query with $graph_id.
+    """
+    from app.api.v1.endpoints.code_graphs import _run_code_query
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([])
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="data_flow",
+                params={"source_symbol": "mod.node", "direction": "both"},
+                limit=50,
+                include_tests=False,
+            )
+
+        _run(run())
+
+    assert mock_driver.execute_query.called
+    call_args = mock_driver.execute_query.call_args
+    cypher = call_args.args[0] if call_args.args else ""
+    assert "$graph_id" in cypher, (
+        "Both-direction Cypher must include $graph_id parameter"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #7 — Unknown query_type raises _QueryParamError
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_unknown_query_type_raises_error():
+    """Unknown query_type (not in the registered types) raises _QueryParamError."""
+    from app.api.v1.endpoints.code_graphs import _QueryParamError, _run_code_query
+
+    mock_driver = AsyncMock()
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=GRAPH_A,
+                query_type="nonexistent_type",
+                params={},
+                limit=50,
+                include_tests=False,
+            )
+
+        with pytest.raises(_QueryParamError):
+            _run(run())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #8 — POST /graphs/{id}/code/query with data_flow returns 200
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_code_query_data_flow_endpoint_returns_200():
+    """
+    POST /graphs/{graph_id}/code/query with query_type=data_flow and
+    source_symbol present must return HTTP 200 with correct shape.
+
+    Uses a minimal FastAPI app that mounts only the code_graphs router.
+    Patches auth_service.verify_token to bypass the real auth stack.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.api.v1.endpoints.code_graphs import router as code_graphs_router
+
+    minimal_app = FastAPI()
+    minimal_app.include_router(code_graphs_router, prefix="/api/v1")
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([
+        {
+            "path_nodes": ["views.handle_request", "views.handle_request.req"],
+            "path_labels": ["Function", "Variable"],
+            "depth": 1,
+        }
+    ])
+
+    fake_user = {"id": USER_A, "email": "test@test.com", "principal_type": "user"}
+
+    with (
+        # Patch at the endpoint module's namespace (not the source module)
+        # because code_graphs.py imports neo4j_client with `from ... import`
+        patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc,
+        patch(
+            "app.services.auth_service.auth_service.verify_token",
+            new=AsyncMock(return_value=fake_user),
+        ),
+        patch(
+            "app.api.v1.endpoints.code_graphs.verify_graph_access",
+            new=AsyncMock(),
+        ),
+    ):
+        mnc.async_driver = mock_driver
+
+        with TestClient(minimal_app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                f"/api/v1/graphs/{GRAPH_A}/code/query",
+                headers={"Authorization": "Bearer test"},
+                json={
+                    "query_type": "data_flow",
+                    "params": {"source_symbol": "views.handle_request"},
+                },
+            )
+
+    assert resp.status_code == 200, (
+        f"Expected 200, got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert body["query_type"] == "data_flow"
+    assert body["total"] == 1
+    assert len(body["results"]) == 1
+    assert "path_nodes" in body["results"][0]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #9 — POST /graphs/{id}/code/query with data_flow missing source_symbol → 400
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_code_query_data_flow_endpoint_missing_source_symbol_returns_400():
+    """
+    POST /graphs/{graph_id}/code/query with query_type=data_flow but no
+    source_symbol must return HTTP 400.
+
+    Uses minimal FastAPI app + auth_service.verify_token mock.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.api.v1.endpoints.code_graphs import router as code_graphs_router
+
+    minimal_app = FastAPI()
+    minimal_app.include_router(code_graphs_router, prefix="/api/v1")
+
+    mock_driver = AsyncMock()
+    fake_user = {"id": USER_A, "email": "test@test.com", "principal_type": "user"}
+
+    with (
+        patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc,
+        patch(
+            "app.services.auth_service.auth_service.verify_token",
+            new=AsyncMock(return_value=fake_user),
+        ),
+        patch(
+            "app.api.v1.endpoints.code_graphs.verify_graph_access",
+            new=AsyncMock(),
+        ),
+    ):
+        mnc.async_driver = mock_driver
+
+        with TestClient(minimal_app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                f"/api/v1/graphs/{GRAPH_A}/code/query",
+                headers={"Authorization": "Bearer test"},
+                json={
+                    "query_type": "data_flow",
+                    "params": {},  # missing source_symbol
+                },
+            )
+
+    assert resp.status_code == 400, (
+        f"Expected 400 for missing source_symbol, got {resp.status_code}: {resp.text}"
+    )
+    detail = resp.json().get("detail", "")
+    assert "source_symbol" in detail.lower(), (
+        f"Error detail must mention 'source_symbol', got: {detail}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test #10 — Multi-tenancy: graph_id never hardcoded in Cypher string
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_data_flow_graph_id_never_hardcoded_in_cypher_string():
+    """
+    The Cypher string passed to execute_query for data_flow must NEVER contain
+    the literal graph_id UUID — it must always be passed as a parameter.
+    """
+    from app.api.v1.endpoints.code_graphs import _run_code_query
+
+    test_graph_id = "fixed-tenant-uuid-9999"
+
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = _neo4j_result([])
+
+    with patch("app.api.v1.endpoints.code_graphs.neo4j_client") as mnc:
+        mnc.async_driver = mock_driver
+
+        async def run():
+            return await _run_code_query(
+                graph_id=test_graph_id,
+                query_type="data_flow",
+                params={"source_symbol": "mod.fn"},
+                limit=50,
+                include_tests=False,
+            )
+
+        _run(run())
+
+    call_args = mock_driver.execute_query.call_args
+    cypher = call_args.args[0] if call_args.args else ""
+
+    # The literal UUID must NOT appear inside the Cypher string
+    assert test_graph_id not in cypher, (
+        f"Graph ID '{test_graph_id}' must not be hardcoded in Cypher: {cypher[:300]}"
+    )
+
+    # But it must appear in the parameters dict
+    if len(call_args.args) > 1:
+        params_dict = call_args.args[1]
+        assert params_dict.get("graph_id") == test_graph_id, (
+            f"graph_id must be passed as parameter, got: {params_dict}"
+        )


### PR DESCRIPTION
## Summary

- Writes the full TASK-023 QA test suite for STORY-004 (data flow analysis), branched from TASK-022's branch (`blocked_by` dependency)
- **39 unit tests** all passing: 28 in `test_data_flow_analyzer.py` + 11 in `test_data_flow_query.py`
- **Integration test** (`test_data_flow_integration.py`) written and syntactically verified; runs post-TASK-022 merge to develop

## Test files

| File | Type | Tests | Status |
|------|------|--------|--------|
| `tests/unit/test_data_flow_analyzer.py` | unit | 28 | all pass |
| `tests/unit/test_data_flow_query.py` | unit | 11 | all pass |
| `tests/integration/test_data_flow_integration.py` | integration | 9 | post-merge |

## Architecture invariants verified

- `$graph_id` in every FLOWS_TO MERGE Cypher — asserted directly on `_MERGE_FLOWS_TO` constant
- `$graph_id` in taint mark Cypher — asserted directly on `_MARK_TAINT` constant
- Parameterized Cypher: literal graph_id UUID never appears in Cypher string — asserted on `execute_query` call args
- Cross-tenant isolation — asserted in integration test (zero FLOWS_TO edges visible from a different graph_id)

## Test plan

- [x] `python -m pytest tests/unit/test_data_flow_analyzer.py tests/unit/test_data_flow_query.py -v` — 39 passed
- [ ] Integration tests run after TASK-022 PR merges to develop and Docker stack rebuilds
- [ ] Cross-tenant isolation integration assertion passes
- [ ] 500-line file timing assertion (<10s) passes