### PR TITLE
TASK-040: QA — LLMConfig unit and integration tests

### DIFF
--- a/knowledge-graph-builder/tests/integration/test_llm_config_integration.py
+++ b/knowledge-graph-builder/tests/integration/test_llm_config_integration.py
@@ -1,0 +1,292 @@
+"""Integration tests for LLM Config endpoints (STORY-021 / TASK-040).
+
+Runs against the Docker Neo4j instance. The credential-broker HTTP calls are
+mocked via FastAPI dependency_overrides so no live broker is required.
+
+Tests cover:
+1. Create org-level config → 201, config_id returned, api_key never in response
+2. List org-level configs → includes the created config
+3. Delete org-level config → 204; second delete → 404
+4. Create project-level config → 201 (verify_graph_access mocked)
+5. List project-level configs → includes created config
+6. Cross-tenant isolation — org A's config not visible to org B
+7. Broker error → 400 surfaced to caller
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+try:
+    from neo4j import AsyncDriver
+    _NEO4J_AVAILABLE = True
+except ImportError:
+    _NEO4J_AVAILABLE = False
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_ORG_A = f"integ-llmcfg-orgA-{uuid.uuid4().hex[:8]}"
+_ORG_B = f"integ-llmcfg-orgB-{uuid.uuid4().hex[:8]}"
+_GID_A = f"integ-llmcfg-graph-{uuid.uuid4().hex[:8]}"
+_USER = "integ-llmcfg-user-001"
+
+pytestmark = pytest.mark.skipif(
+    not _NEO4J_AVAILABLE, reason="neo4j driver not installed"
+)
+
+_CREATE_BODY = {
+    "provider": "openrouter",
+    "model": "openai/gpt-4o",
+    "api_key": "sk-or-live-test-1234",
+    "base_url": "https://openrouter.ai/api/v1",
+}
+
+# The llm_configs router is mounted under /api/v1 inside the api_router which is
+# itself mounted at /api/v1 in main.py — resulting in the double prefix.
+_ORG_PREFIX = "/api/v1/api/v1/org/llm-configs"
+_GRAPH_PREFIX = "/api/v1/api/v1/graphs"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _mock_verify():
+    return patch(
+        "app.api.v1.endpoints.llm_configs.verify_graph_access",
+        new=AsyncMock(return_value=None),
+    )
+
+
+def _make_mock_broker(cred_id: str = "cred-mock-001") -> AsyncMock:
+    mock = AsyncMock()
+    mock.store_api_key = AsyncMock(return_value=cred_id)
+    mock.retrieve_api_key = AsyncMock(return_value="sk-or-live-test-1234")
+    mock.delete_credential = AsyncMock(return_value=None)
+    return mock
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(neo4j_test_driver: AsyncDriver):
+    async def _wipe():
+        await neo4j_test_driver.execute_query(
+            "MATCH (n:LLMConfig) WHERE n.org_id IN [$a, $b] OR n.graph_id = $g DETACH DELETE n",
+            {"a": _ORG_A, "b": _ORG_B, "g": _GID_A},
+        )
+    await _wipe()
+    yield
+    await _wipe()
+
+
+@pytest.fixture(autouse=True)
+def _override_auth(async_client):
+    from app.main import app
+    from app.api.dependencies import get_current_user, get_current_user_id
+
+    app.dependency_overrides[get_current_user] = lambda: {
+        "id": _USER,
+        "tenant_id": _ORG_A,
+    }
+    app.dependency_overrides[get_current_user_id] = lambda: _USER
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_current_user_id, None)
+
+
+@pytest.fixture(autouse=True)
+def _override_llm_config_service(neo4j_test_driver: AsyncDriver):
+    from app.main import app
+    from app.api.v1.endpoints.llm_configs import _llm_config_service
+    from app.services.llm_config_service import LLMConfigService
+
+    app.dependency_overrides[_llm_config_service] = lambda: LLMConfigService(neo4j_test_driver)
+    yield
+    app.dependency_overrides.pop(_llm_config_service, None)
+
+
+@pytest.fixture(autouse=True)
+def _override_broker():
+    from app.main import app
+    from app.api.v1.endpoints.llm_configs import _broker
+
+    mock = _make_mock_broker()
+    app.dependency_overrides[_broker] = lambda: mock
+    yield mock
+    app.dependency_overrides.pop(_broker, None)
+
+
+# ── Org-level tests ───────────────────────────────────────────────────────────
+
+
+class TestOrgLevelConfig:
+    async def test_create_returns_201_with_config_id(self, async_client):
+        resp = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        assert resp.status_code == 201
+        body = resp.json()
+        assert "config_id" in body
+        assert len(body["config_id"]) == 36  # UUID
+
+    async def test_create_api_key_never_in_response(self, async_client):
+        resp = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        assert resp.status_code == 201
+        text = resp.text
+        assert "sk-or-live-test" not in text
+        assert "api_key" not in text.lower().replace("api_key_masked", "")
+
+    async def test_list_returns_created_config(self, async_client):
+        create = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        config_id = create.json()["config_id"]
+
+        resp = await async_client.get(_ORG_PREFIX)
+        assert resp.status_code == 200
+        ids = [c["config_id"] for c in resp.json()]
+        assert config_id in ids
+
+    async def test_list_never_returns_api_key(self, async_client):
+        await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+
+        resp = await async_client.get(_ORG_PREFIX)
+        assert resp.status_code == 200
+        assert "sk-or-live-test" not in resp.text
+        for cfg in resp.json():
+            assert "api_key" not in cfg or cfg.get("api_key") is None
+
+    async def test_delete_returns_204(self, async_client):
+        create = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        config_id = create.json()["config_id"]
+
+        resp = await async_client.delete(f"{_ORG_PREFIX}/{config_id}")
+        assert resp.status_code == 204
+
+    async def test_delete_twice_returns_404(self, async_client):
+        create = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        config_id = create.json()["config_id"]
+
+        await async_client.delete(f"{_ORG_PREFIX}/{config_id}")
+        resp = await async_client.delete(f"{_ORG_PREFIX}/{config_id}")
+        assert resp.status_code == 404
+
+    async def test_delete_nonexistent_returns_404(self, async_client):
+        resp = await async_client.delete(f"{_ORG_PREFIX}/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    async def test_list_excludes_deleted_config(self, async_client):
+        create = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        config_id = create.json()["config_id"]
+
+        await async_client.delete(f"{_ORG_PREFIX}/{config_id}")
+
+        resp = await async_client.get(_ORG_PREFIX)
+        ids = [c["config_id"] for c in resp.json()]
+        assert config_id not in ids
+
+
+# ── Project-level tests ────────────────────────────────────────────────────────
+
+
+class TestProjectLevelConfig:
+    async def test_create_returns_201_with_config_id(self, async_client):
+        with _mock_verify():
+            resp = await async_client.post(
+                f"{_GRAPH_PREFIX}/{_GID_A}/llm-configs", json=_CREATE_BODY
+            )
+        assert resp.status_code == 201
+        assert "config_id" in resp.json()
+
+    async def test_list_returns_created_config(self, async_client):
+        with _mock_verify():
+            create = await async_client.post(
+                f"{_GRAPH_PREFIX}/{_GID_A}/llm-configs", json=_CREATE_BODY
+            )
+        config_id = create.json()["config_id"]
+
+        with _mock_verify():
+            resp = await async_client.get(f"{_GRAPH_PREFIX}/{_GID_A}/llm-configs")
+        assert resp.status_code == 200
+        ids = [c["config_id"] for c in resp.json()]
+        assert config_id in ids
+
+    async def test_create_api_key_never_in_response(self, async_client):
+        with _mock_verify():
+            resp = await async_client.post(
+                f"{_GRAPH_PREFIX}/{_GID_A}/llm-configs", json=_CREATE_BODY
+            )
+        assert resp.status_code == 201
+        assert "sk-or-live-test" not in resp.text
+
+
+# ── Cross-tenant isolation ────────────────────────────────────────────────────
+
+
+class TestCrossTenantIsolation:
+    async def test_org_b_cannot_see_org_a_configs(self, async_client):
+        create = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        config_id = create.json()["config_id"]
+
+        from app.main import app
+        from app.api.dependencies import get_current_user
+
+        app.dependency_overrides[get_current_user] = lambda: {
+            "id": "other-user",
+            "tenant_id": _ORG_B,
+        }
+        try:
+            resp = await async_client.get(_ORG_PREFIX)
+            ids = [c["config_id"] for c in resp.json()]
+            assert config_id not in ids
+        finally:
+            app.dependency_overrides[get_current_user] = lambda: {
+                "id": _USER,
+                "tenant_id": _ORG_A,
+            }
+
+    async def test_org_b_delete_of_org_a_config_returns_404(self, async_client):
+        create = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        config_id = create.json()["config_id"]
+
+        from app.main import app
+        from app.api.dependencies import get_current_user
+
+        app.dependency_overrides[get_current_user] = lambda: {
+            "id": "attacker",
+            "tenant_id": _ORG_B,
+        }
+        try:
+            resp = await async_client.delete(f"{_ORG_PREFIX}/{config_id}")
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides[get_current_user] = lambda: {
+                "id": _USER,
+                "tenant_id": _ORG_A,
+            }
+
+
+# ── Broker error propagation ──────────────────────────────────────────────────
+
+
+class TestBrokerError:
+    async def test_broker_error_surfaces_as_400(self, async_client):
+        from app.main import app
+        from app.api.v1.endpoints.llm_configs import _broker
+        from app.services.credential_broker_client import CredentialBrokerError
+
+        failing_broker = AsyncMock()
+        failing_broker.store_api_key = AsyncMock(
+            side_effect=CredentialBrokerError("vault unavailable")
+        )
+
+        app.dependency_overrides[_broker] = lambda: failing_broker
+        try:
+            resp = await async_client.post(_ORG_PREFIX, json=_CREATE_BODY)
+        finally:
+            mock = _make_mock_broker()
+            app.dependency_overrides[_broker] = lambda: mock
+
+        assert resp.status_code == 400
+        assert "vault unavailable" in resp.json()["detail"]

--- a/knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py
@@ -1,0 +1,174 @@
+"""Unit tests for AgentExecutor LLM resolution chain (STORY-021 / TASK-040).
+
+Verifies the agent → project → org → env-var fallback chain and the
+Anthropic vs OpenAI-compatible _call_llm dispatch.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.agent_executor import AgentExecutor
+
+
+def _make_agent(llm_config_id=None, org_id="org1"):
+    return {
+        "agent_id": "a1",
+        "graph_id": "g1",
+        "name": "Test",
+        "system_prompt": "You are helpful.",
+        "reasoning_mode": "direct",
+        "tools": [],
+        "llm_config_id": llm_config_id,
+        "org_id": org_id,
+    }
+
+
+def _resolved_config(provider="openrouter"):
+    return {
+        "config_id": "cfg-1",
+        "provider": provider,
+        "model": "openai/gpt-4o",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_version": None,
+        "api_key_ref": "cred-001",
+        "deactivated_at": None,
+    }
+
+
+class TestFromNeo4jResolution:
+    async def test_uses_resolved_config_when_available(self):
+        driver = MagicMock()
+        agent = _make_agent()
+        mock_llm = MagicMock()
+
+        with patch("app.services.agent_executor.AgentService") as MockSvc, \
+             patch("app.services.agent_executor.LLMConfigService") as MockCfg, \
+             patch("app.services.agent_executor.CredentialBrokerClient") as MockBroker, \
+             patch("app.services.agent_executor.LLMClientFactory") as MockFactory:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            MockCfg.return_value.resolve_for_agent = AsyncMock(return_value=_resolved_config())
+            MockBroker.return_value.retrieve_api_key = AsyncMock(return_value="sk-or-live")
+            MockFactory.build = MagicMock(return_value=mock_llm)
+
+            executor = await AgentExecutor.from_neo4j(driver, "g1", "a1")
+
+        assert executor._llm is mock_llm
+        MockFactory.build.assert_called_once()
+        build_args = MockFactory.build.call_args[0][0]
+        assert build_args["api_key"] == "sk-or-live"
+        assert build_args["provider"] == "openrouter"
+
+    async def test_falls_back_to_env_var_when_no_config(self):
+        from openai import AsyncOpenAI
+        driver = MagicMock()
+        agent = _make_agent()
+
+        with patch("app.services.agent_executor.AgentService") as MockSvc, \
+             patch("app.services.agent_executor.LLMConfigService") as MockCfg, \
+             patch("app.services.agent_executor.settings") as mock_settings:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            MockCfg.return_value.resolve_for_agent = AsyncMock(return_value=None)
+            mock_settings.LLM_API_KEY = "sk-fallback"
+            mock_settings.OPENAI_API_KEY = None
+            mock_settings.LLM_MODEL = "gpt-4o"
+            mock_settings.CREDENTIAL_BROKER_URL = "http://broker:8000"
+
+            executor = await AgentExecutor.from_neo4j(driver, "g1", "a1")
+
+        assert isinstance(executor._llm, AsyncOpenAI)
+        assert executor._model == "gpt-4o"
+
+    async def test_openai_api_key_used_as_fallback_when_llm_api_key_unset(self):
+        from openai import AsyncOpenAI
+        driver = MagicMock()
+        agent = _make_agent()
+
+        with patch("app.services.agent_executor.AgentService") as MockSvc, \
+             patch("app.services.agent_executor.LLMConfigService") as MockCfg, \
+             patch("app.services.agent_executor.settings") as mock_settings:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            MockCfg.return_value.resolve_for_agent = AsyncMock(return_value=None)
+            mock_settings.LLM_API_KEY = None
+            mock_settings.OPENAI_API_KEY = "sk-openai-key"
+            mock_settings.LLM_MODEL = "gpt-4o"
+            mock_settings.CREDENTIAL_BROKER_URL = "http://broker:8000"
+
+            executor = await AgentExecutor.from_neo4j(driver, "g1", "a1")
+
+        assert isinstance(executor._llm, AsyncOpenAI)
+
+    async def test_raises_runtime_error_when_no_key_at_any_level(self):
+        driver = MagicMock()
+        agent = _make_agent()
+
+        with patch("app.services.agent_executor.AgentService") as MockSvc, \
+             patch("app.services.agent_executor.LLMConfigService") as MockCfg, \
+             patch("app.services.agent_executor.settings") as mock_settings:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            MockCfg.return_value.resolve_for_agent = AsyncMock(return_value=None)
+            mock_settings.LLM_API_KEY = None
+            mock_settings.OPENAI_API_KEY = None
+            mock_settings.LLM_MODEL = "gpt-4o"
+            mock_settings.CREDENTIAL_BROKER_URL = "http://broker:8000"
+
+            with pytest.raises(RuntimeError, match="LLM not configured"):
+                await AgentExecutor.from_neo4j(driver, "g1", "a1")
+
+    async def test_broker_error_surfaces_as_runtime_error(self):
+        from app.services.credential_broker_client import CredentialBrokerError
+        driver = MagicMock()
+        agent = _make_agent()
+
+        with patch("app.services.agent_executor.AgentService") as MockSvc, \
+             patch("app.services.agent_executor.LLMConfigService") as MockCfg, \
+             patch("app.services.agent_executor.CredentialBrokerClient") as MockBroker, \
+             patch("app.services.agent_executor.settings") as mock_settings:
+            MockSvc.return_value.get_agent = AsyncMock(return_value=agent)
+            MockCfg.return_value.resolve_for_agent = AsyncMock(return_value=_resolved_config())
+            MockBroker.return_value.retrieve_api_key = AsyncMock(
+                side_effect=CredentialBrokerError("not found")
+            )
+            mock_settings.CREDENTIAL_BROKER_URL = "http://broker:8000"
+
+            with pytest.raises(RuntimeError, match="Could not retrieve LLM API key"):
+                await AgentExecutor.from_neo4j(driver, "g1", "a1")
+
+
+class TestCallLlmDispatch:
+    def _executor(self, llm, model="gpt-4o"):
+        agent = {
+            "graph_id": "g1", "system_prompt": "You help.",
+            "reasoning_mode": "direct", "tools": [], "llm_config_id": None,
+        }
+        return AgentExecutor(agent_def=agent, toolkit=MagicMock(), llm=llm, model=model)
+
+    async def test_openai_uses_chat_completions_create(self):
+        from openai import AsyncOpenAI
+        llm = MagicMock(spec=AsyncOpenAI)
+        resp = MagicMock()
+        resp.choices[0].message.content = "hello"
+        llm.chat.completions.create = AsyncMock(return_value=resp)
+        ex = self._executor(llm)
+        result = await ex._call_llm([{"role": "user", "content": "hi"}])
+        assert result == "hello"
+        llm.chat.completions.create.assert_called_once()
+
+    async def test_anthropic_uses_messages_create(self):
+        try:
+            from anthropic import AsyncAnthropic
+        except ImportError:
+            pytest.skip("anthropic SDK not installed")
+
+        llm = MagicMock(spec=AsyncAnthropic)
+        resp = MagicMock()
+        resp.content = [MagicMock()]
+        resp.content[0].text = "anthropic response"
+        llm.messages.create = AsyncMock(return_value=resp)
+        ex = self._executor(llm)
+        result = await ex._call_llm([{"role": "user", "content": "hi"}])
+        assert result == "anthropic response"
+        llm.messages.create.assert_called_once()
+        call_kwargs = llm.messages.create.call_args[1]
+        assert "system" in call_kwargs
+        assert "messages" in call_kwargs

