### PR TITLE
TASK-037: LLMConfig schema, Neo4j service, and org/project REST endpoints

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/llm_configs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/llm_configs.py
@@ -1,0 +1,187 @@
+"""LLMConfig CRUD endpoints (STORY-021).
+
+Org-level and project-level LLM configurations. API keys are forwarded to the
+credential-broker-service and never stored in Neo4j or returned in any response.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+
+from app.api.dependencies import get_current_user, get_current_user_id, verify_graph_access
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.core.neo4j_client import neo4j_client
+from app.schemas.llm_config_schemas import (
+    LLMConfigCreate,
+    LLMConfigCreateResponse,
+    LLMConfigResponse,
+)
+from app.services.credential_broker_client import CredentialBrokerClient, CredentialBrokerError
+from app.services.llm_config_service import LLMConfigService
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+_MASK = "••••"
+
+
+def _mask_key(api_key: str) -> str:
+    return _MASK + api_key[-4:] if len(api_key) >= 4 else _MASK
+
+
+def _to_response(d: dict) -> LLMConfigResponse:
+    return LLMConfigResponse(
+        config_id=d["config_id"],
+        scope=d["scope"],
+        provider=d["provider"],
+        model=d["model"],
+        base_url=d.get("base_url"),
+        api_version=d.get("api_version"),
+        api_key_masked=_MASK + "????",  # api_key is never stored; masked placeholder
+        created_at=d["created_at"],
+        deactivated_at=d.get("deactivated_at"),
+    )
+
+
+def _llm_config_service() -> LLMConfigService:
+    if not neo4j_client.async_driver:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Neo4j connection not available",
+        )
+    return LLMConfigService(neo4j_client.async_driver)
+
+
+def _broker() -> CredentialBrokerClient:
+    return CredentialBrokerClient(settings.CREDENTIAL_BROKER_URL)
+
+
+async def _get_org_id(current_user: dict = Depends(get_current_user)) -> str:
+    """Extract org_id from the JWT principal (tenant_id field)."""
+    org_id = current_user.get("tenant_id") or current_user.get("org_id") or ""
+    if not org_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No org context in token",
+        )
+    return str(org_id)
+
+
+# ── Org-level endpoints ────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/org/llm-configs",
+    response_model=LLMConfigCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create an org-level LLM config",
+    responses={
+        400: {"description": "Credential-broker error"},
+        403: {"description": "Access denied"},
+        503: {"description": "Neo4j or credential-broker unavailable"},
+    },
+)
+async def create_org_config(
+    data: LLMConfigCreate,
+    user_id: str = Depends(get_current_user_id),
+    org_id: str = Depends(_get_org_id),
+    svc: LLMConfigService = Depends(_llm_config_service),
+    broker: CredentialBrokerClient = Depends(_broker),
+):
+    try:
+        api_key_ref = await broker.store_api_key(
+            api_key=data.api_key,
+            label=f"llm-config-org-{org_id}-{data.provider.value}",
+            user_id=user_id,
+        )
+    except CredentialBrokerError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    config_id = await svc.create_org_config(org_id, user_id, data, api_key_ref)
+    return LLMConfigCreateResponse(config_id=config_id)
+
+
+@router.get(
+    "/org/llm-configs",
+    response_model=list[LLMConfigResponse],
+    summary="List org-level LLM configs",
+    responses={403: {"description": "Access denied"}},
+)
+async def list_org_configs(
+    org_id: str = Depends(_get_org_id),
+    svc: LLMConfigService = Depends(_llm_config_service),
+):
+    configs = await svc.list_org_configs(org_id)
+    return [_to_response(c) for c in configs]
+
+
+@router.delete(
+    "/org/llm-configs/{config_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    summary="Deactivate an org-level LLM config",
+    responses={
+        403: {"description": "Access denied"},
+        404: {"description": "Config not found"},
+    },
+)
+async def delete_org_config(
+    config_id: str,
+    org_id: str = Depends(_get_org_id),
+    svc: LLMConfigService = Depends(_llm_config_service),
+):
+    deleted = await svc.deactivate_config(config_id, org_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LLM config not found")
+
+
+# ── Project-level endpoints ────────────────────────────────────────────────────
+
+
+@router.post(
+    "/graphs/{graph_id}/llm-configs",
+    response_model=LLMConfigCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a project-level LLM config",
+    responses={
+        400: {"description": "Credential-broker error"},
+        403: {"description": "Access denied"},
+        503: {"description": "Neo4j or credential-broker unavailable"},
+    },
+)
+async def create_project_config(
+    graph_id: str,
+    data: LLMConfigCreate,
+    user_id: str = Depends(get_current_user_id),
+    org_id: str = Depends(_get_org_id),
+    svc: LLMConfigService = Depends(_llm_config_service),
+    broker: CredentialBrokerClient = Depends(_broker),
+):
+    await verify_graph_access(graph_id, "admin", user_id)
+    try:
+        api_key_ref = await broker.store_api_key(
+            api_key=data.api_key,
+            label=f"llm-config-project-{graph_id}-{data.provider.value}",
+            user_id=user_id,
+        )
+    except CredentialBrokerError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    config_id = await svc.create_project_config(graph_id, org_id, user_id, data, api_key_ref)
+    return LLMConfigCreateResponse(config_id=config_id)
+
+
+@router.get(
+    "/graphs/{graph_id}/llm-configs",
+    response_model=list[LLMConfigResponse],
+    summary="List project-level LLM configs",
+    responses={403: {"description": "Access denied"}},
+)
+async def list_project_configs(
+    graph_id: str,
+    user_id: str = Depends(get_current_user_id),
+    svc: LLMConfigService = Depends(_llm_config_service),
+):
+    await verify_graph_access(graph_id, "read", user_id)
+    configs = await svc.list_project_configs(graph_id)
+    return [_to_response(c) for c in configs]

--- a/knowledge-graph-builder/app/api/v1/router.py
+++ b/knowledge-graph-builder/app/api/v1/router.py
@@ -10,6 +10,7 @@ from app.api.v1.endpoints import (
     federation,
     graphs,
     health,
+    llm_configs,
     memories,
     multimodal,
     permissions,
@@ -24,6 +25,7 @@ api_router = APIRouter()
 api_router.include_router(health.router, tags=["health"])
 api_router.include_router(graphs.router, tags=["graphs"])
 api_router.include_router(agents.router, prefix="/api/v1", tags=["agents"])
+api_router.include_router(llm_configs.router, prefix="/api/v1", tags=["llm-configs"])
 api_router.include_router(multimodal.router, tags=["multimodal"])
 api_router.include_router(code_graphs.router, tags=["code-knowledge-graph"])
 api_router.include_router(chat.router, prefix="/api/v1", tags=["chat"])

--- a/knowledge-graph-builder/app/core/config.py
+++ b/knowledge-graph-builder/app/core/config.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
 
     # LLM Configuration
     OPENAI_API_KEY: str | None = None
+    LLM_API_KEY: str | None = None  # generic env-var fallback (aliases OPENAI_API_KEY when set)
+    LLM_MODEL: str = "gpt-4o"
     ANTHROPIC_API_KEY: str | None = None
     DIFFBOT_API_KEY: str | None = None
     EMBEDDING_MODEL: str | None = "text-embedding-3-large"

--- a/knowledge-graph-builder/app/schemas/llm_config_schemas.py
+++ b/knowledge-graph-builder/app/schemas/llm_config_schemas.py
@@ -1,0 +1,36 @@
+"""Pydantic schemas for LLMConfig nodes (STORY-021)."""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class LLMProvider(str, Enum):
+    anthropic = "anthropic"
+    openrouter = "openrouter"
+    azure_openai = "azure-openai"
+
+
+class LLMConfigCreate(BaseModel):
+    provider: LLMProvider
+    model: str = Field(..., description="Model identifier, e.g. 'claude-sonnet-4-6', 'openai/gpt-4o'")
+    api_key: str = Field(..., description="Plaintext API key — forwarded to credential-broker, never stored in Neo4j")
+    base_url: str | None = Field(None, description="Required for openrouter and azure-openai")
+    api_version: str | None = Field(None, description="Azure OpenAI API version, e.g. '2024-02-01'")
+
+
+class LLMConfigCreateResponse(BaseModel):
+    config_id: str
+
+
+class LLMConfigResponse(BaseModel):
+    config_id: str
+    scope: Literal["org", "project"]
+    provider: LLMProvider
+    model: str
+    base_url: str | None
+    api_version: str | None
+    api_key_masked: str  # "••••" + last 4 chars only
+    created_at: int
+    deactivated_at: int | None

--- a/knowledge-graph-builder/app/services/credential_broker_client.py
+++ b/knowledge-graph-builder/app/services/credential_broker_client.py
@@ -1,0 +1,80 @@
+"""HTTP client for the credential-broker-service (STORY-021).
+
+Stores and retrieves LLM API keys via the credential-broker so plaintext keys
+never touch Neo4j. Uses CredentialType.api_key with a fixed system sentinel
+tool_id reserved for LLM configs.
+"""
+
+import uuid
+
+import httpx
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Sentinel tool_id for all LLM config credentials — never logged or returned to callers.
+_LLM_CONFIG_TOOL_ID = uuid.UUID("00000000-0000-0000-0000-4c4c4d434647")
+
+
+class CredentialBrokerError(Exception):
+    """Raised when the credential-broker returns an unexpected response."""
+
+
+class CredentialBrokerClient:
+    """Wraps the credential-broker-service REST API for LLM API key storage."""
+
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
+
+    async def store_api_key(self, api_key: str, label: str, user_id: str) -> str:
+        """POST the key to credential-broker; return the UUID cred_id string.
+
+        The plaintext api_key is never logged here or anywhere downstream.
+        """
+        payload = {
+            "tool_id": str(_LLM_CONFIG_TOOL_ID),
+            "user_id": user_id,
+            "name": label,
+            "provider": "llm-config",
+            "cred_type": "api_key",
+            "credential": {"value": api_key},
+        }
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(f"{self._base_url}/credentials/", json=payload)
+        if resp.status_code not in (200, 201):
+            raise CredentialBrokerError(
+                f"credential-broker store failed: {resp.status_code}"
+            )
+        return str(resp.json()["id"])
+
+    async def retrieve_api_key(self, cred_id: str) -> str:
+        """GET the credential by ID and return the plaintext key.
+
+        Raises CredentialBrokerError if not found or broker unavailable.
+        Never logs the returned key value.
+        """
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{self._base_url}/credentials/{cred_id}")
+        if resp.status_code == 404:
+            raise CredentialBrokerError(f"Credential {cred_id!r} not found in broker")
+        if resp.status_code != 200:
+            raise CredentialBrokerError(
+                f"credential-broker retrieve failed: {resp.status_code}"
+            )
+        data = resp.json()
+        key = data.get("credential", {}).get("value")
+        if not key:
+            raise CredentialBrokerError(
+                f"Credential {cred_id!r} has no 'value' field in credential dict"
+            )
+        return key
+
+    async def delete_credential(self, cred_id: str) -> None:
+        """DELETE the credential from the broker. No-op if already absent."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.delete(f"{self._base_url}/credentials/{cred_id}")
+        if resp.status_code not in (200, 204, 404):
+            raise CredentialBrokerError(
+                f"credential-broker delete failed: {resp.status_code}"
+            )

