### PR TITLE
TASK-033: Seven graph algorithm tools for agent execution

### DIFF
--- a/knowledge-graph-builder/app/schemas/agent_schemas.py
+++ b/knowledge-graph-builder/app/schemas/agent_schemas.py
@@ -92,3 +92,18 @@ class AgentCreateResponse(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     session_id: str | None = None
+
+
+# ── Agent tool result types ───────────────────────────────────────────────────
+
+
+class NodeResult(BaseModel):
+    id: str
+    qualified_name: str | None = None
+    label: str
+    properties: dict = {}
+
+
+class PathResult(BaseModel):
+    nodes: list[NodeResult]
+    hop_count: int

--- a/knowledge-graph-builder/app/services/agent_tools.py
+++ b/knowledge-graph-builder/app/services/agent_tools.py
@@ -1,0 +1,219 @@
+"""Seven graph-algorithm tools available to graph-native agents (TASK-033 / STORY-020).
+
+Each tool is an async method on AgentToolkit. Instantiate with a driver, the
+agent's allowed_tools list, and an optional embedder for graph_search.
+
+ToolNotPermittedError is raised at the top of every method, before any I/O,
+so the check cannot be bypassed by the calling code.
+"""
+
+import asyncio
+import inspect
+from typing import Any
+
+from neo4j import AsyncDriver
+
+from app.core.logging import get_logger
+from app.schemas.agent_schemas import NodeResult, PathResult
+
+logger = get_logger(__name__)
+
+_MAX_DEPTH = 20  # safety cap on variable-length traversals
+
+
+class ToolNotPermittedError(Exception):
+    """Raised when an agent calls a tool not in its allowlist."""
+
+    def __init__(self, tool_name: str) -> None:
+        super().__init__(f"Tool '{tool_name}' is not permitted for this agent")
+        self.tool_name = tool_name
+
+
+def _node_to_result(props: dict[str, Any]) -> NodeResult:
+    _skip = {"id", "node_id", "qualified_name", "label", "name", "embedding"}
+    return NodeResult(
+        id=str(props.get("id") or props.get("node_id") or ""),
+        qualified_name=props.get("qualified_name"),
+        label=str(props.get("label") or props.get("name") or ""),
+        properties={k: v for k, v in props.items() if k not in _skip},
+    )
+
+
+def _safe_label(label: str) -> str:
+    """Validate a Neo4j node label used as an f-string literal in Cypher."""
+    if not label.replace("_", "").isalnum():
+        raise ValueError(
+            f"Invalid node label {label!r}: only alphanumeric characters and underscores allowed"
+        )
+    return label
+
+
+class AgentToolkit:
+    """Executes graph algorithm tools scoped to a single agent's allowlist.
+
+    Parameters
+    ----------
+    driver:
+        Async Neo4j driver.
+    allowed_tools:
+        Tool names this agent is permitted to call (from the :Agent node).
+    embedder:
+        Object with an ``embed_query(text)`` method (sync or async) used by
+        ``graph_search``. May be None if graph_search is not in allowed_tools.
+    """
+
+    def __init__(
+        self,
+        driver: AsyncDriver,
+        allowed_tools: list[str],
+        embedder: Any = None,
+    ) -> None:
+        self._driver = driver
+        self._allowed = frozenset(allowed_tools)
+        self._embedder = embedder
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _require(self, tool_name: str) -> None:
+        if tool_name not in self._allowed:
+            raise ToolNotPermittedError(tool_name)
+
+    async def _embed(self, text: str) -> list[float]:
+        result = self._embedder.embed_query(text)
+        return await result if inspect.isawaitable(result) else result
+
+    # ── Tools ─────────────────────────────────────────────────────────────────
+
+    async def graph_search(
+        self, graph_id: str, query: str, max_results: int = 10
+    ) -> list[NodeResult]:
+        """Semantic similarity search over the graph's embedding space."""
+        self._require("graph_search")
+        embedding = await self._embed(query)
+        result = await self._driver.execute_query(
+            """
+            CALL db.index.vector.queryNodes('text_embeddings_primary', $max_results, $embedding)
+            YIELD node, score
+            WHERE node.graph_id = $gid
+            RETURN node, score
+            ORDER BY score DESC
+            """,
+            {"gid": graph_id, "max_results": max_results, "embedding": embedding},
+        )
+        return [_node_to_result(dict(rec["node"])) for rec in result.records]
+
+    async def community_members(
+        self, graph_id: str, community_id: str, max_results: int = 50
+    ) -> list[NodeResult]:
+        """Return all nodes belonging to a Leiden community."""
+        self._require("community_members")
+        result = await self._driver.execute_query(
+            """
+            MATCH (n {graph_id: $gid})-[:BELONGS_TO]->(:Community {community_id: $cid})
+            RETURN n
+            LIMIT $max_results
+            """,
+            {"gid": graph_id, "cid": community_id, "max_results": max_results},
+        )
+        return [_node_to_result(dict(rec["n"])) for rec in result.records]
+
+    async def neighbors(
+        self,
+        graph_id: str,
+        node_id: str,
+        edge_type: str | None = None,
+        depth: int = 1,
+    ) -> list[NodeResult]:
+        """BFS from node_id up to `depth` hops, optionally filtered by relationship type."""
+        self._require("neighbors")
+        depth = min(max(1, depth), _MAX_DEPTH)
+        # depth embedded as f-string — Neo4j 5.x does not allow range upper bounds as params
+        edge_filter = "AND ALL(rel IN r WHERE TYPE(rel) = $edge_type)" if edge_type else ""
+        query = f"""
+        MATCH (n {{graph_id: $gid, id: $nid}})-[r*1..{depth}]-(m)
+        WHERE m.graph_id = $gid {edge_filter}
+        RETURN DISTINCT m
+        """
+        params: dict[str, Any] = {"gid": graph_id, "nid": node_id}
+        if edge_type:
+            params["edge_type"] = edge_type
+        result = await self._driver.execute_query(query, params)
+        return [_node_to_result(dict(rec["m"])) for rec in result.records]
+
+    async def degree_centrality(
+        self, graph_id: str, node_label: str, top_n: int = 10
+    ) -> list[NodeResult]:
+        """Return top_n most-connected nodes of the given label (Cypher COUNT, not GDS)."""
+        self._require("degree_centrality")
+        label = _safe_label(node_label)
+        # label cannot be a Cypher parameter; validated above
+        query = f"""
+        MATCH (n:{label} {{graph_id: $gid}})-[r]-()
+        RETURN n, count(r) AS degree
+        ORDER BY degree DESC
+        LIMIT $top_n
+        """
+        result = await self._driver.execute_query(query, {"gid": graph_id, "top_n": top_n})
+        return [_node_to_result(dict(rec["n"])) for rec in result.records]
+
+    async def shortest_path(
+        self, graph_id: str, from_qname: str, to_qname: str
+    ) -> PathResult | None:
+        """Return shortest undirected path between two nodes by qualified_name."""
+        self._require("shortest_path")
+        result = await self._driver.execute_query(
+            """
+            MATCH p = shortestPath(
+                (a {graph_id: $gid})-[*]-(b {graph_id: $gid})
+            )
+            WHERE a.qualified_name = $from AND b.qualified_name = $to
+            RETURN p, length(p) AS hop_count
+            """,
+            {"gid": graph_id, "from": from_qname, "to": to_qname},
+        )
+        if not result.records:
+            return None
+        rec = result.records[0]
+        path = rec["p"]
+        nodes = [_node_to_result(dict(n)) for n in path.nodes]
+        return PathResult(nodes=nodes, hop_count=rec["hop_count"])
+
+    async def taint_trace(
+        self, graph_id: str, source_qname: str, depth: int = 10
+    ) -> list[NodeResult]:
+        """Follow FLOWS_TO edges from source_qname (valid for code knowledge graphs)."""
+        self._require("taint_trace")
+        depth = min(max(1, depth), _MAX_DEPTH)
+        # depth embedded as f-string — Neo4j 5.x does not allow range upper bounds as params
+        query = f"""
+        MATCH (src {{graph_id: $gid, qualified_name: $qname}})-[:FLOWS_TO*1..{depth}]->(sink)
+        WHERE sink.graph_id = $gid
+        RETURN DISTINCT sink
+        """
+        result = await self._driver.execute_query(
+            query, {"gid": graph_id, "qname": source_qname}
+        )
+        return [_node_to_result(dict(rec["sink"])) for rec in result.records]
+
+    async def temporal_slice(
+        self,
+        graph_id: str,
+        node_label: str,
+        at_time: int,
+        max_results: int = 50,
+    ) -> list[NodeResult]:
+        """Return nodes valid at a given point in time (bitemporal valid_from/valid_to)."""
+        self._require("temporal_slice")
+        label = _safe_label(node_label)
+        # label cannot be a Cypher parameter; validated above
+        query = f"""
+        MATCH (n:{label} {{graph_id: $gid}})
+        WHERE n.valid_from <= $at_time
+          AND (n.valid_to IS NULL OR n.valid_to >= $at_time)
+        RETURN n
+        LIMIT $max_results
+        """
+        result = await self._driver.execute_query(
+            query, {"gid": graph_id, "at_time": at_time, "max_results": max_results}
+        )
+        return [_node_to_result(dict(rec["n"])) for rec in result.records]

--- a/knowledge-graph-builder/tests/unit/test_agent_tools.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_tools.py
@@ -1,0 +1,375 @@
+"""Unit tests for the seven graph algorithm tools (TASK-033 / STORY-020).
+
+Every test:
+- Uses a mock Neo4j async driver — no real database required
+- Verifies graph_id is present in Cypher params (as $gid)
+- Verifies ToolNotPermittedError is raised when tool not in allowlist
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.schemas.agent_schemas import NodeResult, PathResult
+from app.services.agent_tools import AgentToolkit, ToolNotPermittedError
+
+
+# ── Test helpers ──────────────────────────────────────────────────────────────
+
+
+class _FakeNode(dict):
+    """Dict subclass that behaves like a Neo4j Node for dict() conversion."""
+
+
+def _make_driver(records=None):
+    mock_result = MagicMock()
+    mock_result.records = records or []
+    driver = AsyncMock()
+    driver.execute_query = AsyncMock(return_value=mock_result)
+    return driver, mock_result
+
+
+def _toolkit(driver, tools: list[str], embedder=None) -> AgentToolkit:
+    return AgentToolkit(driver, allowed_tools=tools, embedder=embedder)
+
+
+# ── ToolNotPermittedError ─────────────────────────────────────────────────────
+
+
+class TestToolNotPermitted:
+    async def test_graph_search_blocked(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).graph_search("g", "q")
+
+    async def test_community_members_blocked(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).community_members("g", "c")
+
+    async def test_neighbors_blocked(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).neighbors("g", "n")
+
+    async def test_degree_centrality_blocked(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).degree_centrality("g", "Person")
+
+    async def test_shortest_path_blocked(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).shortest_path("g", "a::b", "c::d")
+
+    async def test_taint_trace_blocked(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).taint_trace("g", "mod::fn")
+
+    async def test_temporal_slice_blocked(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).temporal_slice("g", "Event", 1000)
+
+    async def test_error_carries_tool_name(self):
+        driver, _ = _make_driver()
+        try:
+            await _toolkit(driver, []).taint_trace("g", "mod::fn")
+        except ToolNotPermittedError as exc:
+            assert exc.tool_name == "taint_trace"
+
+    async def test_allowed_tool_does_not_raise(self):
+        driver, _ = _make_driver()
+        # Should NOT raise — driver returns empty records
+        result = await _toolkit(driver, ["community_members"]).community_members("g", "c")
+        assert result == []
+
+
+# ── graph_search ──────────────────────────────────────────────────────────────
+
+
+class TestGraphSearch:
+    def _make_rec(self, props: dict):
+        node = _FakeNode(props)
+        rec = {"node": node, "score": 0.9}
+        return rec
+
+    async def test_returns_node_results(self):
+        rec = self._make_rec({"id": "n1", "label": "Foo", "graph_id": "g1"})
+        driver, _ = _make_driver(records=[rec])
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(return_value=[0.1, 0.2])
+        results = await _toolkit(driver, ["graph_search"], embedder).graph_search("g1", "query")
+        assert len(results) == 1
+        assert isinstance(results[0], NodeResult)
+
+    async def test_embed_query_called_with_text(self):
+        driver, _ = _make_driver()
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(return_value=[0.0])
+        await _toolkit(driver, ["graph_search"], embedder).graph_search("g1", "my question")
+        embedder.embed_query.assert_called_once_with("my question")
+
+    async def test_graph_id_in_params(self):
+        driver, _ = _make_driver()
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(return_value=[0.0])
+        await _toolkit(driver, ["graph_search"], embedder).graph_search("target-graph", "q")
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "target-graph"
+
+    async def test_max_results_in_params(self):
+        driver, _ = _make_driver()
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(return_value=[0.0])
+        await _toolkit(driver, ["graph_search"], embedder).graph_search("g", "q", max_results=7)
+        params = driver.execute_query.call_args[0][1]
+        assert params["max_results"] == 7
+
+
+# ── community_members ─────────────────────────────────────────────────────────
+
+
+class TestCommunityMembers:
+    async def test_returns_node_results(self):
+        rec = {"n": _FakeNode({"id": "n1", "label": "Member", "graph_id": "g1"})}
+        driver, _ = _make_driver(records=[rec])
+        results = await _toolkit(driver, ["community_members"]).community_members("g1", "c42")
+        assert len(results) == 1
+        assert isinstance(results[0], NodeResult)
+
+    async def test_graph_id_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["community_members"]).community_members("g-xyz", "c1")
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "g-xyz"
+
+    async def test_community_id_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["community_members"]).community_members("g", "comm-99")
+        params = driver.execute_query.call_args[0][1]
+        assert params["cid"] == "comm-99"
+
+    async def test_empty_returns_empty_list(self):
+        driver, _ = _make_driver(records=[])
+        results = await _toolkit(driver, ["community_members"]).community_members("g", "c")
+        assert results == []
+
+
+# ── neighbors ─────────────────────────────────────────────────────────────────
+
+
+class TestNeighbors:
+    async def test_returns_node_results(self):
+        rec = {"m": _FakeNode({"id": "m1", "label": "Neighbor", "graph_id": "g1"})}
+        driver, _ = _make_driver(records=[rec])
+        results = await _toolkit(driver, ["neighbors"]).neighbors("g1", "n1")
+        assert len(results) == 1
+
+    async def test_depth_embedded_as_literal_in_cypher(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["neighbors"]).neighbors("g1", "n1", depth=3)
+        cypher = driver.execute_query.call_args[0][0]
+        assert "*1..3" in cypher
+
+    async def test_depth_is_not_a_param(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["neighbors"]).neighbors("g1", "n1", depth=3)
+        params = driver.execute_query.call_args[0][1]
+        assert "depth" not in params
+
+    async def test_depth_capped_at_max(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["neighbors"]).neighbors("g1", "n1", depth=9999)
+        cypher = driver.execute_query.call_args[0][0]
+        assert "*1..20" in cypher
+
+    async def test_edge_type_filter_included(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["neighbors"]).neighbors("g1", "n1", edge_type="CALLS")
+        cypher = driver.execute_query.call_args[0][0]
+        params = driver.execute_query.call_args[0][1]
+        assert "edge_type" in params
+        assert params["edge_type"] == "CALLS"
+        assert "TYPE(rel)" in cypher
+
+    async def test_no_edge_type_no_filter(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["neighbors"]).neighbors("g1", "n1")
+        cypher = driver.execute_query.call_args[0][0]
+        params = driver.execute_query.call_args[0][1]
+        assert "edge_type" not in params
+        assert "TYPE(rel)" not in cypher
+
+    async def test_graph_id_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["neighbors"]).neighbors("g-abc", "n1")
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "g-abc"
+
+
+# ── degree_centrality ─────────────────────────────────────────────────────────
+
+
+class TestDegreeCentrality:
+    async def test_returns_node_results(self):
+        rec = {"n": _FakeNode({"id": "n1", "label": "Person", "graph_id": "g1"}), "degree": 5}
+        driver, _ = _make_driver(records=[rec])
+        results = await _toolkit(driver, ["degree_centrality"]).degree_centrality("g1", "Person")
+        assert len(results) == 1
+
+    async def test_node_label_embedded_in_cypher(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["degree_centrality"]).degree_centrality("g1", "Concept")
+        cypher = driver.execute_query.call_args[0][0]
+        assert ":Concept" in cypher
+
+    async def test_graph_id_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["degree_centrality"]).degree_centrality("g-123", "Entity")
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "g-123"
+
+    async def test_top_n_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["degree_centrality"]).degree_centrality("g", "X", top_n=3)
+        params = driver.execute_query.call_args[0][1]
+        assert params["top_n"] == 3
+
+    async def test_invalid_label_raises_value_error(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ValueError):
+            await _toolkit(driver, ["degree_centrality"]).degree_centrality("g", "DROP; MATCH(n)")
+
+    async def test_label_not_a_cypher_param(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["degree_centrality"]).degree_centrality("g", "Thing")
+        params = driver.execute_query.call_args[0][1]
+        assert "node_label" not in params
+
+
+# ── shortest_path ─────────────────────────────────────────────────────────────
+
+
+class TestShortestPath:
+    async def test_returns_none_when_no_path(self):
+        driver, _ = _make_driver(records=[])
+        result = await _toolkit(driver, ["shortest_path"]).shortest_path("g", "a::X", "b::Y")
+        assert result is None
+
+    async def test_returns_path_result(self):
+        n1 = _FakeNode({"id": "n1", "label": "A", "qualified_name": "mod::A", "graph_id": "g"})
+        n2 = _FakeNode({"id": "n2", "label": "B", "qualified_name": "mod::B", "graph_id": "g"})
+        mock_path = MagicMock()
+        mock_path.nodes = [n1, n2]
+        rec = {"p": mock_path, "hop_count": 1}
+        driver, _ = _make_driver(records=[rec])
+        result = await _toolkit(driver, ["shortest_path"]).shortest_path("g", "mod::A", "mod::B")
+        assert result is not None
+        assert isinstance(result, PathResult)
+        assert result.hop_count == 1
+        assert len(result.nodes) == 2
+
+    async def test_graph_id_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["shortest_path"]).shortest_path("g-999", "a", "b")
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "g-999"
+
+    async def test_from_and_to_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["shortest_path"]).shortest_path("g", "src::A", "dst::B")
+        params = driver.execute_query.call_args[0][1]
+        assert params["from"] == "src::A"
+        assert params["to"] == "dst::B"
+
+
+# ── taint_trace ───────────────────────────────────────────────────────────────
+
+
+class TestTaintTrace:
+    async def test_returns_node_results(self):
+        rec = {"sink": _FakeNode({"id": "s1", "label": "Sink", "graph_id": "g"})}
+        driver, _ = _make_driver(records=[rec])
+        results = await _toolkit(driver, ["taint_trace"]).taint_trace("g", "src::fn")
+        assert len(results) == 1
+
+    async def test_depth_embedded_as_literal_in_cypher(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["taint_trace"]).taint_trace("g", "src::main", depth=5)
+        cypher = driver.execute_query.call_args[0][0]
+        assert "*1..5" in cypher
+
+    async def test_depth_is_not_a_param(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["taint_trace"]).taint_trace("g", "src::main", depth=5)
+        params = driver.execute_query.call_args[0][1]
+        assert "depth" not in params
+
+    async def test_flows_to_in_cypher(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["taint_trace"]).taint_trace("g", "src::main")
+        cypher = driver.execute_query.call_args[0][0]
+        assert "FLOWS_TO" in cypher
+
+    async def test_graph_id_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["taint_trace"]).taint_trace("g-taint", "src::fn")
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "g-taint"
+
+    async def test_depth_capped_at_max(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["taint_trace"]).taint_trace("g", "src::fn", depth=9999)
+        cypher = driver.execute_query.call_args[0][0]
+        assert "*1..20" in cypher
+
+
+# ── temporal_slice ────────────────────────────────────────────────────────────
+
+
+class TestTemporalSlice:
+    async def test_returns_node_results(self):
+        rec = {"n": _FakeNode({"id": "e1", "label": "Event", "graph_id": "g", "valid_from": 0})}
+        driver, _ = _make_driver(records=[rec])
+        results = await _toolkit(driver, ["temporal_slice"]).temporal_slice("g", "Event", 500)
+        assert len(results) == 1
+
+    async def test_graph_id_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["temporal_slice"]).temporal_slice("g-time", "Event", 1000)
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "g-time"
+
+    async def test_at_time_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["temporal_slice"]).temporal_slice("g", "Event", 12345)
+        params = driver.execute_query.call_args[0][1]
+        assert params["at_time"] == 12345
+
+    async def test_valid_from_and_valid_to_in_cypher(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["temporal_slice"]).temporal_slice("g", "Event", 0)
+        cypher = driver.execute_query.call_args[0][0]
+        assert "valid_from" in cypher
+        assert "valid_to" in cypher
+
+    async def test_node_label_embedded_in_cypher(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["temporal_slice"]).temporal_slice("g", "Snapshot", 0)
+        cypher = driver.execute_query.call_args[0][0]
+        assert ":Snapshot" in cypher
+
+    async def test_invalid_label_raises_value_error(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ValueError):
+            await _toolkit(driver, ["temporal_slice"]).temporal_slice(
+                "g", "'; DROP TABLE events; --", 0
+            )
+
+    async def test_max_results_in_params(self):
+        driver, _ = _make_driver()
+        await _toolkit(driver, ["temporal_slice"]).temporal_slice("g", "Event", 0, max_results=25)
+        params = driver.execute_query.call_args[0][1]
+        assert params["max_results"] == 25


### PR DESCRIPTION
## Summary

- Implements `AgentToolkit` in `app/services/agent_tools.py` with all seven graph-algorithm tool methods: `graph_search`, `community_members`, `neighbors`, `degree_centrality`, `shortest_path`, `taint_trace`, `temporal_slice`
- Appends `NodeResult` and `PathResult` Pydantic models to `app/schemas/agent_schemas.py`
- 47 unit tests in `tests/unit/test_agent_tools.py` — all passing

## Key implementation decisions

- `ToolNotPermittedError` is checked as the first statement in every method, before any I/O, so the check cannot be bypassed
- `depth` is embedded as an f-string literal in `neighbors` and `taint_trace` per Neo4j 5.x constraint (range upper bounds cannot be runtime params); depth is capped at 20
- Node labels (`degree_centrality`, `temporal_slice`) are validated with `_safe_label()` — only alphanumeric + underscore allowed — before embedding in Cypher
- `edge_type` filtering in `neighbors` uses `WHERE TYPE(rel) = $edge_type` (parameterized) rather than embedding the type in the MATCH clause
- Embedder accepted as `Any` with `inspect.isawaitable` check so both sync (`OpenAIEmbeddings`) and async mock embedders work without wrapping

## Test plan

- [x] `ToolNotPermittedError` raised for all 7 tools when not in allowlist
- [x] `graph_id` present in Cypher params ($gid) for every tool
- [x] Depth f-string literal verified in Cypher string for `neighbors` and `taint_trace`
- [x] Depth not present as a runtime param
- [x] Depth capped at 20 for both variable-depth tools
- [x] Label injection raises `ValueError` for `degree_centrality` and `temporal_slice`
- [x] Functional result assertions for each tool
- [x] TASK-032 tests (17) still passing