### PR TITLE
TASK-038: Three-provider LLM adapter and resolution chain

### DIFF
--- a/knowledge-graph-builder/app/services/agent_executor.py
+++ b/knowledge-graph-builder/app/services/agent_executor.py
@@ -1,9 +1,10 @@
 """Agent execution engine — four reasoning modes (TASK-034 / STORY-020).
 
 AgentExecutor is instantiated per chat request. It loads the agent definition
-from Neo4j, resolves the LLM client, and dispatches to the correct reasoning
-mode. Every execution produces a ProvenancePayload that the caller returns
-alongside the agent's response.
+from Neo4j, resolves the LLM client via the three-level LLMConfig chain
+(agent → project → org → env-var fallback), and dispatches to the correct
+reasoning mode. Every execution produces a ProvenancePayload that the caller
+returns alongside the agent's response.
 
 Reasoning modes
 ---------------
@@ -25,6 +26,9 @@ from app.core.logging import get_logger
 from app.schemas.agent_schemas import AgentChatResponse, NodeResult, PathResult
 from app.services.agent_service import AgentService
 from app.services.agent_tools import AgentToolkit, ToolNotPermittedError
+from app.services.credential_broker_client import CredentialBrokerClient, CredentialBrokerError
+from app.services.llm_client_factory import LLMClientFactory
+from app.services.llm_config_service import LLMConfigService
 from app.services.provenance import ProvenanceCollector
 
 logger = get_logger(__name__)
@@ -94,17 +98,33 @@ class AgentExecutor:
         if not agent_def:
             raise ValueError(f"Agent '{agent_id}' not found in graph '{graph_id}'")
 
-        if agent_def.get("llm_config_id"):
-            raise NotImplementedError(
-                "LLM config resolution not yet implemented; leave llm_config_id null"
-            )
+        # Resolve LLM config: agent → project → org → env-var fallback
+        org_id = agent_def.get("org_id") or ""
+        svc_config = LLMConfigService(driver)
+        resolved = await svc_config.resolve_for_agent(
+            graph_id=graph_id,
+            org_id=org_id,
+            agent_llm_config_id=agent_def.get("llm_config_id"),
+        )
 
-        api_key = settings.OPENAI_API_KEY
-        if not api_key:
-            raise RuntimeError("No LLM API key configured (set OPENAI_API_KEY)")
+        if resolved:
+            try:
+                broker = CredentialBrokerClient(settings.CREDENTIAL_BROKER_URL)
+                api_key = await broker.retrieve_api_key(resolved["api_key_ref"])
+            except CredentialBrokerError as exc:
+                raise RuntimeError(f"Could not retrieve LLM API key: {exc}") from exc
+            config_dict = {**resolved, "api_key": api_key}
+            llm = LLMClientFactory.build(config_dict)
+            model = resolved["model"]
+        else:
+            api_key = settings.LLM_API_KEY or settings.OPENAI_API_KEY
+            if not api_key:
+                raise RuntimeError(
+                    "LLM not configured. Set an LLM config at org or project level."
+                )
+            model = settings.LLM_MODEL
+            llm = AsyncOpenAI(api_key=api_key)
 
-        model = getattr(settings, "LLM_MODEL", "gpt-4o")
-        llm = AsyncOpenAI(api_key=api_key)
         toolkit = AgentToolkit(driver, agent_def["tools"])
         return cls(agent_def, toolkit, llm, model)
 
@@ -141,13 +161,29 @@ class AgentExecutor:
         self, messages: list[dict], system_prompt: str | None = None
     ) -> str:
         sp = system_prompt or self._agent.get("system_prompt", "You are a helpful assistant.")
-        all_msgs = [{"role": "system", "content": sp}] + messages
-        resp = await self._llm.chat.completions.create(
-            model=self._model,
-            messages=all_msgs,
-            temperature=0.7,
-        )
-        return resp.choices[0].message.content or ""
+
+        try:
+            from anthropic import AsyncAnthropic
+            _is_anthropic = isinstance(self._llm, AsyncAnthropic)
+        except ImportError:
+            _is_anthropic = False
+
+        if _is_anthropic:
+            resp = await self._llm.messages.create(
+                model=self._model,
+                max_tokens=4096,
+                system=sp,
+                messages=messages,
+            )
+            return resp.content[0].text or ""
+        else:
+            all_msgs = [{"role": "system", "content": sp}] + messages
+            resp = await self._llm.chat.completions.create(
+                model=self._model,
+                messages=all_msgs,
+                temperature=0.7,
+            )
+            return resp.choices[0].message.content or ""
 
     # ── Tool dispatch ─────────────────────────────────────────────────────────
 

--- a/knowledge-graph-builder/app/services/llm_client_factory.py
+++ b/knowledge-graph-builder/app/services/llm_client_factory.py
@@ -1,0 +1,52 @@
+"""Constructs async LLM clients from a resolved LLMConfig dict (STORY-021).
+
+Three providers are supported:
+  anthropic    — AsyncAnthropic (native SDK)
+  openrouter   — AsyncOpenAI with custom base_url
+  azure-openai — AsyncAzureOpenAI with azure_endpoint + api_version
+"""
+
+from typing import Any, Union
+
+try:
+    from anthropic import AsyncAnthropic
+    _ANTHROPIC_AVAILABLE = True
+except ImportError:
+    AsyncAnthropic = None  # type: ignore[misc,assignment]
+    _ANTHROPIC_AVAILABLE = False
+
+from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+LLMClient = Union["AsyncAnthropic", AsyncOpenAI, AsyncAzureOpenAI]
+
+
+class LLMClientFactory:
+    @staticmethod
+    def build(config: dict[str, Any]) -> LLMClient:
+        """Return the appropriate async LLM client for *config*.
+
+        config keys used: provider, api_key, base_url, api_version
+        api_key must be the plaintext key retrieved from credential-broker.
+        """
+        provider = config["provider"]
+        api_key = config["api_key"]
+
+        if provider == "anthropic":
+            if not _ANTHROPIC_AVAILABLE:
+                raise RuntimeError(
+                    "anthropic SDK not installed; add 'anthropic' to requirements.txt"
+                )
+            return AsyncAnthropic(api_key=api_key)
+
+        if provider == "openrouter":
+            base_url = config.get("base_url") or "https://openrouter.ai/api/v1"
+            return AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+        if provider == "azure-openai":
+            return AsyncAzureOpenAI(
+                api_key=api_key,
+                azure_endpoint=config["base_url"],
+                api_version=config.get("api_version") or "2024-02-01",
+            )
+
+        raise ValueError(f"Unknown LLM provider: {provider!r}")

--- a/knowledge-graph-builder/tests/unit/test_agent_executor.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_executor.py
@@ -342,21 +342,36 @@ class TestFromNeo4jErrors:
             with pytest.raises(ValueError, match="not found"):
                 await AgentExecutor.from_neo4j(driver, "g", "missing-id")
 
-    async def test_llm_config_id_set_raises_not_implemented(self):
+    async def test_llm_config_id_resolved_via_chain(self):
         driver = MagicMock()
         agent = _make_agent(llm_config_id="some-config")
-        with patch("app.services.agent_executor.AgentService") as MockSvc:
+        resolved = {
+            "config_id": "some-config", "provider": "openrouter",
+            "model": "openai/gpt-4o", "base_url": "https://openrouter.ai/api/v1",
+            "api_version": None, "api_key_ref": "cred-123", "deactivated_at": None,
+        }
+        with patch("app.services.agent_executor.AgentService") as MockSvc, \
+             patch("app.services.agent_executor.LLMConfigService") as MockCfg, \
+             patch("app.services.agent_executor.CredentialBrokerClient") as MockBroker, \
+             patch("app.services.agent_executor.LLMClientFactory") as MockFactory:
             MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
-            with pytest.raises(NotImplementedError):
-                await AgentExecutor.from_neo4j(driver, "g", "a")
+            MockCfg.return_value.resolve_for_agent = AsyncMock(return_value=resolved)
+            MockBroker.return_value.retrieve_api_key = AsyncMock(return_value="sk-or-test")
+            MockFactory.build = MagicMock(return_value=MagicMock())
+            executor = await AgentExecutor.from_neo4j(driver, "g", "a")
+        assert executor is not None
 
     async def test_no_api_key_raises_runtime_error(self):
         driver = MagicMock()
         agent = _make_agent()
-        with patch("app.services.agent_executor.AgentService") as MockSvc:
+        with patch("app.services.agent_executor.AgentService") as MockSvc, \
+             patch("app.services.agent_executor.LLMConfigService") as MockCfg:
             MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            MockCfg.return_value.resolve_for_agent = AsyncMock(return_value=None)
             with patch("app.services.agent_executor.settings") as mock_settings:
+                mock_settings.LLM_API_KEY = None
                 mock_settings.OPENAI_API_KEY = None
                 mock_settings.LLM_MODEL = "gpt-4o"
-                with pytest.raises(RuntimeError, match="API key"):
+                mock_settings.CREDENTIAL_BROKER_URL = "http://broker:8000"
+                with pytest.raises(RuntimeError, match="LLM not configured"):
                     await AgentExecutor.from_neo4j(driver, "g", "a")


### PR DESCRIPTION
## Summary
- `LLMClientFactory` builds correct async client for anthropic/openrouter/azure-openai
- `AgentExecutor.from_neo4j` now resolves LLM config: agent → project → org → env-var fallback
- `_call_llm` dispatches to Anthropic `messages.create` or OpenAI-compatible `chat.completions.create`
- Closes `NotImplementedError` left in STORY-020 for `llm_config_id` path
- Updated 2 unit tests to reflect new behavior (no longer `NotImplementedError`; new error message)

## Test plan
- [x] 45 agent executor + integration tests passing
- [ ] TASK-039 security review
- [ ] TASK-040 dedicated LLM config test suite