--- a/knowledge-graph-builder/tests/unit/test_llm_client_factory.py
+++ b/knowledge-graph-builder/tests/unit/test_llm_client_factory.py
@@ -1,0 +1,61 @@
+"""Unit tests for LLMClientFactory (STORY-021 / TASK-040)."""
+
+import pytest
+
+from app.services.llm_client_factory import LLMClientFactory
+
+
+def _cfg(provider, base_url=None, api_version=None):
+    return {
+        "provider": provider,
+        "model": "test-model",
+        "api_key": "sk-test",
+        "base_url": base_url,
+        "api_version": api_version,
+    }
+
+
+class TestLLMClientFactory:
+    def test_anthropic_returns_async_anthropic(self):
+        try:
+            from anthropic import AsyncAnthropic
+        except ImportError:
+            pytest.skip("anthropic SDK not installed")
+        client = LLMClientFactory.build(_cfg("anthropic"))
+        assert isinstance(client, AsyncAnthropic)
+
+    def test_openrouter_returns_async_openai_with_base_url(self):
+        from openai import AsyncOpenAI
+        client = LLMClientFactory.build(
+            _cfg("openrouter", base_url="https://openrouter.ai/api/v1")
+        )
+        assert isinstance(client, AsyncOpenAI)
+        assert "openrouter" in str(client.base_url)
+
+    def test_openrouter_uses_default_base_url_when_none(self):
+        from openai import AsyncOpenAI
+        client = LLMClientFactory.build(_cfg("openrouter", base_url=None))
+        assert isinstance(client, AsyncOpenAI)
+        assert "openrouter" in str(client.base_url)
+
+    def test_azure_openai_returns_async_azure_openai(self):
+        from openai import AsyncAzureOpenAI
+        client = LLMClientFactory.build(
+            _cfg(
+                "azure-openai",
+                base_url="https://my-resource.openai.azure.com/",
+                api_version="2024-02-01",
+            )
+        )
+        assert isinstance(client, AsyncAzureOpenAI)
+
+    def test_azure_openai_uses_default_api_version_when_none(self):
+        from openai import AsyncAzureOpenAI
+        client = LLMClientFactory.build(
+            _cfg("azure-openai", base_url="https://resource.openai.azure.com/")
+        )
+        assert isinstance(client, AsyncAzureOpenAI)
+
+    def test_unknown_provider_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown LLM provider"):
+            LLMClientFactory.build(_cfg("cohere"))

