### PR TITLE
TASK-035: Security review — ReBAC, graph_id scoping, tool allowlist

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/agents.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/agents.py
@@ -180,8 +180,8 @@ async def agent_chat(
         executor = await AgentExecutor.from_neo4j(
             neo4j_client.async_driver, graph_id, agent_id
         )
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
     except NotImplementedError as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)

--- a/knowledge-graph-builder/app/services/agent_tools.py
+++ b/knowledge-graph-builder/app/services/agent_tools.py
@@ -167,6 +167,7 @@ class AgentToolkit:
                 (a {graph_id: $gid})-[*]-(b {graph_id: $gid})
             )
             WHERE a.qualified_name = $from AND b.qualified_name = $to
+              AND ALL(n IN nodes(p) WHERE n.graph_id = $gid)
             RETURN p, length(p) AS hop_count
             """,
             {"gid": graph_id, "from": from_qname, "to": to_qname},


### PR DESCRIPTION
## Security Review — TASK-035

Reviewed: `agent_tools.py`, `agent_executor.py`, `provenance.py`, `agents.py` (endpoints)

---

### 1. graph_id isolation ✅ (1 fix required — applied)

All seven tools scope queries with `{graph_id: $gid}`. One gap found:

**BLOCKING — `shortest_path` cross-graph path traversal:**
`shortestPath()` anchored both endpoints to `graph_id` but intermediate nodes were unconstrained — a path could traverse nodes belonging to a different tenant.

**Fix applied:** Added `AND ALL(n IN nodes(p) WHERE n.graph_id = $gid)` to the WHERE clause.

### 2. ReBAC enforcement ✅

- All CRUD mutations require `admin` role; permission check is before the Neo4j write
- All reads require `read` role; check is before any query
- Deactivated agents return 404 via `WHERE a.deactivated_at IS NULL` in `get_agent()` — no graph contents queried before the 404

### 3. Tool allowlist ✅

- `ToolNotPermittedError` raised in the tool layer itself (`AgentToolkit._require`) before any I/O
- Allowlist loaded from the `:Agent` Neo4j node, not from the request body — caller cannot expand their own access
- Bypassing `AgentExecutor` does not bypass the check

### 4. Input validation ✅

- `system_prompt`/`name`/`description`: stored via parameterised Cypher; never eval'd or exec'd
- `message`: passed as a user-role string to the LLM; never interpolated into Cypher
- `session_id`: used only as an in-memory dict key; never passed to Neo4j or embedded in LLM prompts

### 5. Error message hygiene ✅ (1 fix required — applied)

**MINOR — 404 revealed internal message string** containing `agent_id` + `graph_id` (already in URL but still bad practice). **Fix applied:** `detail="Agent not found"` (generic).

**MINOR (noted, no fix for Phase 1):** In-memory session store has no eviction policy. Authenticated-only DoS vector. Acceptable per task scope; flagged for Phase 2.

---

**Verdict: SECURITY REVIEW PASSED** (blocking finding fixed; two minor items documented)

## Test plan

- [x] All 94 STORY-020 unit tests pass after fixes
- [x] `shortest_path` test confirms graph_id scoping in Cypher string