### PR TITLE
TASK-034: Four reasoning modes, agent chat endpoint, and provenance

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/agents.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/agents.py
@@ -11,12 +11,16 @@ from app.api.dependencies import get_current_user_id, verify_graph_access
 from app.core.logging import get_logger
 from app.core.neo4j_client import neo4j_client
 from app.schemas.agent_schemas import (
+    AgentChatResponse,
     AgentCreate,
     AgentCreateResponse,
     AgentResponse,
     AgentUpdate,
+    ChatRequest,
 )
+from app.services.agent_executor import AgentExecutor
 from app.services.agent_service import AgentService
+from app.services.agent_tools import ToolNotPermittedError
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -142,3 +146,55 @@ async def delete_agent(
     deleted = await svc.deactivate_agent(graph_id, agent_id)
     if not deleted:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+
+# ── Chat ──────────────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/graphs/{graph_id}/agents/{agent_id}/chat",
+    response_model=AgentChatResponse,
+    summary="Run a chat turn against a graph-native agent",
+    responses={
+        400: {"description": "Tool not permitted for this agent"},
+        403: {"description": "Access denied"},
+        404: {"description": "Agent not found or deactivated"},
+        503: {"description": "Neo4j or LLM unavailable"},
+    },
+)
+async def agent_chat(
+    graph_id: str,
+    agent_id: str,
+    body: ChatRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    await verify_graph_access(graph_id, "read", user_id)
+
+    if not neo4j_client.async_driver:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Neo4j connection not available",
+        )
+
+    try:
+        executor = await AgentExecutor.from_neo4j(
+            neo4j_client.async_driver, graph_id, agent_id
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except NotImplementedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        )
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        )
+
+    try:
+        return await executor.run(body.message, body.session_id)
+    except ToolNotPermittedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )

--- a/knowledge-graph-builder/app/schemas/agent_schemas.py
+++ b/knowledge-graph-builder/app/schemas/agent_schemas.py
@@ -107,3 +107,19 @@ class NodeResult(BaseModel):
 class PathResult(BaseModel):
     nodes: list[NodeResult]
     hop_count: int
+
+
+class ProvenancePayload(BaseModel):
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    queries_executed: list[str] = []
+    nodes_used_in_response: list[str] = []
+    total_nodes_traversed: int = 0
+    reasoning_steps: int = 0
+    tools_called: list[str] = []
+
+
+class AgentChatResponse(BaseModel):
+    response: str
+    session_id: str | None = None
+    provenance: ProvenancePayload