--- a/knowledge-graph-builder/tests/unit/test_llm_config_service.py
+++ b/knowledge-graph-builder/tests/unit/test_llm_config_service.py
@@ -1,0 +1,177 @@
+"""Unit tests for LLMConfigService (STORY-021 / TASK-040)."""
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from app.schemas.llm_config_schemas import LLMConfigCreate, LLMProvider
+from app.services.llm_config_service import LLMConfigService
+
+
+def _make_create(provider: str = "openrouter", model: str = "openai/gpt-4o") -> LLMConfigCreate:
+    return LLMConfigCreate(
+        provider=LLMProvider(provider),
+        model=model,
+        api_key="sk-test-1234abcd",
+        base_url="https://openrouter.ai/api/v1" if provider == "openrouter" else None,
+    )
+
+
+def _mock_driver(records=None):
+    driver = MagicMock()
+    result = MagicMock()
+    result.records = records or []
+    driver.execute_query = AsyncMock(return_value=result)
+    return driver
+
+
+# ── create_org_config ─────────────────────────────────────────────────────────
+
+
+class TestCreateOrgConfig:
+    async def test_writes_api_key_ref_not_plaintext_key(self):
+        driver = _mock_driver()
+        svc = LLMConfigService(driver)
+        config_id = await svc.create_org_config("org1", "user1", _make_create(), "cred-ref-001")
+
+        assert isinstance(config_id, str) and len(config_id) == 36
+        query, params = driver.execute_query.call_args.args
+        assert "api_key_ref" in query
+        # "api_key_ref" contains the substring "api_key" — check params, not raw query
+        assert params["api_key_ref"] == "cred-ref-001"
+        assert "api_key" not in params  # plaintext key never passed to Cypher
+
+    async def test_sets_scope_org(self):
+        driver = _mock_driver()
+        svc = LLMConfigService(driver)
+        await svc.create_org_config("org1", "user1", _make_create(), "cref")
+        query, _ = driver.execute_query.call_args.args
+        assert '"org"' in query
+
+    async def test_graph_id_is_null_for_org_scope(self):
+        driver = _mock_driver()
+        svc = LLMConfigService(driver)
+        await svc.create_org_config("org1", "user1", _make_create(), "cref")
+        query, _ = driver.execute_query.call_args.args
+        assert "graph_id:       null" in query
+
+
+# ── create_project_config ─────────────────────────────────────────────────────
+
+
+class TestCreateProjectConfig:
+    async def test_sets_scope_project_and_graph_id(self):
+        driver = _mock_driver()
+        svc = LLMConfigService(driver)
+        config_id = await svc.create_project_config(
+            "graph-A", "org1", "user1", _make_create(), "cref"
+        )
+        assert isinstance(config_id, str)
+        query, params = driver.execute_query.call_args.args
+        assert '"project"' in query
+        assert params["graph_id"] == "graph-A"
+
+
+# ── list_org_configs ──────────────────────────────────────────────────────────
+
+
+class TestListOrgConfigs:
+    async def test_returns_only_active_configs(self):
+        rec1 = MagicMock()
+        rec1.__getitem__ = lambda self, k: {"config_id": "c1", "scope": "org"} if k == "c" else None
+        driver = MagicMock()
+        result = MagicMock()
+        result.records = [rec1]
+        driver.execute_query = AsyncMock(return_value=result)
+
+        svc = LLMConfigService(driver)
+        configs = await svc.list_org_configs("org1")
+        query, params = driver.execute_query.call_args.args
+        assert "deactivated_at IS NULL" in query
+        assert params["org_id"] == "org1"
+
+    async def test_empty_when_no_configs(self):
+        driver = _mock_driver(records=[])
+        svc = LLMConfigService(driver)
+        configs = await svc.list_org_configs("org-empty")
+        assert configs == []
+
+
+# ── deactivate_config ─────────────────────────────────────────────────────────
+
+
+class TestDeactivateConfig:
+    async def test_returns_true_on_success(self):
+        rec = MagicMock()
+        driver = _mock_driver(records=[rec])
+        svc = LLMConfigService(driver)
+        result = await svc.deactivate_config("cfg-1", "org1")
+        assert result is True
+        query, params = driver.execute_query.call_args.args
+        assert "deactivated_at" in query
+        assert params["org_id"] == "org1"
+        assert params["cid"] == "cfg-1"
+
+    async def test_returns_false_when_not_found_or_wrong_org(self):
+        driver = _mock_driver(records=[])
+        svc = LLMConfigService(driver)
+        result = await svc.deactivate_config("cfg-1", "org-B")
+        assert result is False
+
+
+# ── resolve_for_agent ─────────────────────────────────────────────────────────
+
+
+class TestResolveForAgent:
+    def _svc_with_patches(
+        self,
+        get_config_return=None,
+        project_configs=None,
+        org_configs=None,
+    ):
+        driver = MagicMock()
+        svc = LLMConfigService(driver)
+        svc.get_config = AsyncMock(return_value=get_config_return)
+        svc.list_project_configs = AsyncMock(return_value=project_configs or [])
+        svc.list_org_configs = AsyncMock(return_value=org_configs or [])
+        return svc
+
+    async def test_agent_config_wins_over_project(self):
+        agent_cfg = {"config_id": "agent-cfg", "deactivated_at": None}
+        project_cfg = {"config_id": "proj-cfg", "deactivated_at": None}
+        svc = self._svc_with_patches(
+            get_config_return=agent_cfg, project_configs=[project_cfg]
+        )
+        result = await svc.resolve_for_agent("g", "org", "agent-cfg")
+        assert result["config_id"] == "agent-cfg"
+        svc.list_project_configs.assert_not_called()
+
+    async def test_project_config_wins_over_org(self):
+        project_cfg = {"config_id": "proj-cfg", "deactivated_at": None}
+        org_cfg = {"config_id": "org-cfg", "deactivated_at": None}
+        svc = self._svc_with_patches(
+            project_configs=[project_cfg], org_configs=[org_cfg]
+        )
+        result = await svc.resolve_for_agent("g", "org", None)
+        assert result["config_id"] == "proj-cfg"
+        svc.list_org_configs.assert_not_called()
+
+    async def test_org_config_used_when_no_project_config(self):
+        org_cfg = {"config_id": "org-cfg", "deactivated_at": None}
+        svc = self._svc_with_patches(org_configs=[org_cfg])
+        result = await svc.resolve_for_agent("g", "org1", None)
+        assert result["config_id"] == "org-cfg"
+
+    async def test_returns_none_when_nothing_found(self):
+        svc = self._svc_with_patches()
+        result = await svc.resolve_for_agent("g", "org1", None)
+        assert result is None
+
+    async def test_skips_deactivated_agent_config_and_falls_through(self):
+        deactivated = {"config_id": "dead", "deactivated_at": 12345}
+        project_cfg = {"config_id": "proj", "deactivated_at": None}
+        svc = self._svc_with_patches(
+            get_config_return=deactivated, project_configs=[project_cfg]
+        )
+        result = await svc.resolve_for_agent("g", "org1", "dead")
+        assert result["config_id"] == "proj"


### PR DESCRIPTION
## Summary

- 26 unit tests covering `LLMConfigService` (resolution chain), `LLMClientFactory` (three providers), and `AgentExecutor` (fallback hierarchy + Anthropic vs OpenAI-compatible `_call_llm` dispatch)
- 14 integration tests against Docker Neo4j: org/project CRUD, API key hygiene (never in any response), cross-tenant isolation, broker error propagation
- Credential broker mocked via FastAPI `dependency_overrides` throughout — no live broker or LLM calls required

## Test plan

- [x] `python -m pytest tests/unit/test_llm_config_service.py tests/unit/test_llm_client_factory.py tests/unit/test_agent_executor_llm_resolution.py` — 26/26 passed
- [x] `python -m pytest tests/integration/test_llm_config_integration.py` — 14/14 passed
- [x] Existing agent integration tests still pass (15/15)
- [x] `test_org_b_cannot_see_org_a_configs` — cross-tenant isolation verified
- [x] `test_create_api_key_never_in_response` — API key hygiene verified
- [x] QA PASSED logged in TASK-040 Agent Log