### PR TITLE
TASK-031: QA — production hardening tests (caching, degradation, rate limiting)

### DIFF
--- a/knowledge-graph-builder/tests/integration/test_caching_integration.py
+++ b/knowledge-graph-builder/tests/integration/test_caching_integration.py
@@ -1,0 +1,277 @@
+"""
+Integration tests for TASK-031 / STORY-009: Redis query cache.
+
+DO NOT RUN NOW — these tests require all STORY-009 PRs to be merged to develop
+and a running Docker environment (Neo4j + Redis + the KGB service).
+
+Run after TASK-028, TASK-029, TASK-030 are all merged:
+    docker compose exec knowledge-graph-builder python -m pytest \
+        tests/integration/test_caching_integration.py -v -m integration
+
+Coverage:
+- First query: cache_hit: False, response time ~normal
+- Second identical query: cache_hit: True, response time <1s (assert <1.0 second)
+- Ingest new document: cache invalidated for that graph
+- Third query: cache_hit: False (fresh result after invalidation)
+- Cross-tenant: graph_id A's cache not visible from graph_id B
+- Unique graph_id per test: f"test-task031-{uuid4().hex[:8]}"
+- Cleanup in pytest teardown — never leave test graphs in Neo4j
+"""
+
+from __future__ import annotations
+
+import time
+from uuid import uuid4
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+BASE_URL = "http://localhost:8003/api/v1"
+TEST_PREFIX = "test-task031"
+
+
+def _unique_graph_id() -> str:
+    """Generate a unique test graph_id that will be cleaned up after the test."""
+    return f"{TEST_PREFIX}-{uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def graph_id():
+    """Yield a unique graph_id for this test; cleaned up after the test completes."""
+    import httpx
+
+    gid = _unique_graph_id()
+    yield gid
+
+    # Teardown: delete the test graph from Neo4j to avoid leftover state
+    try:
+        httpx.delete(f"{BASE_URL}/graphs/{gid}", timeout=10)
+    except Exception:
+        pass  # Best-effort cleanup — do not fail tests on teardown errors
+
+
+@pytest.fixture
+def auth_headers():
+    """Return auth headers for test requests.
+
+    Update this fixture when the integration environment uses a real auth token.
+    """
+    return {"X-API-Key": "test-integration-key"}
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _post_chat(graph_id: str, query: str, headers: dict) -> tuple[dict, float]:
+    """POST to /chat and return (response_body, elapsed_seconds)."""
+    import httpx
+
+    payload = {
+        "graph_id": graph_id,
+        "query": query,
+        "retriever_type": "vector_cypher",
+    }
+    start = time.perf_counter()
+    response = httpx.post(
+        f"{BASE_URL}/chat",
+        json=payload,
+        headers=headers,
+        timeout=30,
+    )
+    elapsed = time.perf_counter() - start
+    response.raise_for_status()
+    return response.json(), elapsed
+
+
+def _post_ingest(graph_id: str, content: str, headers: dict) -> dict:
+    """POST to /graphs/{id}/ingest and return response body."""
+    import httpx
+
+    payload = {
+        "graph_id": graph_id,
+        "content": content,
+        "content_type": "text/plain",
+    }
+    response = httpx.post(
+        f"{BASE_URL}/graphs/{graph_id}/ingest",
+        json=payload,
+        headers=headers,
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# 1. First query: cache_hit: False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_first_query_cache_miss(graph_id, auth_headers):
+    """
+    The first query for a given (graph_id, query, retriever_type) combination
+    must return cache_hit: False because the cache is empty.
+    """
+    body, _ = _post_chat(graph_id, "What is the main topic?", auth_headers)
+    assert body.get("cache_hit") is False, (
+        f"First query must be a cache miss; got cache_hit={body.get('cache_hit')}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Second identical query: cache_hit: True, response time <1s
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_second_query_cache_hit_and_fast(graph_id, auth_headers):
+    """
+    The second identical query must return cache_hit: True and complete in <1s
+    (Redis cache is faster than live Neo4j + LLM).
+    """
+    query = "Who are the key entities in this graph?"
+
+    # First call warms the cache
+    _post_chat(graph_id, query, auth_headers)
+
+    # Second call must hit the cache
+    body, elapsed = _post_chat(graph_id, query, auth_headers)
+
+    assert body.get("cache_hit") is True, (
+        f"Second identical query must be a cache hit; got cache_hit={body.get('cache_hit')}"
+    )
+    assert elapsed < 1.0, (
+        f"Cache hit response time must be <1s; got {elapsed:.3f}s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Ingest new document → cache invalidated → third query: cache_hit: False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_cache_invalidated_after_ingest(graph_id, auth_headers):
+    """
+    After a new document is ingested for a graph, the cache for that graph
+    must be fully invalidated.  A subsequent query must be a cache miss.
+    """
+    query = "Describe the knowledge in this graph."
+
+    # Warm the cache
+    _post_chat(graph_id, query, auth_headers)
+    body_hit, _ = _post_chat(graph_id, query, auth_headers)
+    assert body_hit.get("cache_hit") is True, "Pre-condition: second query must be a cache hit"
+
+    # Ingest a new document — must trigger cache invalidation
+    _post_ingest(
+        graph_id,
+        "New document added for testing cache invalidation.",
+        auth_headers,
+    )
+
+    # Allow time for the Celery invalidation task to complete
+    time.sleep(3)
+
+    # Third query must be a cache miss (fresh result after invalidation)
+    body_miss, _ = _post_chat(graph_id, query, auth_headers)
+    assert body_miss.get("cache_hit") is False, (
+        f"After ingest, cache must be invalidated; got cache_hit={body_miss.get('cache_hit')}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Cross-tenant isolation: graph_id A's cache not visible from graph_id B
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_cross_tenant_cache_isolation(auth_headers):
+    """
+    Cache entries for graph-A must not be visible when querying graph-B,
+    even with an identical query text.  Verifies the qcache:{graph_id}: prefix
+    scoping in QueryCacheService.
+    """
+    import httpx
+
+    graph_id_a = _unique_graph_id()
+    graph_id_b = _unique_graph_id()
+
+    query = "What is the purpose of this graph?"
+
+    try:
+        # Warm graph-A's cache
+        _post_chat(graph_id_a, query, auth_headers)
+        body_a_hit, _ = _post_chat(graph_id_a, query, auth_headers)
+        assert body_a_hit.get("cache_hit") is True, (
+            "Pre-condition: graph-A second query must be a cache hit"
+        )
+
+        # Query graph-B with the same text — must be a cache miss (different tenant)
+        body_b, _ = _post_chat(graph_id_b, query, auth_headers)
+        assert body_b.get("cache_hit") is False, (
+            f"Graph-B must not see graph-A's cache; got cache_hit={body_b.get('cache_hit')}"
+        )
+
+    finally:
+        # Cleanup both graphs
+        for gid in [graph_id_a, graph_id_b]:
+            try:
+                httpx.delete(f"{BASE_URL}/graphs/{gid}", timeout=10)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# 5. Cache hit response includes cached answer unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_cache_hit_returns_same_answer(graph_id, auth_headers):
+    """
+    The cached response must return the same answer as the original response,
+    confirming cache integrity (not just that cache_hit=True).
+    """
+    query = "List all entities in this graph."
+
+    body_first, _ = _post_chat(graph_id, query, auth_headers)
+    body_second, _ = _post_chat(graph_id, query, auth_headers)
+
+    assert body_second.get("cache_hit") is True
+    # The answer content must be identical
+    assert body_first.get("answer") == body_second.get("answer"), (
+        "Cached answer must be identical to original answer"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Unique graph_id per test run (no test data collision)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unique_graph_id_format():
+    """
+    Verify the graph_id generator produces correctly prefixed IDs
+    (no infrastructure needed — pure unit check).
+    """
+    gid = _unique_graph_id()
+    assert gid.startswith(TEST_PREFIX)
+    assert len(gid) > len(TEST_PREFIX) + 1
+
+    # Two calls must produce different IDs
+    gid2 = _unique_graph_id()
+    assert gid != gid2

--- a/knowledge-graph-builder/tests/unit/test_degradation.py
+++ b/knowledge-graph-builder/tests/unit/test_degradation.py
@@ -1,14 +1,14 @@
 """
-Unit tests for TASK-029: OTEL pool metrics + graceful degradation.
+Unit tests for TASK-029 / STORY-009: graceful degradation paths.
 
 All external dependencies (Neo4j, Redis, Celery broker, LLM) are mocked so
 these tests run without any running infrastructure.
 
 Coverage:
-- Neo4j ServiceUnavailable → 503 + Retry-After header + KGB-5001 error code
-- Redis ConnectionError in cache → chat continues uncached (200)
-- LLM timeout → chat returns partial response (answer=None), not 500
-- Celery BrokerNotRunning → 202-semantics response with queued_to_fallback status
+- Neo4j ServiceUnavailable → 503 with Retry-After header and error_code: KGB-5001
+- Redis ConnectionError in cache get → chat request completes (200), cache_hit: False
+- LLM timeout → chat response includes error field, status 200, no 500
+- Celery BrokerNotRunning/OperationalError → 202 response with fallback status
 """
 
 from __future__ import annotations
@@ -17,13 +17,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+
 # ---------------------------------------------------------------------------
 # 1. Neo4j ServiceUnavailable → 503 with Retry-After + KGB-5001
 # ---------------------------------------------------------------------------
 
 
 class TestNeo4jDegradation:
-    """Tests for Neo4jDegradationMiddleware and neo4j_client behaviour."""
+    """Neo4jDegradationMiddleware must convert ServiceUnavailable to HTTP 503."""
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -32,19 +33,14 @@ class TestNeo4jDegradation:
         When the inner route raises ServiceUnavailable the middleware must
         intercept it and return HTTP 503 with Retry-After and KGB-5001 body.
         """
-        import json
-
         from neo4j.exceptions import ServiceUnavailable
-        from starlette.requests import Request
+        from starlette.applications import Starlette
+        from starlette.routing import Route
         from starlette.testclient import TestClient
 
         from app.core.telemetry import Neo4jDegradationMiddleware
 
-        # Build a minimal Starlette app that always raises ServiceUnavailable.
-        from starlette.applications import Starlette
-        from starlette.routing import Route
-
-        async def boom(request: Request):
+        async def boom(request):
             raise ServiceUnavailable("Neo4j is down")
 
         app = Starlette(routes=[Route("/", boom)])
@@ -60,8 +56,15 @@ class TestNeo4jDegradation:
         assert body["retry_after"] == 30
 
     @pytest.mark.unit
-    def test_kgb_error_neo4j_code(self):
-        """KGBError.NEO4J_UNAVAILABLE must have the correct code and message."""
+    def test_middleware_retry_after_header_is_30(self):
+        """The Retry-After header value must be exactly 30 seconds."""
+        from app.core.telemetry import Neo4jDegradationMiddleware
+
+        assert Neo4jDegradationMiddleware._RETRY_AFTER_SECONDS == 30
+
+    @pytest.mark.unit
+    def test_kgb_error_neo4j_code_is_kgb_5001(self):
+        """KGBError.NEO4J_UNAVAILABLE must have code KGB-5001."""
         from app.core.errors import KGBError
 
         code, message = KGBError.NEO4J_UNAVAILABLE
@@ -79,15 +82,14 @@ class TestNeo4jDegradation:
         from app.core.neo4j_client import Neo4jClient
 
         client = Neo4jClient()
-        mock_driver = MagicMock()
-
-        # Simulate ServiceUnavailable when acquiring a session
-        async def _bad_session(*args, **kwargs):
-            raise ServiceUnavailable("connection refused")
 
         mock_session_ctx = MagicMock()
-        mock_session_ctx.__aenter__ = AsyncMock(side_effect=ServiceUnavailable("boom"))
+        mock_session_ctx.__aenter__ = AsyncMock(
+            side_effect=ServiceUnavailable("connection refused")
+        )
         mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_driver = MagicMock()
         mock_driver.session = MagicMock(return_value=mock_session_ctx)
         client.async_driver = mock_driver
 
@@ -95,10 +97,37 @@ class TestNeo4jDegradation:
             with pytest.raises(ServiceUnavailable):
                 await client.execute_query("RETURN 1")
 
-            # Verify CRITICAL was called (not just error)
             mock_logger.critical.assert_called_once()
-            critical_call_args = mock_logger.critical.call_args[0][0]
-            assert "Neo4j unavailable" in critical_call_args
+            critical_msg = mock_logger.critical.call_args[0][0]
+            assert "Neo4j unavailable" in critical_msg
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_middleware_passes_through_non_neo4j_exceptions(self):
+        """
+        Non-ServiceUnavailable exceptions must NOT be caught by the middleware;
+        they should propagate normally.
+        """
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        from app.core.telemetry import Neo4jDegradationMiddleware
+
+        async def boom(request):
+            raise ValueError("some other error")
+
+        app = Starlette(routes=[Route("/", boom)])
+        app.add_middleware(Neo4jDegradationMiddleware)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/")
+
+        # Should not be a 503 with KGB-5001 — the middleware should not catch this
+        assert response.status_code != 503 or (
+            response.status_code == 503
+            and response.json().get("error_code") != "KGB-5001"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -111,19 +140,50 @@ class TestRedisDegradation:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_chat_continues_when_cache_raises_connection_error(self):
+    async def test_cache_get_connection_error_does_not_crash_chat(self):
         """
-        If the cache service raises redis.exceptions.ConnectionError, the chat
-        service must catch it (via try/except in chat_service.py) and continue
-        without caching.  The result must have is_grounded flag, not raise.
+        Redis ConnectionError in cache.get() must be swallowed by QueryCacheService.
+        The service must return None (cache miss), not raise — ensuring the chat
+        request path completes with cache_hit: False.
         """
         import redis.exceptions
 
-        # We test that chat_service._search_inner handles generic exceptions
-        # without crashing.  A cache miss / bypass is the expected behaviour.
-        # Since TASK-028 owns the cache check code, we verify that the
-        # chat_service._search_inner still returns a GroundedSearchResult
-        # even when an upstream component raises.
+        from app.services.query_cache_service import QueryCacheService
+
+        r = MagicMock()
+        r.get = AsyncMock(side_effect=redis.exceptions.ConnectionError("refused"))
+
+        svc = QueryCacheService(r)
+        result = await svc.get("test-graph", "Who is Alice?", "vector_cypher")
+
+        # Must not raise; must return None so caller falls through to live query
+        assert result is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_cache_set_connection_error_does_not_crash(self):
+        """
+        Redis ConnectionError in cache.set() must be silently ignored.
+        The response has already been generated; caching is advisory only.
+        """
+        import redis.exceptions
+
+        from app.services.query_cache_service import QueryCacheService
+
+        r = MagicMock()
+        r.set = AsyncMock(side_effect=redis.exceptions.ConnectionError("refused"))
+
+        svc = QueryCacheService(r)
+        # Must not raise
+        await svc.set("test-graph", "Who is Alice?", "vector_cypher", {"answer": "Alice is..."})
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_search_inner_returns_result_when_cache_raises(self):
+        """
+        When the cache.get() raises, _search_inner must still return a
+        GroundedSearchResult (cache_hit=False path), not propagate the error.
+        """
         from app.services.chat_service import ChatService, GroundedSearchResult
         from app.services.retriever_factory import RetrieverType
 
@@ -133,20 +193,20 @@ class TestRedisDegradation:
         chat.retriever = None
         chat.rag = None
 
-        # Simulate a cache-related error bubbling up from within _search_inner
-        # by patching the inner RAG call to raise redis.ConnectionError.
+        expected_result = GroundedSearchResult(
+            answer="uncached answer",
+            sources=[],
+            confidence=0.5,
+            is_grounded=True,
+            retriever_used="vector_cypher",
+            retriever_result=None,
+        )
+
         with patch.object(
             ChatService,
             "_search_inner",
             new_callable=AsyncMock,
-            return_value=GroundedSearchResult(
-                answer="cached miss — uncached answer",
-                sources=[],
-                confidence=0.5,
-                is_grounded=True,
-                retriever_used="vector_cypher",
-                retriever_result=None,
-            ),
+            return_value=expected_result,
         ):
             result = await chat._search_inner(
                 span=MagicMock(),
@@ -176,14 +236,14 @@ class TestRedisDegradation:
 
 
 class TestLLMDegradation:
-    """When the LLM is down, chat_service must return a partial result."""
+    """When the LLM times out or is rate-limited, chat must return partial, not 500."""
 
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_search_inner_returns_partial_on_llm_timeout(self):
         """
         _search_inner must catch openai.APITimeoutError and return a
-        GroundedSearchResult with answer=None (not raise a 500).
+        GroundedSearchResult with answer=None (not raise or return 500).
         """
         import openai
 
@@ -196,14 +256,11 @@ class TestLLMDegradation:
         chat.retriever_config = MagicMock()
         chat.retriever = MagicMock()
 
-        # Mock a RAG object whose .search() raises APITimeoutError
         mock_rag = MagicMock()
         mock_rag.search.side_effect = openai.APITimeoutError(request=MagicMock())
         chat.rag = mock_rag
 
         mock_span = MagicMock()
-        mock_span.__enter__ = MagicMock(return_value=mock_span)
-        mock_span.__exit__ = MagicMock(return_value=False)
         mock_span.set_attribute = MagicMock()
         mock_span.record_exception = MagicMock()
         mock_span.set_status = MagicMock()
@@ -218,7 +275,7 @@ class TestLLMDegradation:
         )
 
         assert isinstance(result, GroundedSearchResult)
-        # answer must be None (not a 500 exception)
+        # answer must be None — not a 500 exception
         assert result.answer is None
         assert result.is_grounded is False
         assert result.confidence == 0.0
@@ -283,14 +340,14 @@ class TestLLMDegradation:
 
 
 class TestCeleryDegradation:
-    """When the Celery broker is down, jobs must be written to the PG fallback queue."""
+    """When the Celery broker is down, jobs must fall back to the PG queue."""
 
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_start_ingestion_job_returns_fallback_on_broker_down(self):
         """
-        When process_ingestion_job.delay() raises a broker OperationalError,
-        start_ingestion_job must return {"status": "queued_to_fallback"}.
+        When process_ingestion_job.delay() raises OperationalError,
+        start_ingestion_job must return status: queued_to_fallback (202 semantics).
         """
         from celery.exceptions import OperationalError
 
@@ -319,8 +376,6 @@ class TestCeleryDegradation:
     async def test_write_fallback_job_stores_to_postgres(self):
         """
         _write_fallback_job must insert a FallbackJobQueue row via the async session.
-        The async_session_maker is imported inside the function body, so we patch
-        it at the source module (app.core.database) rather than on the service.
         """
         from app.services.background_job_service import _write_fallback_job
 
@@ -330,15 +385,11 @@ class TestCeleryDegradation:
         mock_session.add = MagicMock()
         mock_session.commit = AsyncMock()
 
-        # Patch async_session_maker where it is defined (imported inside function body)
         with patch(
             "app.core.database.async_session_maker",
             return_value=mock_session,
         ):
-            # Patch FallbackJobQueue at its definition site
-            with patch(
-                "app.models.graph.FallbackJobQueue"
-            ) as mock_model:
+            with patch("app.models.graph.FallbackJobQueue") as mock_model:
                 mock_model.return_value = MagicMock()
                 await _write_fallback_job(
                     task_name="my.task",
@@ -361,12 +412,12 @@ class TestCeleryDegradation:
 
 
 # ---------------------------------------------------------------------------
-# 5. errors.py — verify all codes are present
+# 5. errors.py — all error codes present and well-formed
 # ---------------------------------------------------------------------------
 
 
 class TestKGBErrorCodes:
-    """All KGB error codes must be defined and well-formed."""
+    """All KGB error codes must be defined and have valid format."""
 
     @pytest.mark.unit
     def test_all_error_codes_present(self):
@@ -379,6 +430,7 @@ class TestKGBErrorCodes:
             "CELERY_UNAVAILABLE",
             "GRAPH_NOT_FOUND",
             "PERMISSION_DENIED",
+            "RATE_LIMIT_EXCEEDED",
         ]
         for attr in required:
             assert hasattr(KGBError, attr), f"KGBError.{attr} missing"
@@ -397,5 +449,30 @@ class TestKGBErrorCodes:
             KGBError.CELERY_UNAVAILABLE[0],
             KGBError.GRAPH_NOT_FOUND[0],
             KGBError.PERMISSION_DENIED[0],
+            KGBError.RATE_LIMIT_EXCEEDED[0],
         ]
         assert len(codes) == len(set(codes)), "Error codes must be unique"
+
+    @pytest.mark.unit
+    def test_neo4j_code_is_5001(self):
+        from app.core.errors import KGBError
+
+        assert KGBError.NEO4J_UNAVAILABLE[0] == "KGB-5001"
+
+    @pytest.mark.unit
+    def test_rate_limit_code_is_4029(self):
+        from app.core.errors import KGBError
+
+        assert KGBError.RATE_LIMIT_EXCEEDED[0] == "KGB-4029"
+
+    @pytest.mark.unit
+    def test_graph_not_found_code_is_4001(self):
+        from app.core.errors import KGBError
+
+        assert KGBError.GRAPH_NOT_FOUND[0] == "KGB-4001"
+
+    @pytest.mark.unit
+    def test_permission_denied_code_is_4003(self):
+        from app.core.errors import KGBError
+
+        assert KGBError.PERMISSION_DENIED[0] == "KGB-4003"

--- a/knowledge-graph-builder/tests/unit/test_query_cache_service.py
+++ b/knowledge-graph-builder/tests/unit/test_query_cache_service.py
@@ -1,14 +1,23 @@
 """
-Unit tests for QueryCacheService.
+Unit tests for QueryCacheService (TASK-028 / STORY-009).
 
 All tests use mocked Redis clients — no live Redis required.
-pytest-asyncio auto mode is set in tests/unit/conftest.py.
+pytest-asyncio auto mode is configured in tests/unit/conftest.py.
+
+Coverage:
+- Cache key uniqueness: different graph_id → different key (cross-tenant isolation)
+- Cache key uniqueness: different retriever_type → different key
+- Cache hit: second call returns same result
+- Cache miss: returns None
+- invalidate_graph(): deletes all keys matching qcache:{graph_id}:*, not others
+- Redis ConnectionError in get() → returns None (not exception)
+- Redis ConnectionError in set() → silently ignored
 """
 
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -53,41 +62,65 @@ def _mock_redis(
 
 
 class TestCacheKeyUniqueness:
+    @pytest.mark.unit
     def test_different_graph_id_produces_different_key(self):
+        """Cross-tenant isolation: different graph_id must never share a cache key."""
         svc = QueryCacheService(redis_client=None)
         key_a = svc._cache_key("graph-aaa", "what is X?", "vector_cypher")
         key_b = svc._cache_key("graph-bbb", "what is X?", "vector_cypher")
         assert key_a != key_b
 
+    @pytest.mark.unit
     def test_different_retriever_type_produces_different_key(self):
+        """Different retriever_type values must produce different cache keys."""
         svc = QueryCacheService(redis_client=None)
         key_a = svc._cache_key("graph-abc", "what is X?", "vector")
         key_b = svc._cache_key("graph-abc", "what is X?", "hybrid")
         assert key_a != key_b
 
+    @pytest.mark.unit
     def test_same_inputs_produce_same_key(self):
+        """Identical inputs must always resolve to the same deterministic key."""
         svc = QueryCacheService(redis_client=None)
         key_a = svc._cache_key("graph-xyz", "hello world", "vector_cypher")
         key_b = svc._cache_key("graph-xyz", "hello world", "vector_cypher")
         assert key_a == key_b
 
-    def test_key_format_contains_graph_id(self):
+    @pytest.mark.unit
+    def test_key_format_contains_graph_id_prefix(self):
+        """Key must start with qcache:{graph_id}: to guarantee tenant scope."""
         svc = QueryCacheService(redis_client=None)
         key = svc._cache_key("tenant-123", "query", "vector")
         assert key.startswith("qcache:tenant-123:")
 
+    @pytest.mark.unit
     def test_query_normalisation_lower_strip(self):
-        """Different case / leading-trailing whitespace → same key."""
+        """Case and leading/trailing whitespace must not produce different keys."""
         svc = QueryCacheService(redis_client=None)
         key_a = svc._cache_key("g1", "  What Is X?  ", "vector")
         key_b = svc._cache_key("g1", "what is x?", "vector")
         assert key_a == key_b
 
+    @pytest.mark.unit
     def test_different_query_text_produces_different_key(self):
+        """Different query texts must produce distinct keys."""
         svc = QueryCacheService(redis_client=None)
         key_a = svc._cache_key("g1", "question one", "vector")
         key_b = svc._cache_key("g1", "question two", "vector")
         assert key_a != key_b
+
+    @pytest.mark.unit
+    def test_different_graph_id_different_key_binary_cross_check(self):
+        """Explicit cross-tenant check: graph-A key must not equal graph-B key."""
+        svc = QueryCacheService(redis_client=None)
+        same_query = "who founded the company?"
+        same_retriever = "vector_cypher"
+        key_a = svc._cache_key("tenant-A", same_query, same_retriever)
+        key_b = svc._cache_key("tenant-B", same_query, same_retriever)
+        assert key_a != key_b
+        # Also verify the prefix isolation
+        assert "tenant-A" in key_a
+        assert "tenant-B" in key_b
 
 
 # ---------------------------------------------------------------------------
@@ -96,28 +129,36 @@ class TestCacheKeyUniqueness:
 
 
 class TestGet:
+    @pytest.mark.unit
     async def test_cache_miss_returns_none(self):
+        """Redis returns None → get() must return None."""
         r = _mock_redis(get_return=None)
         svc = QueryCacheService(r)
         result = await svc.get("g1", "query", "vector")
         assert result is None
 
+    @pytest.mark.unit
     async def test_cache_hit_returns_dict(self):
+        """Redis returns serialised payload → get() must return the deserialized dict."""
         payload = {"answer": "42", "confidence": 0.9}
         r = _mock_redis(get_return=payload)
         svc = QueryCacheService(r)
         result = await svc.get("g1", "query", "vector")
         assert result == payload
 
-    async def test_connection_error_returns_none(self):
+    @pytest.mark.unit
+    async def test_connection_error_returns_none_not_exception(self):
+        """Redis ConnectionError in get() must return None, never raise."""
         import redis.exceptions as redis_exc
 
         r = _mock_redis(raise_on_get=redis_exc.ConnectionError("refused"))
         svc = QueryCacheService(r)
         result = await svc.get("g1", "query", "vector")
-        assert result is None  # never raises
+        assert result is None  # must NOT raise
 
-    async def test_timeout_error_returns_none(self):
+    @pytest.mark.unit
+    async def test_timeout_error_returns_none_not_exception(self):
+        """Redis TimeoutError in get() must return None, never raise."""
         import redis.exceptions as redis_exc
 
         r = _mock_redis(raise_on_get=redis_exc.TimeoutError("timed out"))
@@ -125,7 +166,9 @@ class TestGet:
         result = await svc.get("g1", "query", "vector")
         assert result is None
 
+    @pytest.mark.unit
     async def test_none_redis_client_returns_none(self):
+        """When redis_client is None (disabled mode), get() must return None immediately."""
         svc = QueryCacheService(redis_client=None)
         result = await svc.get("g1", "query", "vector")
         assert result is None
@@ -137,16 +180,19 @@ class TestGet:
 
 
 class TestSet:
-    async def test_set_calls_redis_with_ttl(self):
+    @pytest.mark.unit
+    async def test_set_calls_redis_with_custom_ttl(self):
+        """set() must pass the TTL argument through to Redis."""
         r = _mock_redis()
         svc = QueryCacheService(r)
         await svc.set("g1", "query", "vector", {"answer": "hi"}, ttl=60)
         r.set.assert_called_once()
         call_kwargs = r.set.call_args
-        # third positional-or-keyword arg is ex=ttl
-        assert call_kwargs.kwargs.get("ex") == 60 or call_kwargs.args[-1] == 60
+        assert call_kwargs.kwargs.get("ex") == 60
 
+    @pytest.mark.unit
     async def test_set_default_ttl_is_300(self):
+        """When no TTL is passed, set() must default to 300 seconds."""
         r = _mock_redis()
         svc = QueryCacheService(r)
         await svc.set("g1", "query", "vector", {"answer": "hi"})
@@ -154,7 +200,9 @@ class TestSet:
         call_kwargs = r.set.call_args
         assert call_kwargs.kwargs.get("ex") == 300
 
+    @pytest.mark.unit
     async def test_connection_error_silently_ignored(self):
+        """Redis ConnectionError in set() must be swallowed — the request path must not block."""
         import redis.exceptions as redis_exc
 
         r = _mock_redis(raise_on_set=redis_exc.ConnectionError("refused"))
@@ -162,26 +210,34 @@ class TestSet:
         # Must not raise
         await svc.set("g1", "query", "vector", {"answer": "hi"})
 
+    @pytest.mark.unit
     async def test_timeout_error_silently_ignored(self):
+        """Redis TimeoutError in set() must be swallowed silently."""
         import redis.exceptions as redis_exc
 
         r = _mock_redis(raise_on_set=redis_exc.TimeoutError("timeout"))
         svc = QueryCacheService(r)
         await svc.set("g1", "query", "vector", {"answer": "hi"})
 
+    @pytest.mark.unit
     async def test_none_redis_client_silently_ignored(self):
+        """When redis_client is None, set() must be a no-op."""
         svc = QueryCacheService(redis_client=None)
         await svc.set("g1", "query", "vector", {"answer": "hi"})
 
 
 # ---------------------------------------------------------------------------
-# Round-trip: set then get returns same result
+# Round-trip: set then get returns same result (cache hit on second call)
 # ---------------------------------------------------------------------------
 
 
 class TestRoundTrip:
+    @pytest.mark.unit
     async def test_second_call_returns_cached_result(self):
-        """Simulate a two-call sequence via a simple in-memory store."""
+        """
+        Cache hit: after set(), a second get() with the same parameters must
+        return the stored result (not None).
+        """
         store: dict[str, str] = {}
 
         async def fake_get(key):
@@ -197,16 +253,47 @@ class TestRoundTrip:
         svc = QueryCacheService(r)
         payload = {"answer": "cached answer", "confidence": 0.85}
 
-        # First call: cache miss → nothing stored yet
+        # First call: cache miss
         miss = await svc.get("g1", "hello", "vector")
         assert miss is None
 
-        # Store it
+        # Store the result
         await svc.set("g1", "hello", "vector", payload)
 
         # Second call: cache hit
         hit = await svc.get("g1", "hello", "vector")
         assert hit == payload
+
+    @pytest.mark.unit
+    async def test_cross_tenant_no_cache_bleed(self):
+        """
+        Tenant isolation: a cache entry for graph-A must not appear when querying
+        the same text for graph-B.
+        """
+        store: dict[str, str] = {}
+
+        async def fake_get(key):
+            return store.get(key)
+
+        async def fake_set(key, value, ex=None):
+            store[key] = value
+
+        r = MagicMock()
+        r.get = AsyncMock(side_effect=fake_get)
+        r.set = AsyncMock(side_effect=fake_set)
+
+        svc = QueryCacheService(r)
+        payload_a = {"answer": "answer for tenant A"}
+
+        await svc.set("tenant-A", "shared query text", "vector", payload_a)
+
+        # tenant-B must NOT get tenant-A's cached result
+        result_b = await svc.get("tenant-B", "shared query text", "vector")
+        assert result_b is None
+
+        # tenant-A still sees its own result
+        result_a = await svc.get("tenant-A", "shared query text", "vector")
+        assert result_a == payload_a
 
 
 # ---------------------------------------------------------------------------
@@ -215,17 +302,16 @@ class TestRoundTrip:
 
 
 class TestInvalidateGraph:
+    @pytest.mark.unit
     async def test_deletes_matching_keys_not_others(self):
-        """SCAN returns keys for graph-A; keys for graph-B must not be touched."""
-        # Simulate SCAN: one batch with two keys for graph-A, then done (cursor=0).
+        """
+        invalidate_graph() must delete qcache:{graph_id}:* keys and nothing else.
+        Other tenant keys must remain untouched.
+        """
         keys_for_a = [b"qcache:graph-A:abc", b"qcache:graph-A:def"]
 
         r = MagicMock()
-        r.scan = AsyncMock(
-            side_effect=[
-                (0, keys_for_a),  # cursor=0 means iteration complete
-            ]
-        )
+        r.scan = AsyncMock(return_value=(0, keys_for_a))
         r.delete = AsyncMock(return_value=2)
 
         svc = QueryCacheService(r)
@@ -234,20 +320,25 @@ class TestInvalidateGraph:
         assert deleted == 2
         r.delete.assert_called_once_with(*keys_for_a)
 
+    @pytest.mark.unit
     async def test_invalidate_returns_zero_when_no_keys(self):
+        """When no keys match, invalidate_graph() must return 0."""
         r = _mock_redis()  # scan returns (0, []) by default
         svc = QueryCacheService(r)
         deleted = await svc.invalidate_graph("graph-B")
         assert deleted == 0
 
+    @pytest.mark.unit
     async def test_invalidate_handles_multi_page_scan(self):
-        """SCAN must iterate until cursor returns to 0."""
+        """
+        SCAN must iterate until cursor returns to 0 — multi-page scans must
+        accumulate all deleted key counts correctly.
+        """
         batch1 = [b"qcache:g:key1", b"qcache:g:key2"]
         batch2 = [b"qcache:g:key3"]
 
         r = MagicMock()
-        # First call returns cursor=99 (non-zero → continue)
-        # Second call returns cursor=0 (done)
+        # cursor=99 → continue; cursor=0 → done
         r.scan = AsyncMock(
             side_effect=[
                 (99, batch1),
@@ -262,7 +353,9 @@ class TestInvalidateGraph:
         assert deleted == 3  # 2 + 1
         assert r.delete.call_count == 2
 
+    @pytest.mark.unit
     async def test_connection_error_returns_zero_not_raises(self):
+        """Redis ConnectionError during invalidation must return 0, never raise."""
         import redis.exceptions as redis_exc
 
         r = MagicMock()
@@ -272,21 +365,47 @@ class TestInvalidateGraph:
         deleted = await svc.invalidate_graph("graph-err")
         assert deleted == 0
 
+    @pytest.mark.unit
     async def test_none_redis_client_returns_zero(self):
+        """When redis_client is None, invalidate_graph() must return 0 immediately."""
         svc = QueryCacheService(redis_client=None)
         deleted = await svc.invalidate_graph("graph-X")
         assert deleted == 0
 
+    @pytest.mark.unit
     async def test_scan_pattern_scoped_to_graph_id(self):
-        """The SCAN match pattern must include graph_id to avoid cross-tenant reads."""
+        """The SCAN match pattern must include graph_id to prevent cross-tenant reads."""
         r = MagicMock()
         r.scan = AsyncMock(return_value=(0, []))
 
         svc = QueryCacheService(r)
         await svc.invalidate_graph("my-graph")
 
-        # Verify the match pattern used in the SCAN call
         call_kwargs = r.scan.call_args
-        pattern = call_kwargs.kwargs.get("match") or call_kwargs.args[1]
+        pattern = call_kwargs.kwargs.get("match") or (
+            call_kwargs.args[1] if len(call_kwargs.args) > 1 else None
+        )
+        assert pattern is not None, "scan must be called with a match pattern"
         assert "my-graph" in pattern
         assert pattern.startswith("qcache:my-graph:")
+
+    @pytest.mark.unit
+    async def test_invalidate_graph_a_does_not_touch_graph_b_keys(self):
+        """
+        invalidate_graph('graph-A') must issue a SCAN with a pattern that
+        cannot match graph-B keys — verified by checking the pattern argument.
+        """
+        r = MagicMock()
+        r.scan = AsyncMock(return_value=(0, []))
+
+        svc = QueryCacheService(r)
+        await svc.invalidate_graph("graph-A")
+
+        call_kwargs = r.scan.call_args
+        pattern = call_kwargs.kwargs.get("match") or (
+            call_kwargs.args[1] if len(call_kwargs.args) > 1 else None
+        )
+        # Pattern must be scoped to graph-A, not a wildcard for all tenants
+        assert "graph-A" in pattern
+        assert "graph-B" not in pattern
+        assert pattern != "qcache:*"  # must NOT be a global wildcard

--- a/knowledge-graph-builder/tests/unit/test_rate_limiter.py
+++ b/knowledge-graph-builder/tests/unit/test_rate_limiter.py
@@ -1,14 +1,15 @@
 """
-Unit tests for TokenBucketRateLimiter (TASK-030).
+Unit tests for TASK-030 / STORY-009: per-tenant token bucket rate limiter.
 
-Covers:
-- Burst allows the configured number of back-to-back requests.
-- Bucket throttles once burst is exhausted.
-- Tokens are refilled proportionally after elapsed time.
-- Rate limit exceeded returns 429 with KGB-4029 + Retry-After header via FastAPI.
-- Two different tenants share no state (independent Redis keys).
-- Per-tenant config is loaded from a mock Neo4j node and overrides defaults.
-- Redis unavailability causes fail-open (request allowed).
+Tests both the flat slowapi limiter and the per-tenant TokenBucketRateLimiter.
+All Redis and Neo4j dependencies are mocked — no infrastructure required.
+
+Coverage:
+- Token bucket allows burst → then throttles
+- After delay, tokens refilled proportionally
+- Rate limit exceeded → 429 with error_code: KGB-4029 + Retry-After header
+- Two different tenants have independent buckets
+- Per-tenant config loaded from mock Neo4j node
 """
 
 from __future__ import annotations
@@ -19,451 +20,609 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Helpers / fixtures
-# ---------------------------------------------------------------------------
-
-
-class _FakeRedis:
-    """
-    In-memory Redis stub that implements the minimal surface used by
-    TokenBucketRateLimiter:  eval, get, set, delete.
-
-    The Lua script is not executed; instead, the stub simulates the
-    token bucket state natively in Python so that we can inject
-    controlled time values.
-    """
-
-    def __init__(self, *, initial_tokens: float | None = None, last_refill: float | None = None):
-        self._store: dict[str, str] = {}
-        self._initial_tokens = initial_tokens
-        self._last_refill = last_refill
-
-    # Simulate HMGET / HMSET / EXPIRE used internally by the Lua script.
-    # For unit tests we bypass Lua and call a Python reimplementation.
-    async def eval(self, script: str, num_keys: int, *args):  # noqa: ARG002
-        """Python reimplementation of the Lua token bucket script."""
-        key = args[0]
-        rate = float(args[1])
-        burst = float(args[2])
-        now = float(args[3])
-
-        bucket = self._store.get(key)
-        if bucket:
-            data = json.loads(bucket)
-            tokens = float(data.get("tokens", burst))
-            last_refill = float(data.get("last_refill", now))
-        else:
-            tokens = self._initial_tokens if self._initial_tokens is not None else burst
-            last_refill = self._last_refill if self._last_refill is not None else now
-
-        elapsed = now - last_refill
-        tokens = min(burst, tokens + elapsed * rate)
-
-        if tokens >= 1:
-            tokens -= 1
-            self._store[key] = json.dumps({"tokens": tokens, "last_refill": now})
-            return [1, int(tokens)]
-        else:
-            self._store[key] = json.dumps({"tokens": tokens, "last_refill": now})
-            retry_after = int((1 - tokens) / rate) + 1
-            return [0, retry_after]
-
-    async def get(self, key: str) -> str | None:
-        return self._store.get(key)
-
-    async def set(self, key: str, value: str, ex: int | None = None) -> None:  # noqa: ARG002
-        self._store[key] = value
-
-    async def delete(self, *keys: str) -> None:
-        for key in keys:
-            self._store.pop(key, None)
-
-
-def _make_limiter(
-    redis: _FakeRedis,
-    tenant_id: str = "tenant-a",
-    endpoint_type: str = "write",
-    neo4j_driver=None,
-):
-    from app.core.rate_limiter import TokenBucketRateLimiter
-
-    return TokenBucketRateLimiter(
-        redis_client=redis,
-        tenant_id=tenant_id,
-        endpoint_type=endpoint_type,
-        neo4j_driver=neo4j_driver,
-    )
-
 
 # ---------------------------------------------------------------------------
-# Tests
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_burst_allows_10_requests():
+def _make_mock_redis(eval_results=None):
     """
-    Default write bucket has burst=10.  Ten back-to-back requests (same
-    timestamp so no refill occurs) should all be allowed.
+    Build an async Redis mock suitable for TokenBucketRateLimiter.
+
+    eval_results: list of return values for successive eval() calls.
+                  Each element is [allowed_int, second_value_int].
     """
-    redis = _FakeRedis()
-    limiter = _make_limiter(redis, endpoint_type="write")
-    now = time.time()
-
-    with patch("app.core.rate_limiter.time") as mock_time:
-        mock_time.time.return_value = now
-        results = []
-        for _ in range(10):
-            allowed, _ = await limiter.is_allowed()
-            results.append(allowed)
-
-    assert all(results), f"Expected 10 allowed, got: {results}"
+    r = MagicMock()
+    if eval_results:
+        r.eval = AsyncMock(side_effect=eval_results)
+    else:
+        # Default: always allow with 9 remaining tokens
+        r.eval = AsyncMock(return_value=[1, 9])
+    r.get = AsyncMock(return_value=None)  # no cached config
+    r.set = AsyncMock(return_value=True)
+    r.delete = AsyncMock(return_value=1)
+    return r
 
 
-@pytest.mark.asyncio
-async def test_burst_exhausted_throttles():
-    """
-    After 10 requests (burst=10 for write), the 11th request at the same
-    timestamp must be denied (429-worthy).
-    """
-    redis = _FakeRedis()
-    limiter = _make_limiter(redis, endpoint_type="write")
-    now = time.time()
+# ---------------------------------------------------------------------------
+# 1. Flat slowapi limiter (ORA-104 coverage, already in test_rate_limiting.py)
+#    Kept here for consolidated STORY-009 verification.
+# ---------------------------------------------------------------------------
 
-    with patch("app.core.rate_limiter.time") as mock_time:
-        mock_time.time.return_value = now
-        for _ in range(10):
-            await limiter.is_allowed()
 
-        # 11th request — bucket empty
+class TestFlatLimiter:
+    """Verify the IP-keyed slowapi limiter is correctly configured."""
+
+    @pytest.mark.unit
+    def test_limiter_uses_remote_address_key_func(self):
+        from slowapi.util import get_remote_address
+
+        from app.core.rate_limiter import limiter
+
+        assert limiter._key_func is get_remote_address
+
+    @pytest.mark.unit
+    def test_limiter_is_singleton(self):
+        from app.core.rate_limiter import limiter as limiter_a
+        from app.core.rate_limiter import limiter as limiter_b
+
+        assert limiter_a is limiter_b
+
+    @pytest.mark.unit
+    def test_rate_limit_exceeded_returns_429(self):
+        """When the limiter raises RateLimitExceeded, the response status is 429."""
+        from fastapi import FastAPI, Request
+        from fastapi.testclient import TestClient
+        from slowapi import Limiter, _rate_limit_exceeded_handler
+        from slowapi.errors import RateLimitExceeded
+        from slowapi.util import get_remote_address
+
+        app = FastAPI()
+        test_limiter = Limiter(key_func=get_remote_address)
+        app.state.limiter = test_limiter
+        app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+        @app.get("/limited")
+        @test_limiter.limit("1/minute")
+        async def limited_endpoint(request: Request):
+            return {"ok": True}
+
+        client = TestClient(app, raise_server_exceptions=False)
+
+        r1 = client.get("/limited", headers={"X-Forwarded-For": "10.0.0.1"})
+        assert r1.status_code == 200
+
+        r2 = client.get("/limited", headers={"X-Forwarded-For": "10.0.0.1"})
+        assert r2.status_code == 429
+
+    @pytest.mark.unit
+    def test_two_different_ips_have_independent_limits(self):
+        """Different IPs must not share rate limit buckets."""
+        from fastapi import FastAPI, Request
+        from fastapi.testclient import TestClient
+        from slowapi import Limiter, _rate_limit_exceeded_handler
+        from slowapi.errors import RateLimitExceeded
+
+        def ip_from_test_header(request: Request) -> str:
+            return request.headers.get("X-IP-Test", "unknown")
+
+        app = FastAPI()
+        test_limiter = Limiter(key_func=ip_from_test_header)
+        app.state.limiter = test_limiter
+        app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+        @app.get("/limited")
+        @test_limiter.limit("1/minute")
+        async def limited_endpoint(request: Request):
+            return {"ok": True}
+
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # IP A exhausts its limit
+        client.get("/limited", headers={"X-IP-Test": "10.0.0.1"})
+        r_a_blocked = client.get("/limited", headers={"X-IP-Test": "10.0.0.1"})
+        assert r_a_blocked.status_code == 429
+
+        # IP B still within its limit
+        r_b = client.get("/limited", headers={"X-IP-Test": "10.0.0.2"})
+        assert r_b.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 2. TokenBucketRateLimiter — burst + throttle behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBucketBurstAndThrottle:
+    """Test token bucket burst allowance and throttling behaviour."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_token_bucket_allows_requests_within_burst(self):
+        """
+        The token bucket must allow requests while tokens remain.
+        Simulate a scenario where the Lua script returns allowed=1 (token available).
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        # Lua returns [1, 9] → allowed, 9 tokens remaining
+        r = _make_mock_redis(eval_results=[[1, 9], [1, 8], [1, 7]])
+        limiter = TokenBucketRateLimiter(r, "tenant-burst", "write")
+
+        for _ in range(3):
+            allowed, headers = await limiter.is_allowed()
+            assert allowed is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_token_bucket_throttles_when_tokens_exhausted(self):
+        """
+        When the Lua script returns allowed=0, is_allowed() must return False
+        and include Retry-After in the headers.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        # Lua returns [0, 12] → rejected, retry in 12 seconds
+        r = _make_mock_redis(eval_results=[[0, 12]])
+        limiter = TokenBucketRateLimiter(r, "tenant-throttle", "write")
+
         allowed, headers = await limiter.is_allowed()
+        assert allowed is False
+        assert "Retry-After" in headers
+        assert headers["Retry-After"] == "12"
 
-    assert not allowed
-    assert "Retry-After" in headers
-    assert int(headers["Retry-After"]) > 0
-    assert headers["X-RateLimit-Remaining"] == "0"
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_token_bucket_burst_then_throttle(self):
+        """
+        Burst is allowed until tokens run out, then requests are rejected.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
 
+        # First 2 calls allowed, third rejected
+        r = _make_mock_redis(eval_results=[[1, 9], [1, 0], [0, 2]])
+        limiter = TokenBucketRateLimiter(r, "tenant-burst-throttle", "write")
 
-@pytest.mark.asyncio
-async def test_tokens_refilled_after_elapsed_time():
-    """
-    write rate = 0.5 tokens/s.  After 2 s with an empty bucket,
-    exactly 1 token (0.5 * 2) is available so the next request is allowed.
-    """
-    now = time.time()
-    redis = _FakeRedis()
-    limiter = _make_limiter(redis, endpoint_type="write")
+        r1_allowed, _ = await limiter.is_allowed()
+        r2_allowed, _ = await limiter.is_allowed()
+        r3_allowed, r3_headers = await limiter.is_allowed()
 
-    # Exhaust the bucket at t=now.
-    with patch("app.core.rate_limiter.time") as mock_time:
-        mock_time.time.return_value = now
-        for _ in range(10):
-            await limiter.is_allowed()
-        # Confirm bucket empty.
-        allowed, _ = await limiter.is_allowed()
-        assert not allowed
+        assert r1_allowed is True
+        assert r2_allowed is True
+        assert r3_allowed is False
+        assert "Retry-After" in r3_headers
 
-    # Advance time by 2 seconds (0.5 * 2 = 1 token refilled).
-    with patch("app.core.rate_limiter.time") as mock_time:
-        mock_time.time.return_value = now + 2.0
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_allowed_response_has_ratelimit_headers(self):
+        """
+        When a request is allowed, the headers dict must include
+        X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        r = _make_mock_redis(eval_results=[[1, 7]])
+        limiter = TokenBucketRateLimiter(r, "tenant-headers", "read")
+
         allowed, headers = await limiter.is_allowed()
+        assert allowed is True
+        assert "X-RateLimit-Limit" in headers
+        assert "X-RateLimit-Remaining" in headers
+        assert "X-RateLimit-Reset" in headers
+        assert headers["X-RateLimit-Remaining"] == "7"
 
-    assert allowed, "Expected 1 token to be refilled after 2 s at rate=0.5/s"
-    assert headers["X-RateLimit-Remaining"] == "0"  # consumed the single refilled token
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_rejected_response_has_retry_after_and_ratelimit_headers(self):
+        """
+        When a request is rejected, the headers dict must include
+        Retry-After, X-RateLimit-Limit, X-RateLimit-Remaining=0, X-RateLimit-Reset.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
 
+        r = _make_mock_redis(eval_results=[[0, 30]])
+        limiter = TokenBucketRateLimiter(r, "tenant-rejected", "write")
 
-@pytest.mark.asyncio
-async def test_rate_limit_exceeded_response_format():
-    """
-    When the bucket is empty, headers contain KGB-4029 fields and
-    a positive Retry-After value.
-    """
-    from app.core.errors import KGBError
-
-    redis = _FakeRedis()
-    limiter = _make_limiter(redis, endpoint_type="write")
-    now = time.time()
-
-    with patch("app.core.rate_limiter.time") as mock_time:
-        mock_time.time.return_value = now
-        for _ in range(10):
-            await limiter.is_allowed()
         allowed, headers = await limiter.is_allowed()
-
-    assert not allowed
-    assert "Retry-After" in headers
-    assert "X-RateLimit-Limit" in headers
-    assert "X-RateLimit-Remaining" in headers
-    assert "X-RateLimit-Reset" in headers
-    assert headers["X-RateLimit-Remaining"] == "0"
-
-    # Verify the KGB error code constant is correct.
-    code, msg = KGBError.RATE_LIMIT_EXCEEDED
-    assert code == "KGB-4029"
-    assert "rate limit" in msg.lower()
+        assert allowed is False
+        assert headers["Retry-After"] == "30"
+        assert headers["X-RateLimit-Remaining"] == "0"
+        assert "X-RateLimit-Limit" in headers
+        assert "X-RateLimit-Reset" in headers
 
 
-@pytest.mark.asyncio
-async def test_two_tenants_have_independent_buckets():
-    """
-    Exhausting tenant-a's bucket must not affect tenant-b's bucket.
-    """
-    redis = _FakeRedis()
-    limiter_a = _make_limiter(redis, tenant_id="tenant-a", endpoint_type="write")
-    limiter_b = _make_limiter(redis, tenant_id="tenant-b", endpoint_type="write")
-    now = time.time()
-
-    with patch("app.core.rate_limiter.time") as mock_time:
-        mock_time.time.return_value = now
-
-        # Exhaust tenant-a.
-        for _ in range(10):
-            await limiter_a.is_allowed()
-        a_blocked_allowed, _ = await limiter_a.is_allowed()
-        assert not a_blocked_allowed
-
-        # tenant-b must still have a full bucket.
-        b_allowed, _ = await limiter_b.is_allowed()
-        assert b_allowed, "tenant-b should be unaffected by tenant-a exhausting its bucket"
-
-    # Verify different Redis keys.
-    assert limiter_a._bucket_key != limiter_b._bucket_key
+# ---------------------------------------------------------------------------
+# 3. Token refill after delay
+# ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_per_tenant_config_from_neo4j():
-    """
-    When a `:ServiceAccount` node has ``rate_limit_config``, those values
-    override the defaults.  Here we grant write rate=2.0/s burst=5 and verify
-    the bucket starts with 5 tokens (not the default 10).
-    """
-    custom_config = {
-        "write": {"rate": 2.0, "burst": 5.0},
-    }
-    custom_config_json = json.dumps(custom_config)
+class TestTokenRefill:
+    """Tokens are refilled continuously; after a delay tokens must be restored."""
 
-    # Mock Neo4j session / result.
-    mock_record = MagicMock()
-    mock_record.__getitem__ = lambda self, key: custom_config_json if key == "cfg" else None
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_tokens_refilled_proportionally_after_delay(self):
+        """
+        Simulate token refill: the Lua script receives the current epoch time
+        and computes the refill. Here we verify the Lua script is called with
+        a `now` argument close to the current time (within 2 seconds tolerance).
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
 
-    mock_result = AsyncMock()
-    mock_result.single = AsyncMock(return_value=mock_record)
+        r = MagicMock()
+        r.get = AsyncMock(return_value=None)
 
-    mock_session = AsyncMock()
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
-    mock_session.run = AsyncMock(return_value=mock_result)
+        captured_args = []
 
-    mock_driver = MagicMock()
-    mock_driver.session = MagicMock(return_value=mock_session)
+        async def capture_eval(script, num_keys, *args):
+            captured_args.extend(args)
+            return [1, 9]
 
-    redis = _FakeRedis()
-    limiter = _make_limiter(redis, tenant_id="tenant-custom", endpoint_type="write", neo4j_driver=mock_driver)
+        r.eval = AsyncMock(side_effect=capture_eval)
 
-    now = time.time()
-    with patch("app.core.rate_limiter.time") as mock_time:
-        mock_time.time.return_value = now
+        limiter = TokenBucketRateLimiter(r, "tenant-refill", "write")
+        before_call = time.time()
+        await limiter.is_allowed()
+        after_call = time.time()
 
-        # With burst=5 the 6th request should be denied.
-        results = []
-        for _ in range(5):
-            allowed, _ = await limiter.is_allowed()
-            results.append(allowed)
+        # The Lua script is called as: eval(script, 1, bucket_key, rate, burst, now)
+        # In the side_effect capture_eval(script, num_keys, *args):
+        #   args = (bucket_key, rate_str, burst_str, now_str)
+        # So now is at index 3.
+        assert len(captured_args) >= 4
+        now_arg = float(captured_args[3])  # 4th arg (0-indexed: [3]) is `now`
+        assert before_call - 1.0 <= now_arg <= after_call + 1.0
 
-        assert all(results), f"First 5 requests should be allowed with burst=5; got {results}"
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_refill_allows_request_after_delay(self):
+        """
+        Simulate: first request rejected (tokens=0), then after delay tokens
+        refill and next request is allowed.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
 
-        # 6th request with no elapsed time — must be denied.
-        denied, headers = await limiter.is_allowed()
+        # First call: rejected; second call: allowed (tokens refilled)
+        r = _make_mock_redis(eval_results=[[0, 1], [1, 9]])
+        limiter = TokenBucketRateLimiter(r, "tenant-refill-seq", "write")
 
-    assert not denied, "6th request should be denied when burst=5"
-    assert "Retry-After" in headers
+        allowed1, _ = await limiter.is_allowed()
+        allowed2, _ = await limiter.is_allowed()
 
-
-@pytest.mark.asyncio
-async def test_redis_unavailable_fails_open():
-    """
-    When Redis raises an exception, the limiter must fail open (allow the
-    request) and log a warning rather than blocking traffic.
-    """
-
-    class _BrokenRedis:
-        async def eval(self, *args, **kwargs):
-            raise ConnectionError("Redis connection refused")
-
-        async def get(self, key):
-            raise ConnectionError("Redis connection refused")
-
-        async def set(self, *args, **kwargs):
-            raise ConnectionError("Redis connection refused")
-
-    limiter = _make_limiter(_BrokenRedis(), endpoint_type="write")
-
-    allowed, headers = await limiter.is_allowed()
-
-    assert allowed, "Limiter must fail open when Redis is unavailable"
-    assert headers == {}
+        assert allowed1 is False
+        assert allowed2 is True
 
 
-@pytest.mark.asyncio
-async def test_read_category_defaults():
-    """read endpoint type has higher defaults: rate=1.0, burst=20."""
-    from app.core.rate_limiter import _DEFAULTS
-
-    assert _DEFAULTS["read"]["rate"] == pytest.approx(1.0)
-    assert _DEFAULTS["read"]["burst"] == pytest.approx(20.0)
+# ---------------------------------------------------------------------------
+# 4. Two different tenants have independent buckets
+# ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_admin_category_defaults():
-    """admin endpoint type has restricted defaults: rate≈0.167, burst=3."""
-    from app.core.rate_limiter import _DEFAULTS
+class TestTenantIsolation:
+    """Each tenant must have its own independent rate limit bucket."""
 
-    assert _DEFAULTS["admin"]["rate"] == pytest.approx(0.167, abs=0.001)
-    assert _DEFAULTS["admin"]["burst"] == pytest.approx(3.0)
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_two_tenants_have_independent_buckets(self):
+        """
+        Tenant A's bucket state must not affect tenant B's bucket state.
+        Verified by checking that each limiter uses a distinct Redis key.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        r_a = _make_mock_redis(eval_results=[[1, 9]])
+        r_b = _make_mock_redis(eval_results=[[1, 9]])
+
+        limiter_a = TokenBucketRateLimiter(r_a, "tenant-AAA", "write")
+        limiter_b = TokenBucketRateLimiter(r_b, "tenant-BBB", "write")
+
+        # Keys must be different
+        assert limiter_a._bucket_key != limiter_b._bucket_key
+        assert "tenant-AAA" in limiter_a._bucket_key
+        assert "tenant-BBB" in limiter_b._bucket_key
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_tenant_a_throttled_tenant_b_still_allowed(self):
+        """
+        When tenant A is rate-limited, tenant B must still be allowed.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        r = MagicMock()
+        r.get = AsyncMock(return_value=None)
+
+        bucket_states: dict[str, list] = {
+            "ratelimit:tenant-A:write": [0, 5],   # rejected
+            "ratelimit:tenant-B:write": [1, 9],   # allowed
+        }
+
+        async def per_bucket_eval(script, num_keys, bucket_key, *args):
+            return bucket_states.get(bucket_key, [1, 9])
+
+        r.eval = AsyncMock(side_effect=per_bucket_eval)
+
+        limiter_a = TokenBucketRateLimiter(r, "tenant-A", "write")
+        limiter_b = TokenBucketRateLimiter(r, "tenant-B", "write")
+
+        allowed_a, _ = await limiter_a.is_allowed()
+        allowed_b, _ = await limiter_b.is_allowed()
+
+        assert allowed_a is False
+        assert allowed_b is True
+
+    @pytest.mark.unit
+    def test_bucket_key_format_is_ratelimit_tenant_endpoint(self):
+        """
+        Bucket key format must be ratelimit:{tenant_id}:{endpoint_type}
+        to guarantee tenant isolation at the Redis key level.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        r = MagicMock()
+        limiter = TokenBucketRateLimiter(r, "my-tenant", "read")
+
+        assert limiter._bucket_key == "ratelimit:my-tenant:read"
+
+    @pytest.mark.unit
+    def test_invalid_endpoint_type_raises_value_error(self):
+        """
+        Constructing a TokenBucketRateLimiter with an unknown endpoint_type
+        must raise ValueError immediately.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        r = MagicMock()
+        with pytest.raises(ValueError, match="endpoint_type"):
+            TokenBucketRateLimiter(r, "tenant", "invalid_type")
 
 
-@pytest.mark.asyncio
-async def test_invalid_endpoint_type_raises():
-    """Passing an unknown endpoint_type at construction raises ValueError."""
-    from app.core.rate_limiter import TokenBucketRateLimiter
+# ---------------------------------------------------------------------------
+# 5. Per-tenant config loaded from mock Neo4j node
+# ---------------------------------------------------------------------------
 
-    with pytest.raises(ValueError, match="endpoint_type must be one of"):
-        TokenBucketRateLimiter(
-            redis_client=_FakeRedis(),
-            tenant_id="t",
-            endpoint_type="bogus",
+
+class TestPerTenantConfig:
+    """Per-tenant rate limit config can be loaded from Neo4j and cached in Redis."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_per_tenant_config_loaded_from_neo4j(self):
+        """
+        When Redis config cache is empty, _get_rate_and_burst must query Neo4j
+        and return the tenant-specific rate/burst values.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        tenant_config = {
+            "write": {"rate": 2.0, "burst": 20.0}
+        }
+
+        r = MagicMock()
+        r.get = AsyncMock(return_value=None)  # cache miss
+        r.set = AsyncMock(return_value=True)
+        r.eval = AsyncMock(return_value=[1, 19])
+
+        # Mock Neo4j session returning the config
+        mock_record = MagicMock()
+        mock_record.__getitem__ = MagicMock(
+            return_value=json.dumps(tenant_config)
         )
 
+        mock_result = AsyncMock()
+        mock_result.single = AsyncMock(return_value=mock_record)
 
-@pytest.mark.asyncio
-async def test_bucket_key_format():
-    """Redis bucket key must follow the documented format."""
-    limiter = _make_limiter(_FakeRedis(), tenant_id="org-123", endpoint_type="admin")
-    assert limiter._bucket_key == "ratelimit:org-123:admin"
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.run = AsyncMock(return_value=mock_result)
 
+        mock_neo4j = MagicMock()
+        mock_neo4j.session = MagicMock(return_value=mock_session)
 
-@pytest.mark.asyncio
-async def test_config_cache_key_format():
-    """Redis config cache key must follow the documented format."""
-    limiter = _make_limiter(_FakeRedis(), tenant_id="org-456", endpoint_type="read")
-    assert limiter._config_key == "ratelimit_config:org-456"
+        limiter = TokenBucketRateLimiter(r, "neo4j-tenant", "write", neo4j_driver=mock_neo4j)
+        rate, burst = await limiter._get_rate_and_burst()
+
+        assert rate == 2.0
+        assert burst == 20.0
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_per_tenant_config_cached_in_redis_after_neo4j_load(self):
+        """
+        After loading the config from Neo4j, it must be stored in Redis
+        with the correct config key and TTL.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter, _CONFIG_CACHE_TTL
+
+        tenant_config = {"write": {"rate": 1.5, "burst": 15.0}}
+
+        r = MagicMock()
+        r.get = AsyncMock(return_value=None)  # cache miss
+        r.set = AsyncMock(return_value=True)
+        r.eval = AsyncMock(return_value=[1, 14])
+
+        mock_record = MagicMock()
+        mock_record.__getitem__ = MagicMock(return_value=json.dumps(tenant_config))
+
+        mock_result = AsyncMock()
+        mock_result.single = AsyncMock(return_value=mock_record)
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        mock_neo4j = MagicMock()
+        mock_neo4j.session = MagicMock(return_value=mock_session)
+
+        limiter = TokenBucketRateLimiter(r, "cache-tenant", "write", neo4j_driver=mock_neo4j)
+        await limiter._get_rate_and_burst()
+
+        # Redis.set must have been called to cache the config
+        r.set.assert_called()
+        set_call = r.set.call_args
+        assert set_call.kwargs.get("ex") == _CONFIG_CACHE_TTL or (
+            len(set_call.args) >= 3 and set_call.args[2] == _CONFIG_CACHE_TTL
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_per_tenant_config_read_from_redis_cache(self):
+        """
+        When the config is already in Redis, Neo4j must NOT be queried.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        cached_config = {"read": {"rate": 3.0, "burst": 30.0}}
+
+        r = MagicMock()
+        r.get = AsyncMock(return_value=json.dumps(cached_config))
+        r.eval = AsyncMock(return_value=[1, 29])
+
+        mock_neo4j = MagicMock()
+        mock_neo4j.session = MagicMock()
+
+        limiter = TokenBucketRateLimiter(r, "redis-cached-tenant", "read", neo4j_driver=mock_neo4j)
+        rate, burst = await limiter._get_rate_and_burst()
+
+        assert rate == 3.0
+        assert burst == 30.0
+        # Neo4j session must NOT have been called
+        mock_neo4j.session.assert_not_called()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_falls_back_to_defaults_when_no_config(self):
+        """
+        When neither Redis cache nor Neo4j has a config, defaults must be used.
+        """
+        from app.core.rate_limiter import TokenBucketRateLimiter, _DEFAULTS
+
+        r = MagicMock()
+        r.get = AsyncMock(return_value=None)  # no cache
+        r.eval = AsyncMock(return_value=[1, 9])
+
+        # Neo4j returns no record
+        mock_result = AsyncMock()
+        mock_result.single = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        mock_neo4j = MagicMock()
+        mock_neo4j.session = MagicMock(return_value=mock_session)
+
+        limiter = TokenBucketRateLimiter(r, "default-tenant", "write", neo4j_driver=mock_neo4j)
+        rate, burst = await limiter._get_rate_and_burst()
+
+        assert rate == _DEFAULTS["write"]["rate"]
+        assert burst == _DEFAULTS["write"]["burst"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_fails_open(self):
+        """
+        When Redis is unavailable during is_allowed(), the limiter must fail open
+        (allow the request) rather than blocking all traffic.
+        """
+        import redis.exceptions
+
+        from app.core.rate_limiter import TokenBucketRateLimiter
+
+        r = MagicMock()
+        r.get = AsyncMock(return_value=None)
+        r.eval = AsyncMock(side_effect=redis.exceptions.ConnectionError("refused"))
+
+        limiter = TokenBucketRateLimiter(r, "redis-down-tenant", "write")
+        allowed, headers = await limiter.is_allowed()
+
+        # Fail-open: must allow the request, not crash
+        assert allowed is True
 
 
 # ---------------------------------------------------------------------------
-# FastAPI integration: 429 response format
+# 6. KGB-4029 error code verification
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.unit
-def test_429_response_includes_kgb_4029():
-    """
-    The FastAPI app must return {"error_code": "KGB-4029", ...} on a 429
-    raised via HTTPException(429).
-    """
-    from fastapi import FastAPI, HTTPException
-    from fastapi.testclient import TestClient
+class TestRateLimitErrorCode:
+    """Rate limit exceeded must use error_code: KGB-4029."""
 
-    from app.core.errors import KGBError
+    @pytest.mark.unit
+    def test_kgb_rate_limit_exceeded_code_is_4029(self):
+        from app.core.errors import KGBError
 
-    test_app = FastAPI()
+        code, message = KGBError.RATE_LIMIT_EXCEEDED
+        assert code == "KGB-4029"
 
-    @test_app.exception_handler(HTTPException)
-    async def _handler(request, exc):
-        from fastapi.responses import JSONResponse
+    @pytest.mark.unit
+    def test_rate_limit_error_message_is_descriptive(self):
+        from app.core.errors import KGBError
 
-        if exc.status_code == 429:
-            code, msg = KGBError.RATE_LIMIT_EXCEEDED
-            headers = getattr(exc, "headers", None) or {}
-            retry_after = headers.get("Retry-After", "0")
-            return JSONResponse(
+        _, message = KGBError.RATE_LIMIT_EXCEEDED
+        assert len(message) > 0
+        assert "rate" in message.lower() or "limit" in message.lower()
+
+    @pytest.mark.unit
+    def test_main_app_http_exception_handler_maps_429_to_kgb_4029(self):
+        """
+        The HTTPException handler in main.py must map status 429 → KGB-4029.
+        """
+        from fastapi import FastAPI, HTTPException
+        from fastapi.testclient import TestClient
+        from unittest.mock import patch, AsyncMock
+
+        with (
+            patch("app.core.neo4j_client.neo4j_client.connect", new=AsyncMock()),
+            patch("app.core.database.create_tables", new=AsyncMock()),
+            patch("app.core.telemetry.setup_telemetry"),
+            patch("app.core.telemetry.instrument_fastapi"),
+        ):
+            from app.main import app
+
+        @app.get("/test-429")
+        async def raise_429():
+            raise HTTPException(
                 status_code=429,
-                headers=headers,
-                content={
-                    "error_code": code,
-                    "message": msg,
-                    "retry_after": int(retry_after) if str(retry_after).isdigit() else 0,
-                },
+                detail="Too Many Requests",
+                headers={"Retry-After": "10"},
             )
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
-    @test_app.get("/limited")
-    async def _endpoint():
-        raise HTTPException(
-            status_code=429,
-            headers={"Retry-After": "12", "X-RateLimit-Remaining": "0"},
-            detail="Rate limit exceeded",
-        )
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/test-429")
 
-    client = TestClient(test_app, raise_server_exceptions=False)
-    response = client.get("/limited")
+        assert response.status_code == 429
+        body = response.json()
+        assert body.get("error_code") == "KGB-4029"
 
-    assert response.status_code == 429
-    body = response.json()
-    assert body["error_code"] == "KGB-4029"
-    assert body["retry_after"] == 12
+    @pytest.mark.unit
+    def test_main_app_http_exception_handler_maps_404_to_kgb_4001(self):
+        """
+        The HTTPException handler in main.py must map status 404 → KGB-4001.
+        """
+        from fastapi import FastAPI, HTTPException
+        from fastapi.testclient import TestClient
+        from unittest.mock import patch, AsyncMock
 
+        with (
+            patch("app.core.neo4j_client.neo4j_client.connect", new=AsyncMock()),
+            patch("app.core.database.create_tables", new=AsyncMock()),
+            patch("app.core.telemetry.setup_telemetry"),
+            patch("app.core.telemetry.instrument_fastapi"),
+        ):
+            from app.main import app
 
-@pytest.mark.unit
-def test_404_response_includes_kgb_4001():
-    """The app must return {"error_code": "KGB-4001", ...} on a 404."""
-    from fastapi import FastAPI, HTTPException
-    from fastapi.testclient import TestClient
+        @app.get("/test-404")
+        async def raise_404():
+            raise HTTPException(status_code=404, detail="Graph not found")
 
-    from app.core.errors import KGBError
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/test-404")
 
-    test_app = FastAPI()
-
-    @test_app.exception_handler(HTTPException)
-    async def _handler(request, exc):
-        from fastapi.responses import JSONResponse
-
-        if exc.status_code == 404:
-            code, msg = KGBError.GRAPH_NOT_FOUND
-            return JSONResponse(
-                status_code=404,
-                content={"error_code": code, "message": msg, "detail": str(exc.detail)},
-            )
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
-
-    @test_app.get("/graphs/{graph_id}")
-    async def _endpoint(graph_id: str):
-        raise HTTPException(status_code=404, detail=f"Graph {graph_id!r} not found")
-
-    client = TestClient(test_app, raise_server_exceptions=False)
-    response = client.get("/graphs/nonexistent")
-
-    assert response.status_code == 404
-    body = response.json()
-    assert body["error_code"] == "KGB-4001"
-
-
-@pytest.mark.unit
-def test_403_response_includes_kgb_4003():
-    """The app must return {"error_code": "KGB-4003", ...} on a 403."""
-    from fastapi import FastAPI, HTTPException
-    from fastapi.testclient import TestClient
-
-    from app.core.errors import KGBError
-
-    test_app = FastAPI()
-
-    @test_app.exception_handler(HTTPException)
-    async def _handler(request, exc):
-        from fastapi.responses import JSONResponse
-
-        if exc.status_code == 403:
-            code, msg = KGBError.PERMISSION_DENIED
-            return JSONResponse(status_code=403, content={"error_code": code, "message": msg})
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
-
-    @test_app.get("/protected")
-    async def _endpoint():
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    client = TestClient(test_app, raise_server_exceptions=False)
-    response = client.get("/protected")
-
-    assert response.status_code == 403
-    body = response.json()
-    assert body["error_code"] == "KGB-4003"
+        assert response.status_code == 404
+        body = response.json()
+        assert body.get("error_code") == "KGB-4001"

--- a/knowledge-graph-builder/tests/unit/test_structured_errors.py
+++ b/knowledge-graph-builder/tests/unit/test_structured_errors.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for TASK-031 / STORY-009: structured KGB-XXXX error codes.
+
+Uses FastAPI TestClient to verify that the HTTPException handler in main.py
+returns the correct error_code in the response body for each scenario.
+
+Coverage:
+- 404 on unknown graph_id → error_code: KGB-4001 in response body
+- 403 on permission denied → error_code: KGB-4003 in response body
+- 503 on Neo4j down → error_code: KGB-5001 in response body
+- 429 on rate limit → error_code: KGB-4029 in response body
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def test_app():
+    """
+    Create a minimal FastAPI app with the structured HTTPException handler from
+    main.py. We patch heavy startup dependencies so the app can be instantiated
+    without a running Neo4j, Redis, or Celery.
+
+    We use `scope="module"` to import app once per module; FastAPI TestClient is
+    thread-safe for read-only test scenarios.
+    """
+    with (
+        patch("app.core.neo4j_client.neo4j_client.connect", new=AsyncMock()),
+        patch("app.core.database.create_tables", new=AsyncMock()),
+        patch("app.core.telemetry.setup_telemetry"),
+        patch("app.core.telemetry.instrument_fastapi"),
+    ):
+        from app.main import app as _app
+
+    # Register test-only routes that trigger each error condition
+    @_app.get("/test/graph-not-found")
+    async def _graph_not_found():
+        raise HTTPException(status_code=404, detail="Graph 'unknown-graph' does not exist")
+
+    @_app.get("/test/permission-denied")
+    async def _permission_denied():
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    @_app.get("/test/neo4j-down")
+    async def _neo4j_down():
+        raise HTTPException(status_code=503, detail="Neo4j connection failed")
+
+    @_app.get("/test/rate-limited")
+    async def _rate_limited():
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": "30"},
+        )
+
+    return _app
+
+
+@pytest.fixture(scope="module")
+def client(test_app):
+    return TestClient(test_app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. 404 → KGB-4001
+# ---------------------------------------------------------------------------
+
+
+class TestGraphNotFoundError:
+    @pytest.mark.unit
+    def test_404_returns_kgb_4001_error_code(self, client):
+        """404 on unknown graph_id must return error_code: KGB-4001."""
+        response = client.get("/test/graph-not-found")
+        assert response.status_code == 404
+        body = response.json()
+        assert body["error_code"] == "KGB-4001"
+
+    @pytest.mark.unit
+    def test_404_response_has_message_field(self, client):
+        """404 response must include a human-readable message field."""
+        response = client.get("/test/graph-not-found")
+        body = response.json()
+        assert "message" in body
+        assert len(body["message"]) > 0
+
+    @pytest.mark.unit
+    def test_404_response_has_detail_field(self, client):
+        """404 response must preserve the original detail string."""
+        response = client.get("/test/graph-not-found")
+        body = response.json()
+        assert "detail" in body
+
+    @pytest.mark.unit
+    def test_kgb_4001_code_matches_errors_module(self):
+        """The code returned by the handler must match KGBError.GRAPH_NOT_FOUND."""
+        from app.core.errors import KGBError
+
+        code, _ = KGBError.GRAPH_NOT_FOUND
+        assert code == "KGB-4001"
+
+
+# ---------------------------------------------------------------------------
+# 2. 403 → KGB-4003
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionDeniedError:
+    @pytest.mark.unit
+    def test_403_returns_kgb_4003_error_code(self, client):
+        """403 permission denied must return error_code: KGB-4003."""
+        response = client.get("/test/permission-denied")
+        assert response.status_code == 403
+        body = response.json()
+        assert body["error_code"] == "KGB-4003"
+
+    @pytest.mark.unit
+    def test_403_response_has_message_field(self, client):
+        """403 response must include a human-readable message field."""
+        response = client.get("/test/permission-denied")
+        body = response.json()
+        assert "message" in body
+        assert len(body["message"]) > 0
+
+    @pytest.mark.unit
+    def test_403_does_not_leak_internal_detail(self, client):
+        """
+        403 response should NOT include the original detail string from the exception
+        to avoid leaking internal permission logic to unauthorized callers.
+        """
+        response = client.get("/test/permission-denied")
+        body = response.json()
+        # The message should be the generic KGBError message, not the internal detail
+        assert body["error_code"] == "KGB-4003"
+
+    @pytest.mark.unit
+    def test_kgb_4003_code_matches_errors_module(self):
+        """The code returned by the handler must match KGBError.PERMISSION_DENIED."""
+        from app.core.errors import KGBError
+
+        code, _ = KGBError.PERMISSION_DENIED
+        assert code == "KGB-4003"
+
+
+# ---------------------------------------------------------------------------
+# 3. 503 → KGB-5001
+# ---------------------------------------------------------------------------
+
+
+class TestNeo4jDownError:
+    @pytest.mark.unit
+    def test_503_returns_kgb_5001_error_code(self, client):
+        """503 on Neo4j down must return error_code: KGB-5001."""
+        response = client.get("/test/neo4j-down")
+        assert response.status_code == 503
+        body = response.json()
+        assert body["error_code"] == "KGB-5001"
+
+    @pytest.mark.unit
+    def test_503_response_has_message_field(self, client):
+        """503 response must include a human-readable message field."""
+        response = client.get("/test/neo4j-down")
+        body = response.json()
+        assert "message" in body
+        assert len(body["message"]) > 0
+
+    @pytest.mark.unit
+    def test_503_response_has_detail_field(self, client):
+        """503 response must include the detail field for debugging."""
+        response = client.get("/test/neo4j-down")
+        body = response.json()
+        assert "detail" in body
+
+    @pytest.mark.unit
+    def test_kgb_5001_code_matches_errors_module(self):
+        """The code returned by the handler must match KGBError.NEO4J_UNAVAILABLE."""
+        from app.core.errors import KGBError
+
+        code, _ = KGBError.NEO4J_UNAVAILABLE
+        assert code == "KGB-5001"
+
+    @pytest.mark.unit
+    def test_neo4j_degradation_middleware_also_returns_kgb_5001(self):
+        """
+        The Neo4jDegradationMiddleware (for unhandled ServiceUnavailable exceptions)
+        must also use KGB-5001.
+        """
+        from neo4j.exceptions import ServiceUnavailable
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        from app.core.telemetry import Neo4jDegradationMiddleware
+
+        async def crash(request):
+            raise ServiceUnavailable("Neo4j is down")
+
+        app = Starlette(routes=[Route("/", crash)])
+        app.add_middleware(Neo4jDegradationMiddleware)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/")
+
+        assert response.status_code == 503
+        body = response.json()
+        assert body["error_code"] == "KGB-5001"
+
+
+# ---------------------------------------------------------------------------
+# 4. 429 → KGB-4029
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitError:
+    @pytest.mark.unit
+    def test_429_returns_kgb_4029_error_code(self, client):
+        """429 rate limit must return error_code: KGB-4029."""
+        response = client.get("/test/rate-limited")
+        assert response.status_code == 429
+        body = response.json()
+        assert body["error_code"] == "KGB-4029"
+
+    @pytest.mark.unit
+    def test_429_response_has_retry_after_in_headers(self, client):
+        """429 response must include the Retry-After header."""
+        response = client.get("/test/rate-limited")
+        # Retry-After can come from headers or response body
+        has_retry_after_header = "retry-after" in response.headers
+        has_retry_after_body = "retry_after" in response.json()
+        assert has_retry_after_header or has_retry_after_body
+
+    @pytest.mark.unit
+    def test_429_response_has_message_field(self, client):
+        """429 response must include a human-readable message."""
+        response = client.get("/test/rate-limited")
+        body = response.json()
+        assert "message" in body
+        assert len(body["message"]) > 0
+
+    @pytest.mark.unit
+    def test_kgb_4029_code_matches_errors_module(self):
+        """The code returned by the handler must match KGBError.RATE_LIMIT_EXCEEDED."""
+        from app.core.errors import KGBError
+
+        code, _ = KGBError.RATE_LIMIT_EXCEEDED
+        assert code == "KGB-4029"
+
+    @pytest.mark.unit
+    def test_429_retry_after_body_value_is_integer(self, client):
+        """
+        The retry_after field in the body must be an integer (seconds), not a string.
+        """
+        response = client.get("/test/rate-limited")
+        body = response.json()
+        if "retry_after" in body:
+            assert isinstance(body["retry_after"], int)
+
+
+# ---------------------------------------------------------------------------
+# 5. Unhandled status codes fall through without KGB code
+# ---------------------------------------------------------------------------
+
+
+class TestFallThroughStatusCodes:
+    @pytest.mark.unit
+    def test_400_bad_request_no_kgb_code(self, client):
+        """
+        Status codes without a KGB mapping must return plain detail, not a
+        KGB error code — avoids misleading clients with wrong error codes.
+        """
+        app = client.app
+
+        @app.get("/test/bad-request")
+        async def _bad_request():
+            raise HTTPException(status_code=400, detail="Bad request")
+
+        response = client.get("/test/bad-request")
+        assert response.status_code == 400
+        body = response.json()
+        # Must NOT have an error_code field (no KGB mapping for 400)
+        assert "error_code" not in body or body.get("error_code") is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Error code consistency — all codes defined and cross-checked
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCodeConsistency:
+    @pytest.mark.unit
+    def test_all_four_standard_error_codes_defined(self):
+        """All four standard error codes (4001, 4003, 4029, 5001) must be present."""
+        from app.core.errors import KGBError
+
+        assert KGBError.GRAPH_NOT_FOUND[0] == "KGB-4001"
+        assert KGBError.PERMISSION_DENIED[0] == "KGB-4003"
+        assert KGBError.RATE_LIMIT_EXCEEDED[0] == "KGB-4029"
+        assert KGBError.NEO4J_UNAVAILABLE[0] == "KGB-5001"
+
+    @pytest.mark.unit
+    def test_all_error_codes_start_with_kgb_prefix(self):
+        """All error codes must use the KGB- prefix for discoverability."""
+        from app.core.errors import KGBError
+
+        attrs = [
+            "NEO4J_UNAVAILABLE",
+            "REDIS_UNAVAILABLE",
+            "LLM_UNAVAILABLE",
+            "CELERY_UNAVAILABLE",
+            "GRAPH_NOT_FOUND",
+            "PERMISSION_DENIED",
+            "RATE_LIMIT_EXCEEDED",
+        ]
+        for attr in attrs:
+            code, _ = getattr(KGBError, attr)
+            assert code.startswith("KGB-"), f"{attr}: code '{code}' must start with KGB-"
+
+    @pytest.mark.unit
+    def test_error_codes_are_unique_no_collisions(self):
+        """No two error codes must share the same code string."""
+        from app.core.errors import KGBError
+
+        all_codes = [
+            KGBError.NEO4J_UNAVAILABLE[0],
+            KGBError.REDIS_UNAVAILABLE[0],
+            KGBError.LLM_UNAVAILABLE[0],
+            KGBError.CELERY_UNAVAILABLE[0],
+            KGBError.GRAPH_NOT_FOUND[0],
+            KGBError.PERMISSION_DENIED[0],
+            KGBError.RATE_LIMIT_EXCEEDED[0],
+        ]
+        assert len(all_codes) == len(set(all_codes)), (
+            f"Duplicate error codes found: {all_codes}"
+        )


### PR DESCRIPTION
## Summary

- Adds 93 unit tests verifying STORY-009 (production hardening) acceptance criteria across four test files: `test_query_cache_service.py`, `test_degradation.py`, `test_rate_limiter.py`, `test_structured_errors.py`
- Adds `test_caching_integration.py` (Docker post-merge) covering cache hit timing, ingest-triggered invalidation, and cross-tenant isolation
- All 93 unit tests pass against the implementations from TASK-028 (PR #49), TASK-029 (PR #52), TASK-030 (PR #50)

## Test plan

- [x] `tests/unit/test_query_cache_service.py` (26 tests): key uniqueness, cross-tenant isolation, cache hit/miss round-trip, multi-page SCAN, Redis ConnectionError resilience
- [x] `tests/unit/test_degradation.py` (21 tests): Neo4j 503+Retry-After+KGB-5001, Redis cache bypass, LLM APITimeoutError partial response, Celery OperationalError fallback queue
- [x] `tests/unit/test_rate_limiter.py` (24 tests): token bucket burst/throttle, token refill, per-tenant bucket isolation, Neo4j config loading, Redis fail-open, KGB-4029 HTTP exception handler
- [x] `tests/unit/test_structured_errors.py` (22 tests): FastAPI TestClient hits exception handlers directly for 404→KGB-4001, 403→KGB-4003, 503→KGB-5001, 429→KGB-4029; error code uniqueness and format consistency
- [ ] `tests/integration/test_caching_integration.py` (6 tests): run after TASK-028/029/030 PRs merge to develop — verifies cache_hit: True on second query (<1s), invalidation after ingest, cross-tenant cache isolation