--- a/knowledge-graph-builder/app/services/agent_executor.py
+++ b/knowledge-graph-builder/app/services/agent_executor.py
@@ -1,0 +1,269 @@
+"""Agent execution engine — four reasoning modes (TASK-034 / STORY-020).
+
+AgentExecutor is instantiated per chat request. It loads the agent definition
+from Neo4j, resolves the LLM client, and dispatches to the correct reasoning
+mode. Every execution produces a ProvenancePayload that the caller returns
+alongside the agent's response.
+
+Reasoning modes
+---------------
+direct          Single retrieval pass → generate (≤ 2 LLM calls)
+research        ReAct loop: retrieve → think → retrieve → generate (≤ 5 iterations)
+analytical      CoT reasoning section prepended before the final answer
+conversational  Full session history injected; warm tone system prompt suffix
+"""
+
+import json
+from typing import Any
+from uuid import uuid4
+
+from neo4j import AsyncDriver
+from openai import AsyncOpenAI
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.schemas.agent_schemas import AgentChatResponse, NodeResult, PathResult
+from app.services.agent_service import AgentService
+from app.services.agent_tools import AgentToolkit, ToolNotPermittedError
+from app.services.provenance import ProvenanceCollector
+
+logger = get_logger(__name__)
+
+# Process-scoped in-memory session store (conversational mode).
+# key: session_id, value: list of {"role": ..., "content": ...} dicts
+_sessions: dict[str, list[dict]] = {}
+
+_REACT_SYSTEM = """You are a graph-native research agent. To answer the question you \
+may call tools one at a time. After each tool result you will decide whether to call \
+another tool or produce a final answer.
+
+Respond ONLY with valid JSON — no prose, no markdown fences:
+  Call a tool : {{"action": "<tool_name>", "args": {{...}}}}
+  Final answer: {{"action": "answer", "text": "<your response>"}}
+
+Available tools: {tools}
+"""
+
+_CONVERSATIONAL_SUFFIX = (
+    "\n\nYou are having a friendly, ongoing conversation. "
+    "Reference earlier turns naturally where relevant."
+)
+
+
+def _format_nodes(nodes: list[NodeResult]) -> str:
+    if not nodes:
+        return "(no results)"
+    lines = []
+    for n in nodes:
+        qn = f" ({n.qualified_name})" if n.qualified_name else ""
+        lines.append(f"- [{n.id}] {n.label}{qn}")
+    return "\n".join(lines)
+
+
+def _extract_cited_nodes(response: str, nodes: list[dict]) -> list[str]:
+    """Return IDs of nodes whose id string appears literally in the response."""
+    return [n["id"] for n in nodes if n["id"] in response]
+
+
+class AgentExecutor:
+    """Runs a single agent's reasoning loop for one chat turn."""
+
+    def __init__(
+        self,
+        agent_def: dict[str, Any],
+        toolkit: AgentToolkit,
+        llm: AsyncOpenAI,
+        model: str,
+    ) -> None:
+        self._agent = agent_def
+        self._toolkit = toolkit
+        self._llm = llm
+        self._model = model
+
+    # ── Factory ───────────────────────────────────────────────────────────────
+
+    @classmethod
+    async def from_neo4j(
+        cls,
+        driver: AsyncDriver,
+        graph_id: str,
+        agent_id: str,
+    ) -> "AgentExecutor":
+        svc = AgentService(driver)
+        agent_def = await svc.get_agent(graph_id, agent_id)
+        if not agent_def:
+            raise ValueError(f"Agent '{agent_id}' not found in graph '{graph_id}'")
+
+        if agent_def.get("llm_config_id"):
+            raise NotImplementedError(
+                "LLM config resolution not yet implemented; leave llm_config_id null"
+            )
+
+        api_key = settings.OPENAI_API_KEY
+        if not api_key:
+            raise RuntimeError("No LLM API key configured (set OPENAI_API_KEY)")
+
+        model = getattr(settings, "LLM_MODEL", "gpt-4o")
+        llm = AsyncOpenAI(api_key=api_key)
+        toolkit = AgentToolkit(driver, agent_def["tools"])
+        return cls(agent_def, toolkit, llm, model)
+
+    # ── Public entry point ────────────────────────────────────────────────────
+
+    async def run(self, message: str, session_id: str | None) -> AgentChatResponse:
+        prov = ProvenanceCollector()
+        mode = self._agent.get("reasoning_mode", "direct")
+        returned_session_id = session_id
+
+        if mode == "direct":
+            response = await self._direct(message, prov)
+        elif mode == "research":
+            response = await self._research(message, prov)
+        elif mode == "analytical":
+            response = await self._analytical(message, prov)
+        elif mode == "conversational":
+            response, returned_session_id = await self._conversational(
+                message, session_id, prov
+            )
+        else:
+            response = await self._direct(message, prov)
+
+        prov.nodes_used_in_response = _extract_cited_nodes(response, prov._nodes)
+        return AgentChatResponse(
+            response=response,
+            session_id=returned_session_id,
+            provenance=prov.to_payload(),
+        )
+
+    # ── LLM helpers ───────────────────────────────────────────────────────────
+
+    async def _call_llm(
+        self, messages: list[dict], system_prompt: str | None = None
+    ) -> str:
+        sp = system_prompt or self._agent.get("system_prompt", "You are a helpful assistant.")
+        all_msgs = [{"role": "system", "content": sp}] + messages
+        resp = await self._llm.chat.completions.create(
+            model=self._model,
+            messages=all_msgs,
+            temperature=0.7,
+        )
+        return resp.choices[0].message.content or ""
+
+    # ── Tool dispatch ─────────────────────────────────────────────────────────
+
+    async def _dispatch(
+        self, name: str, args: dict, prov: ProvenanceCollector
+    ) -> list[NodeResult]:
+        graph_id = self._agent["graph_id"]
+        method = getattr(self._toolkit, name, None)
+        if method is None:
+            raise ToolNotPermittedError(name)
+
+        result = await method(graph_id, **args)
+
+        if isinstance(result, PathResult):
+            nodes = result.nodes
+        elif result is None:
+            nodes = []
+        else:
+            nodes = result
+
+        prov.record_tool(name, nodes)
+        return nodes
+
+    # ── Reasoning modes ───────────────────────────────────────────────────────
+
+    async def _direct(self, message: str, prov: ProvenanceCollector) -> str:
+        context = ""
+        if "graph_search" in self._agent.get("tools", []):
+            nodes = await self._dispatch("graph_search", {"query": message}, prov)
+            context = _format_nodes(nodes)
+
+        user_content = (
+            f"Context:\n{context}\n\nQuestion: {message}" if context else message
+        )
+        return await self._call_llm([{"role": "user", "content": user_content}])
+
+    async def _research(self, message: str, prov: ProvenanceCollector) -> str:
+        tools_list = ", ".join(self._agent.get("tools", []))
+        system = _REACT_SYSTEM.format(tools=tools_list)
+        messages: list[dict] = [{"role": "user", "content": message}]
+
+        for _ in range(5):
+            raw = await self._call_llm(messages, system_prompt=system)
+            messages.append({"role": "assistant", "content": raw})
+
+            try:
+                decision = json.loads(raw.strip())
+            except json.JSONDecodeError:
+                # Unparseable response — treat as final answer
+                return raw
+
+            action = decision.get("action", "answer")
+            if action == "answer":
+                return decision.get("text", raw)
+
+            # Tool call
+            args = decision.get("args", {})
+            try:
+                nodes = await self._dispatch(action, args, prov)
+            except (ToolNotPermittedError, TypeError) as exc:
+                messages.append(
+                    {"role": "user", "content": f"Tool error: {exc}. Try a different tool."}
+                )
+                continue
+
+            tool_result = _format_nodes(nodes)
+            messages.append(
+                {"role": "user", "content": f"Tool '{action}' result:\n{tool_result}"}
+            )
+
+        # Iteration cap reached — generate final answer with accumulated context
+        messages.append(
+            {"role": "user", "content": "Please provide your final answer based on the information gathered so far."}
+        )
+        return await self._call_llm(messages, system_prompt=system)
+
+    async def _analytical(self, message: str, prov: ProvenanceCollector) -> str:
+        context = ""
+        if "graph_search" in self._agent.get("tools", []):
+            nodes = await self._dispatch("graph_search", {"query": message}, prov)
+            context = _format_nodes(nodes)
+
+        user_content = (
+            f"Context:\n{context}\n\nQuestion: {message}\n\n"
+            "Think step by step before giving your final answer.\n\n"
+            "Reasoning:\n"
+        ) if context else (
+            f"{message}\n\nThink step by step before giving your final answer.\n\nReasoning:\n"
+        )
+        return await self._call_llm([{"role": "user", "content": user_content}])
+
+    async def _conversational(
+        self, message: str, session_id: str | None, prov: ProvenanceCollector
+    ) -> tuple[str, str]:
+        if session_id is None:
+            session_id = str(uuid4())
+
+        history = list(_sessions.get(session_id, []))
+
+        context = ""
+        if "graph_search" in self._agent.get("tools", []):
+            nodes = await self._dispatch("graph_search", {"query": message}, prov)
+            context = _format_nodes(nodes)
+
+        user_content = (
+            f"Context:\n{context}\n\nQuestion: {message}" if context else message
+        )
+
+        sp = self._agent.get("system_prompt", "You are a helpful assistant.")
+        system = sp + _CONVERSATIONAL_SUFFIX
+        messages = history + [{"role": "user", "content": user_content}]
+        response = await self._call_llm(messages, system_prompt=system)
+
+        _sessions[session_id] = history + [
+            {"role": "user", "content": message},
+            {"role": "assistant", "content": response},
+        ]
+
+        return response, session_id