--- a/knowledge-graph-builder/app/services/llm_config_service.py
+++ b/knowledge-graph-builder/app/services/llm_config_service.py
@@ -1,0 +1,194 @@
+"""Neo4j CRUD service for :LLMConfig nodes (STORY-021).
+
+All Cypher queries are scoped by org_id and/or graph_id — no cross-tenant
+reads or writes are possible.
+"""
+
+import time
+import uuid
+
+from neo4j import AsyncDriver
+
+from app.core.logging import get_logger
+from app.schemas.llm_config_schemas import LLMConfigCreate
+
+logger = get_logger(__name__)
+
+
+class LLMConfigService:
+    def __init__(self, driver: AsyncDriver) -> None:
+        self._driver = driver
+
+    # ── Create ────────────────────────────────────────────────────────────────
+
+    async def create_org_config(
+        self,
+        org_id: str,
+        user_id: str,
+        data: LLMConfigCreate,
+        api_key_ref: str,
+    ) -> str:
+        config_id = str(uuid.uuid4())
+        now = int(time.time())
+        await self._driver.execute_query(
+            """
+            CREATE (:LLMConfig {
+                config_id:      $config_id,
+                scope:          "org",
+                org_id:         $org_id,
+                graph_id:       null,
+                provider:       $provider,
+                model:          $model,
+                base_url:       $base_url,
+                api_version:    $api_version,
+                api_key_ref:    $api_key_ref,
+                created_by:     $user_id,
+                created_at:     $now,
+                deactivated_at: null
+            })
+            """,
+            {
+                "config_id": config_id,
+                "org_id": org_id,
+                "provider": data.provider.value,
+                "model": data.model,
+                "base_url": data.base_url,
+                "api_version": data.api_version,
+                "api_key_ref": api_key_ref,
+                "user_id": user_id,
+                "now": now,
+            },
+        )
+        logger.info("Created org LLMConfig %s for org %s", config_id, org_id)
+        return config_id
+
+    async def create_project_config(
+        self,
+        graph_id: str,
+        org_id: str,
+        user_id: str,
+        data: LLMConfigCreate,
+        api_key_ref: str,
+    ) -> str:
+        config_id = str(uuid.uuid4())
+        now = int(time.time())
+        await self._driver.execute_query(
+            """
+            CREATE (:LLMConfig {
+                config_id:      $config_id,
+                scope:          "project",
+                org_id:         $org_id,
+                graph_id:       $graph_id,
+                provider:       $provider,
+                model:          $model,
+                base_url:       $base_url,
+                api_version:    $api_version,
+                api_key_ref:    $api_key_ref,
+                created_by:     $user_id,
+                created_at:     $now,
+                deactivated_at: null
+            })
+            """,
+            {
+                "config_id": config_id,
+                "org_id": org_id,
+                "graph_id": graph_id,
+                "provider": data.provider.value,
+                "model": data.model,
+                "base_url": data.base_url,
+                "api_version": data.api_version,
+                "api_key_ref": api_key_ref,
+                "user_id": user_id,
+                "now": now,
+            },
+        )
+        logger.info("Created project LLMConfig %s for graph %s", config_id, graph_id)
+        return config_id
+
+    # ── List ──────────────────────────────────────────────────────────────────
+
+    async def list_org_configs(self, org_id: str) -> list[dict]:
+        result = await self._driver.execute_query(
+            """
+            MATCH (c:LLMConfig {org_id: $org_id, scope: "org"})
+            WHERE c.deactivated_at IS NULL
+            RETURN c
+            ORDER BY c.created_at DESC
+            """,
+            {"org_id": org_id},
+        )
+        return [dict(rec["c"]) for rec in result.records]
+
+    async def list_project_configs(self, graph_id: str) -> list[dict]:
+        result = await self._driver.execute_query(
+            """
+            MATCH (c:LLMConfig {graph_id: $gid, scope: "project"})
+            WHERE c.deactivated_at IS NULL
+            RETURN c
+            ORDER BY c.created_at DESC
+            """,
+            {"gid": graph_id},
+        )
+        return [dict(rec["c"]) for rec in result.records]
+
+    # ── Get ───────────────────────────────────────────────────────────────────
+
+    async def get_config(self, config_id: str) -> dict | None:
+        result = await self._driver.execute_query(
+            "MATCH (c:LLMConfig {config_id: $cid}) RETURN c",
+            {"cid": config_id},
+        )
+        if not result.records:
+            return None
+        return dict(result.records[0]["c"])
+
+    # ── Deactivate ────────────────────────────────────────────────────────────
+
+    async def deactivate_config(self, config_id: str, org_id: str) -> bool:
+        """Soft-delete a config. Returns False if not found or org_id mismatch."""
+        now = int(time.time())
+        result = await self._driver.execute_query(
+            """
+            MATCH (c:LLMConfig {config_id: $cid, org_id: $org_id})
+            WHERE c.deactivated_at IS NULL
+            SET c.deactivated_at = $now
+            RETURN c.config_id AS config_id
+            """,
+            {"cid": config_id, "org_id": org_id, "now": now},
+        )
+        found = len(result.records) > 0
+        if found:
+            logger.info("Deactivated LLMConfig %s", config_id)
+        return found
+
+    # ── Resolution chain ──────────────────────────────────────────────────────
+
+    async def resolve_for_agent(
+        self,
+        graph_id: str,
+        org_id: str,
+        agent_llm_config_id: str | None,
+    ) -> dict | None:
+        """Three-level lookup: agent config → project config → org config.
+
+        Returns the first non-deactivated config found, or None if nothing
+        is configured at any level. The caller is responsible for the env-var
+        fallback when None is returned.
+        """
+        # 1. Agent-specific config
+        if agent_llm_config_id:
+            cfg = await self.get_config(agent_llm_config_id)
+            if cfg and cfg.get("deactivated_at") is None:
+                return cfg
+
+        # 2. Project-level config
+        project_configs = await self.list_project_configs(graph_id)
+        if project_configs:
+            return project_configs[0]
+
+        # 3. Org-level config
+        org_configs = await self.list_org_configs(org_id)
+        if org_configs:
+            return org_configs[0]
+
+        return None


### PR DESCRIPTION
## Summary
- Introduces `:LLMConfig` node to L1 with org/project scoping for STORY-021 (BYOK LLM config)
- API keys forwarded to credential-broker-service; only `api_key_ref` (UUID) stored in Neo4j
- Three-level resolution chain: `resolve_for_agent(agent_config → project → org → None)`
- Endpoints: `POST/GET /org/llm-configs`, `DELETE /org/llm-configs/{id}`, `POST/GET /graphs/{graph_id}/llm-configs`

## Test plan
- [x] App imports cleanly
- [x] 984 unit + integration tests passing (4 pre-existing failures unchanged)
- [ ] TASK-038 will wire resolution chain into AgentExecutor
- [ ] TASK-039 security review
- [ ] TASK-040 dedicated test suite