--- a/knowledge-graph-builder/app/services/provenance.py
+++ b/knowledge-graph-builder/app/services/provenance.py
@@ -1,0 +1,36 @@
+"""Provenance tracking for agent execution (TASK-034 / STORY-020).
+
+ProvenanceCollector is passed through all reasoning mode methods and records
+every tool call, node returned, and query executed during a single agent run.
+"""
+
+from app.schemas.agent_schemas import NodeResult, ProvenancePayload
+
+
+class ProvenanceCollector:
+    """Accumulates execution evidence for a single agent chat turn."""
+
+    def __init__(self) -> None:
+        self._nodes: list[dict] = []
+        self._queries: list[str] = []
+        self._tools: list[str] = []
+        self.nodes_used_in_response: list[str] = []
+
+    def record_tool(self, tool_name: str, nodes: list[NodeResult]) -> None:
+        self._tools.append(tool_name)
+        for n in nodes:
+            self._nodes.append({"id": n.id, "label": n.label})
+
+    def record_query(self, cypher: str) -> None:
+        self._queries.append(cypher)
+
+    def to_payload(self) -> ProvenancePayload:
+        return ProvenancePayload(
+            nodes=list(self._nodes),
+            edges=[],
+            queries_executed=list(self._queries),
+            nodes_used_in_response=list(self.nodes_used_in_response),
+            total_nodes_traversed=len(self._nodes),
+            reasoning_steps=len(self._tools),
+            tools_called=list(self._tools),
+        )

--- a/knowledge-graph-builder/tests/unit/test_agent_executor.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_executor.py
@@ -1,0 +1,362 @@
+"""Unit tests for AgentExecutor — four reasoning modes and provenance (TASK-034 / STORY-020).
+
+Every test mocks:
+- The AgentToolkit (no Neo4j I/O)
+- The AsyncOpenAI client (no real LLM calls)
+Tests verify reasoning mode behaviour, provenance collection, session handling,
+and error surfacing.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.agent_schemas import AgentChatResponse, NodeResult
+from app.services.agent_executor import AgentExecutor, _sessions
+from app.services.agent_tools import AgentToolkit, ToolNotPermittedError
+from app.services.provenance import ProvenanceCollector
+
+
+# ── Test helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_agent(
+    graph_id: str = "g1",
+    mode: str = "direct",
+    tools: list[str] | None = None,
+    system_prompt: str = "You are helpful.",
+    llm_config_id: str | None = None,
+) -> dict:
+    return {
+        "agent_id": "agent-1",
+        "graph_id": graph_id,
+        "name": "Test",
+        "system_prompt": system_prompt,
+        "reasoning_mode": mode,
+        "tools": tools if tools is not None else ["graph_search"],
+        "llm_config_id": llm_config_id,
+    }
+
+
+def _make_toolkit(graph_search_returns=None) -> AgentToolkit:
+    nodes = graph_search_returns or [NodeResult(id="n1", label="Node", properties={})]
+    tk = MagicMock(spec=AgentToolkit)
+    tk.graph_search = AsyncMock(return_value=nodes)
+    tk.community_members = AsyncMock(return_value=[])
+    tk.neighbors = AsyncMock(return_value=[])
+    tk.degree_centrality = AsyncMock(return_value=[])
+    tk.shortest_path = AsyncMock(return_value=None)
+    tk.taint_trace = AsyncMock(return_value=[])
+    tk.temporal_slice = AsyncMock(return_value=[])
+    return tk
+
+
+def _make_llm(responses: list[str]) -> MagicMock:
+    """Build a mock AsyncOpenAI client returning responses in order."""
+    client = MagicMock()
+    completions = []
+    for text in responses:
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = text
+        completions.append(mock_resp)
+    client.chat.completions.create = AsyncMock(side_effect=completions)
+    return client
+
+
+def _executor(agent=None, toolkit=None, llm=None, responses=None) -> AgentExecutor:
+    if agent is None:
+        agent = _make_agent()
+    if toolkit is None:
+        toolkit = _make_toolkit()
+    if llm is None:
+        llm = _make_llm(responses or ["Default response."])
+    return AgentExecutor(agent, toolkit, llm, model="gpt-4o")
+
+
+# ── ProvenanceCollector ───────────────────────────────────────────────────────
+
+
+class TestProvenanceCollector:
+    def test_empty_payload(self):
+        prov = ProvenanceCollector()
+        p = prov.to_payload()
+        assert p.total_nodes_traversed == 0
+        assert p.reasoning_steps == 0
+        assert p.tools_called == []
+
+    def test_record_tool_adds_nodes(self):
+        prov = ProvenanceCollector()
+        prov.record_tool("graph_search", [NodeResult(id="n1", label="X", properties={})])
+        p = prov.to_payload()
+        assert p.total_nodes_traversed == 1
+        assert p.reasoning_steps == 1
+        assert "graph_search" in p.tools_called
+
+    def test_record_multiple_tools(self):
+        prov = ProvenanceCollector()
+        prov.record_tool("graph_search", [NodeResult(id="n1", label="A", properties={})])
+        prov.record_tool("neighbors", [NodeResult(id="n2", label="B", properties={})])
+        p = prov.to_payload()
+        assert p.total_nodes_traversed == 2
+        assert p.reasoning_steps == 2
+
+    def test_nodes_used_in_response_settable(self):
+        prov = ProvenanceCollector()
+        prov.nodes_used_in_response = ["n1", "n2"]
+        p = prov.to_payload()
+        assert p.nodes_used_in_response == ["n1", "n2"]
+
+
+# ── Direct mode ───────────────────────────────────────────────────────────────
+
+
+class TestDirectMode:
+    async def test_returns_agent_chat_response(self):
+        ex = _executor(responses=["The answer."])
+        result = await ex.run("What is X?", session_id=None)
+        assert isinstance(result, AgentChatResponse)
+        assert result.response == "The answer."
+
+    async def test_calls_graph_search_once(self):
+        tk = _make_toolkit()
+        ex = _executor(toolkit=tk, responses=["ok"])
+        await ex.run("question", session_id=None)
+        tk.graph_search.assert_called_once()
+
+    async def test_graph_id_passed_to_graph_search(self):
+        tk = _make_toolkit()
+        ex = _executor(agent=_make_agent(graph_id="my-graph"), toolkit=tk, responses=["ok"])
+        await ex.run("q", session_id=None)
+        call_args = tk.graph_search.call_args
+        assert call_args[0][0] == "my-graph"
+
+    async def test_provenance_records_tool_call(self):
+        ex = _executor(responses=["answer"])
+        result = await ex.run("q", session_id=None)
+        assert "graph_search" in result.provenance.tools_called
+
+    async def test_provenance_nodes_populated(self):
+        nodes = [NodeResult(id="abc", label="Thing", properties={})]
+        tk = _make_toolkit(graph_search_returns=nodes)
+        ex = _executor(toolkit=tk, responses=["the answer"])
+        result = await ex.run("q", session_id=None)
+        assert result.provenance.total_nodes_traversed == 1
+
+    async def test_skips_graph_search_when_not_in_tools(self):
+        tk = _make_toolkit()
+        agent = _make_agent(tools=["neighbors"])
+        ex = _executor(agent=agent, toolkit=tk, responses=["ok"])
+        await ex.run("q", session_id=None)
+        tk.graph_search.assert_not_called()
+
+    async def test_at_most_two_llm_calls(self):
+        llm = _make_llm(["resp1", "resp2", "resp3"])
+        ex = _executor(llm=llm)
+        await ex.run("q", session_id=None)
+        assert llm.chat.completions.create.call_count <= 2
+
+    async def test_nodes_used_in_response_contains_cited_id(self):
+        nodes = [NodeResult(id="node-xyz", label="Thing", properties={})]
+        tk = _make_toolkit(graph_search_returns=nodes)
+        ex = _executor(toolkit=tk, responses=["The node-xyz is relevant."])
+        result = await ex.run("q", session_id=None)
+        assert "node-xyz" in result.provenance.nodes_used_in_response
+
+
+# ── Research mode (ReAct) ─────────────────────────────────────────────────────
+
+
+class TestResearchMode:
+    def _react_responses(self, tool_calls: list[tuple[str, dict]], answer: str) -> list[str]:
+        """Build JSON response sequence for the ReAct loop."""
+        resp = []
+        for name, args in tool_calls:
+            resp.append(json.dumps({"action": name, "args": args}))
+        resp.append(json.dumps({"action": "answer", "text": answer}))
+        return resp
+
+    async def test_executes_at_least_two_tool_calls(self):
+        tk = _make_toolkit()
+        responses = self._react_responses(
+            [("graph_search", {"query": "step1"}), ("graph_search", {"query": "step2"})],
+            "Final answer",
+        )
+        agent = _make_agent(mode="research", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        await ex.run("What is Y?", session_id=None)
+        assert tk.graph_search.call_count >= 2
+
+    async def test_returns_answer_from_json(self):
+        tk = _make_toolkit()
+        responses = self._react_responses(
+            [("graph_search", {"query": "info"})],
+            "The definitive answer.",
+        )
+        agent = _make_agent(mode="research", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        result = await ex.run("question", session_id=None)
+        assert result.response == "The definitive answer."
+
+    async def test_caps_at_five_iterations(self):
+        tk = _make_toolkit()
+        # Always call a tool — never answer. Should cap at 5 and generate final answer.
+        looping = [json.dumps({"action": "graph_search", "args": {"query": "x"}})] * 6
+        looping.append("Final fallback answer")  # used when cap is reached
+        agent = _make_agent(mode="research", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, responses=looping)
+        result = await ex.run("q", session_id=None)
+        # At most 5 tool calls from ReAct + 1 final LLM call
+        assert tk.graph_search.call_count <= 5
+        assert result.response  # non-empty
+
+    async def test_provenance_records_all_tool_calls(self):
+        tk = _make_toolkit()
+        responses = self._react_responses(
+            [("graph_search", {"query": "a"}), ("graph_search", {"query": "b"})],
+            "Done",
+        )
+        agent = _make_agent(mode="research", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        result = await ex.run("q", session_id=None)
+        assert result.provenance.tools_called.count("graph_search") == 2
+
+    async def test_unparseable_llm_response_treated_as_answer(self):
+        tk = _make_toolkit()
+        agent = _make_agent(mode="research", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, responses=["not json at all"])
+        result = await ex.run("q", session_id=None)
+        assert result.response == "not json at all"
+
+    async def test_tool_error_continues_loop(self):
+        tk = _make_toolkit()
+        tk.graph_search = AsyncMock(side_effect=ToolNotPermittedError("graph_search"))
+        responses = [
+            json.dumps({"action": "graph_search", "args": {"query": "x"}}),
+            json.dumps({"action": "answer", "text": "Recovered answer"}),
+        ]
+        agent = _make_agent(mode="research", tools=[])
+        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        result = await ex.run("q", session_id=None)
+        assert result.response == "Recovered answer"
+
+
+# ── Analytical mode ───────────────────────────────────────────────────────────
+
+
+class TestAnalyticalMode:
+    async def test_returns_response(self):
+        agent = _make_agent(mode="analytical")
+        ex = _executor(agent=agent, responses=["Reasoning:\nStep 1...\n\nFinal Answer: X"])
+        result = await ex.run("Analyse this.", session_id=None)
+        assert "Reasoning" in result.response or result.response
+
+    async def test_prompt_contains_step_by_step_instruction(self):
+        tk = _make_toolkit()
+        llm = _make_llm(["analysis result"])
+        agent = _make_agent(mode="analytical")
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
+        await ex.run("q", session_id=None)
+        call_kwargs = llm.chat.completions.create.call_args
+        messages = call_kwargs[1]["messages"] if "messages" in call_kwargs[1] else call_kwargs[0][0]
+        full_text = " ".join(m["content"] for m in messages)
+        assert "step by step" in full_text.lower()
+
+    async def test_calls_graph_search_when_available(self):
+        tk = _make_toolkit()
+        agent = _make_agent(mode="analytical", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, responses=["result"])
+        await ex.run("q", session_id=None)
+        tk.graph_search.assert_called_once()
+
+    async def test_provenance_has_graph_search(self):
+        agent = _make_agent(mode="analytical")
+        ex = _executor(agent=agent, responses=["ok"])
+        result = await ex.run("q", session_id=None)
+        assert "graph_search" in result.provenance.tools_called
+
+
+# ── Conversational mode ───────────────────────────────────────────────────────
+
+
+class TestConversationalMode:
+    def setup_method(self):
+        _sessions.clear()
+
+    async def test_new_session_id_assigned(self):
+        agent = _make_agent(mode="conversational")
+        ex = _executor(agent=agent, responses=["Hello!"])
+        result = await ex.run("Hi", session_id=None)
+        assert result.session_id is not None
+
+    async def test_same_session_id_returned(self):
+        agent = _make_agent(mode="conversational")
+        ex = _executor(agent=agent, responses=["Hello!", "Follow-up"])
+        r1 = await ex.run("Turn 1", session_id=None)
+        r2 = await ex.run("Turn 2", session_id=r1.session_id)
+        assert r2.session_id == r1.session_id
+
+    async def test_history_injected_in_subsequent_turns(self):
+        tk = _make_toolkit()
+        llm = _make_llm(["First response", "Second response"])
+        agent = _make_agent(mode="conversational")
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
+
+        r1 = await ex.run("Turn 1", session_id=None)
+        await ex.run("Turn 2", session_id=r1.session_id)
+
+        # Second call should include history (prior user + assistant messages)
+        second_call_messages = llm.chat.completions.create.call_args_list[1][1]["messages"]
+        roles = [m["role"] for m in second_call_messages]
+        assert "assistant" in roles  # prior assistant turn injected
+
+    async def test_system_prompt_has_conversational_suffix(self):
+        tk = _make_toolkit()
+        llm = _make_llm(["response"])
+        agent = _make_agent(mode="conversational", system_prompt="Base prompt.")
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
+        await ex.run("q", session_id=None)
+        system_msg = llm.chat.completions.create.call_args[1]["messages"][0]["content"]
+        assert "ongoing conversation" in system_msg.lower()
+
+    async def test_different_sessions_are_independent(self):
+        agent = _make_agent(mode="conversational")
+        tk = _make_toolkit()
+        llm = _make_llm(["A1", "B1"])
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
+
+        r_a = await ex.run("Session A", session_id=None)
+        r_b = await ex.run("Session B", session_id=None)
+        assert r_a.session_id != r_b.session_id
+
+
+# ── AgentExecutor.from_neo4j error paths ──────────────────────────────────────
+
+
+class TestFromNeo4jErrors:
+    async def test_missing_agent_raises_value_error(self):
+        driver = MagicMock()
+        with patch("app.services.agent_executor.AgentService") as MockSvc:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=None)
+            with pytest.raises(ValueError, match="not found"):
+                await AgentExecutor.from_neo4j(driver, "g", "missing-id")
+
+    async def test_llm_config_id_set_raises_not_implemented(self):
+        driver = MagicMock()
+        agent = _make_agent(llm_config_id="some-config")
+        with patch("app.services.agent_executor.AgentService") as MockSvc:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            with pytest.raises(NotImplementedError):
+                await AgentExecutor.from_neo4j(driver, "g", "a")
+
+    async def test_no_api_key_raises_runtime_error(self):
+        driver = MagicMock()
+        agent = _make_agent()
+        with patch("app.services.agent_executor.AgentService") as MockSvc:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            with patch("app.services.agent_executor.settings") as mock_settings:
+                mock_settings.OPENAI_API_KEY = None
+                mock_settings.LLM_MODEL = "gpt-4o"
+                with pytest.raises(RuntimeError, match="API key"):
+                    await AgentExecutor.from_neo4j(driver, "g", "a")


### PR DESCRIPTION
## Summary

- `AgentExecutor` in `app/services/agent_executor.py`: `direct`, `research`, `analytical`, `conversational` modes
- `ProvenanceCollector` in `app/services/provenance.py`: records tools called, nodes traversed, queries executed per run
- `POST /graphs/{graph_id}/agents/{agent_id}/chat` endpoint appended to `agents.py`
- `ProvenancePayload` and `AgentChatResponse` Pydantic models added to `agent_schemas.py`
- 30 unit tests, all passing

## Key implementation decisions

| Decision | Rationale |
|----------|-----------|
| ReAct loop uses JSON-structured prompting (`{"action": "tool_name", "args": {...}}`) rather than OpenAI function-calling API | More portable, avoids vendor lock-in, fully testable with mock LLM |
| `nodes_used_in_response` populated by string-match of node IDs in response | Avoids extra LLM round-trip; sufficient for provenance audit |
| `_sessions` dict is process-scoped and module-level | Task spec: no persistence required for Phase 1 |
| `llm_config_id` set → 503 `NotImplementedError` | STORY-021 will implement BYOK resolution |
| `ToolNotPermittedError` caught at endpoint level → 400 | Keeps executor layer clean; error policy lives at HTTP boundary |

## Test plan

- [x] `direct` mode: graph_search called once, ≤2 LLM calls, provenance populated
- [x] `research` mode: ≥2 tool calls before answer, cap at 5 iterations, JSON parse fallback, tool error recovery
- [x] `analytical` mode: step-by-step instruction in prompt, provenance has graph_search
- [x] `conversational` mode: new session_id assigned, history injected on second turn, sessions are independent
- [x] `from_neo4j` error paths: missing agent → ValueError, llm_config_id set → NotImplementedError, no API key → RuntimeError
- [x] Full suite: 969/973 passing (4 pre-existing failures in test_chat_ownership.py, unrelated to this task)