### PR TITLE
STORY-4a: community-kind registry + chunk-community visibility

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/communities.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/communities.py
@@ -1,24 +1,28 @@
 """
-Communities listing endpoint (TASK-050).
+Communities listing + kind-discovery endpoints (TASK-050, STORY-4a).
 
-Exposes Leiden communities computed during ingestion in the flat,
-contract-stable shape the frontend's `Community` interface expects.
+Exposes communities computed during ingestion in the flat, contract-stable
+shape the frontend's `Community` interface expects, and a discovery
+endpoint that publishes the kind registry so the UI can stay metadata-driven.
 
 The richer per-community detail and detection-status routes still live in
 `graphs.py` (`/graphs/{id}/communities/{community_id}`,
-`/graphs/{id}/communities/status`, `/graphs/{id}/communities/detect`).
-This module only owns the *list* route, which previously returned a
-wrapped envelope (`CommunityListResponse`) and now returns the flat list
-documented in TASK-050.
+`/graphs/{id}/communities/status`, `/graphs/{id}/communities/detect`); they
+also accept `?kind=` to address any registered kind.
 """
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.api.dependencies import get_current_user_id, verify_graph_access
 from app.core.logging import get_logger
-from app.schemas.community_schemas import Community
+from app.schemas.community_kinds import (
+    UnknownCommunityKindError,
+    all_kinds,
+    get_kind,
+)
+from app.schemas.community_schemas import Community, CommunityKindInfo
 from app.services.analytics_service import GraphAnalyticsService
 
 router = APIRouter()
@@ -32,9 +36,9 @@ def _get_analytics_service() -> GraphAnalyticsService:
 def _derive_label(community_id: str, summary: str | None) -> str:
     """Derive a short human-readable label for a community.
 
-    Leiden communities don't have an explicit `label` property today, so
-    we use the first sentence of the summary (truncated) and fall back to
-    a synthetic `Community <short-id>` when no summary is available.
+    Communities don't have an explicit `label` property today, so we use
+    the first sentence of the summary (truncated) and fall back to a
+    synthetic `Community <short-id>` when no summary is available.
     """
     if summary:
         # Take up to the first period or 80 chars, whichever comes first
@@ -51,35 +55,77 @@ def _derive_label(community_id: str, summary: str | None) -> str:
 
 
 @router.get(
+    "/communities/kinds",
+    response_model=list[CommunityKindInfo],
+    summary="List registered community kinds",
+)
+async def list_community_kinds(
+    _user_id: str = Depends(get_current_user_id),
+) -> list[CommunityKindInfo]:
+    """Return every community kind the platform knows how to handle.
+
+    This is the source of truth for the frontend's kind picker. Each entry
+    declares the underlying Neo4j label, member label, hierarchical-ness,
+    and whether detection is supported (vs. read-only).
+
+    Auth required so unauthenticated callers can't enumerate platform
+    internals, but no graph-level ReBAC: the registry is the same for all
+    graphs.
+    """
+    return [
+        CommunityKindInfo(
+            kind=spec.kind,
+            display_name=spec.display_name,
+            community_label=spec.community_label,
+            member_label=spec.member_label,
+            hierarchical=spec.hierarchical,
+            detection_supported=spec.detector_task_name is not None,
+        )
+        for spec in all_kinds()
+    ]
+
+
+@router.get(
     "/graphs/{graph_id}/communities",
     response_model=list[Community],
-    summary="List Leiden communities for a graph",
+    summary="List communities for a graph",
     responses={
+        400: {"description": "Unknown community kind"},
         403: {"description": "Caller lacks read access to the graph"},
     },
 )
 async def list_communities(
     graph_id: UUID,
     level: int | None = None,
+    kind: str = Query(
+        default="entity",
+        description=(
+            "Which community kind to list. Must be one of the kinds returned "
+            "by GET /communities/kinds. Defaults to ``entity`` to preserve "
+            "behavior for clients that pre-date the registry."
+        ),
+    ),
     user_id: str = Depends(get_current_user_id),
     analytics: GraphAnalyticsService = Depends(_get_analytics_service),
 ) -> list[Community]:
     """
-    Return Leiden communities computed during ingestion as a flat list,
-    ordered by `level` then descending `size`.
+    Return communities computed for the graph as a flat list, ordered by
+    `level` then descending `size` (hierarchical kinds) or by descending
+    `size` alone (flat kinds).
 
-    The shape is `[{community_id, level, label, size, summary?}]` to match
-    the frontend's `Community` interface
-    (`oraclous-visual-flow-main/src/lib/api.ts`). When no community data
-    exists yet for the graph, the route returns an empty list — community
-    detection is triggered separately via
-    `POST /graphs/{graph_id}/communities/detect`.
+    The shape is `[{community_id, kind, level, label, size, member_label,
+    summary?}]`. When no community data exists yet for the kind, the route
+    returns an empty list — entity-level detection is triggered separately
+    via `POST /graphs/{graph_id}/communities/detect`; flat kinds (e.g.,
+    chunk-Louvain) are read-only today.
 
     Requires `read`-level access via ReBAC.
-
-    Optional `level` query param filters to a single hierarchy level.
     """
-    # ReBAC check — read level required
+    try:
+        spec = get_kind(kind)
+    except UnknownCommunityKindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
     await verify_graph_access(str(graph_id), "read", user_id)
 
     try:
@@ -92,7 +138,10 @@ async def list_communities(
             limit=10_000,
             offset=0,
             include_summary=True,
+            kind=kind,
         )
+    except UnknownCommunityKindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
     except Exception as e:
         logger.error(f"Failed to list communities for graph {graph_id}: {e}")
         raise HTTPException(
@@ -104,9 +153,13 @@ async def list_communities(
     return [
         Community(
             community_id=item["community_id"],
-            level=item["level"],
+            kind=item.get("kind", kind),
+            # Flat kinds have no hierarchy — surface level as 0 so the
+            # response stays type-stable for clients with int-only level.
+            level=item["level"] if item.get("level") is not None else 0,
             label=_derive_label(item["community_id"], item.get("summary")),
             size=item.get("entity_count", 0) or 0,
+            member_label=spec.member_label,
             summary=item.get("summary"),
         )
         for item in items

--- a/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
@@ -10,6 +10,7 @@ from fastapi import (
     Depends,
     File,
     HTTPException,
+    Query,
     Request,
     UploadFile,
     status,
@@ -1416,6 +1417,10 @@ async def retroactive_apply_ontology(
 
 # ==================== COMMUNITY DETECTION ENDPOINTS ====================
 
+from app.schemas.community_kinds import (
+    UnknownCommunityKindError,
+    get_kind,
+)
 from app.services.analytics_service import GraphAnalyticsService
 from app.tasks.community_tasks import COMMUNITY_DETECTION_MIN_ENTITIES
 
@@ -1438,7 +1443,12 @@ async def _verify_graph_ownership(
     "/graphs/{graph_id}/communities/detect",
     response_model=CommunityDetectResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    summary="Trigger hierarchical community detection",
+    summary="Trigger community detection",
+    responses={
+        400: {"description": "Unknown kind or insufficient member nodes"},
+        405: {"description": "Detection not supported for this kind (read-only)"},
+        409: {"description": "Detection already in progress"},
+    },
 )
 async def detect_communities(
     graph_id: UUID,
@@ -1447,46 +1457,79 @@ async def detect_communities(
     analytics: GraphAnalyticsService = Depends(_get_analytics_service),
 ):
     """
-    Queue a background Leiden community detection job for the graph.
+    Queue a background community detection job for the graph.
+
+    The ``kind`` field of the request body selects which kind to detect.
+    Kinds whose ``detection_supported`` is False (e.g. ``chunk`` today)
+    return HTTP 405 — those communities are read-only.
 
     Returns 202 with job_id when queued.
     Returns 409 when a detection job is already running.
-    Returns 400 when graph has fewer than the minimum required entities.
+    Returns 400 when graph has fewer than the minimum required member nodes.
     """
     await _verify_graph_ownership(graph_id, user_id)
 
-    # Check current status
-    current_status = await analytics.get_community_status(graph_id)
+    kind = request.kind
+    try:
+        spec = get_kind(kind)
+    except UnknownCommunityKindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+    if spec.detector_task_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
+            detail=(
+                f"Detection for community kind {kind!r} is not supported; "
+                f"existing {spec.community_label} nodes are read-only."
+            ),
+        )
+
+    current_status = await analytics.get_community_status(graph_id, kind=kind)
     if current_status["status"] == "rebuilding" and not request.force_rebuild:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Community detection already in progress",
         )
 
-    # Check entity count
+    # Count the member-node population the detector needs. Label comes
+    # from the registry (compile-time constant), so f-string is safe.
     count_result = await neo4j_client.execute_query(
-        "MATCH (e:__Entity__ {graph_id: $graph_id}) RETURN count(e) AS cnt",
+        f"MATCH (n:`{spec.member_label}` {{graph_id: $graph_id}}) "
+        "RETURN count(n) AS cnt",
         {"graph_id": str(graph_id)},
     )
-    entity_count = count_result[0]["cnt"] if count_result else 0
+    member_count = count_result[0]["cnt"] if count_result else 0
     min_entities = request.min_entities or COMMUNITY_DETECTION_MIN_ENTITIES
-    if entity_count < min_entities:
+    if member_count < min_entities:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Graph has {entity_count} entities — minimum is {min_entities} for community detection",
+            detail=(
+                f"Graph has {member_count} {spec.member_label} nodes — "
+                f"minimum is {min_entities} for community detection"
+            ),
         )
 
-    result = await analytics.detect_communities_async(
-        graph_id=graph_id,
-        levels=request.levels,
-        force_rebuild=request.force_rebuild,
-    )
+    try:
+        result = await analytics.detect_communities_async(
+            graph_id=graph_id,
+            levels=request.levels,
+            force_rebuild=request.force_rebuild,
+            kind=kind,
+        )
+    except NotImplementedError as exc:
+        # Defense-in-depth — the detector_task_name check above already
+        # catches this. Re-raise as 405 if the analytics layer guards a
+        # case we didn't filter for at the endpoint.
+        raise HTTPException(
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail=str(exc)
+        ) from None
 
     return CommunityDetectResponse(
         job_id=result["job_id"],
         graph_id=result["graph_id"],
+        kind=result.get("kind", kind),
         status=result["status"],
-        estimated_entities=entity_count,
+        estimated_entities=member_count,
     )
 
 
@@ -1494,15 +1537,26 @@ async def detect_communities(
     "/graphs/{graph_id}/communities/status",
     response_model=CommunityStatusResponse,
     summary="Get community detection status for a graph",
+    responses={400: {"description": "Unknown community kind"}},
 )
 async def get_community_status(
     graph_id: UUID,
+    kind: str = Query(
+        default="entity",
+        description=(
+            "Which community kind to report status for. Default `entity` "
+            "preserves the pre-registry response shape."
+        ),
+    ),
     user_id: str = Depends(get_current_user_id),
     analytics: GraphAnalyticsService = Depends(_get_analytics_service),
 ):
-    """Return current detection status, entity counts, and staleness."""
+    """Return current detection status, member counts, and staleness for one kind."""
     await _verify_graph_ownership(graph_id, user_id)
-    result = await analytics.get_community_status(graph_id)
+    try:
+        result = await analytics.get_community_status(graph_id, kind=kind)
+    except UnknownCommunityKindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
     return CommunityStatusResponse(**result)
 
 
@@ -1517,16 +1571,28 @@ async def get_community_status(
     "/graphs/{graph_id}/communities/{community_id}",
     response_model=CommunityDetailResponse,
     summary="Get a single community with its members",
+    responses={400: {"description": "Unknown community kind"}},
 )
 async def get_community_detail(
     graph_id: UUID,
     community_id: str,
+    kind: str | None = Query(
+        default=None,
+        description=(
+            "Optional kind hint. Omit to let the server probe every "
+            "registered kind for a matching community node (one extra "
+            "round trip per registered kind in the worst case)."
+        ),
+    ),
     user_id: str = Depends(get_current_user_id),
     analytics: GraphAnalyticsService = Depends(_get_analytics_service),
 ):
     """Return community detail including member entities and parent/child hierarchy."""
     await _verify_graph_ownership(graph_id, user_id)
-    result = await analytics.get_community_detail(graph_id, community_id)
+    try:
+        result = await analytics.get_community_detail(graph_id, community_id, kind=kind)
+    except UnknownCommunityKindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
     if not result:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Community not found"

--- a/knowledge-graph-builder/app/schemas/community_kinds.py
+++ b/knowledge-graph-builder/app/schemas/community_kinds.py
@@ -1,0 +1,166 @@
+"""Community-kind registry (STORY-4a).
+
+A single source of truth for "what kinds of communities can this graph
+hold." Endpoints, the analytics service, the agent toolkit, and any
+future tasks all read from the same registry instead of hardcoding
+Neo4j labels and relationship types.
+
+Adding a new community kind = add one ``CommunityKindSpec`` entry to the
+``COMMUNITY_KINDS`` dict below. No endpoint, service, or schema code
+change required. The discovery endpoint ``GET /communities/kinds``
+exposes the registry to API consumers so the frontend can also stay
+metadata-driven.
+
+Design notes
+------------
+- ``kind`` is the stable wire identifier. Never rename without a
+  deprecation cycle — it appears in API query params, JSON payloads, and
+  Celery task names.
+- ``detector_task_name`` may be ``None`` when a kind is read-only — e.g.,
+  the chunk-community Louvain script that produced :ChunkCommunity nodes
+  during STORY-024 demo prep has not yet been promoted to a Celery task,
+  but the nodes still need to be queryable. ``POST .../detect`` returns
+  HTTP 405 with a clear message when ``detector_task_name is None``.
+- ``hierarchical`` distinguishes Leiden (entity, multi-level) from Louvain
+  (chunk, flat). Callers can branch on this to decide whether the
+  ``level`` field on a Community is meaningful or always ``None``.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityKindSpec:
+    """Describes one kind of community Neo4j can hold for a graph.
+
+    Property-name fields (``id_property``, ``size_property``) exist because
+    the two kinds we have today were materialized by different scripts that
+    chose different conventions. Rather than retroactively renaming
+    properties on live data, the registry tells callers what to query.
+    """
+
+    # Stable wire identifier. Used in API query params, JSON payloads,
+    # Celery task names. Lowercase, snake_case, no spaces.
+    kind: str
+
+    # Human-readable name for UI / error messages.
+    display_name: str
+
+    # Neo4j label of the community node itself.
+    community_label: str
+
+    # Neo4j label of the node type members of this community are.
+    member_label: str
+
+    # Neo4j relationship that connects (member)-[REL]->(community).
+    # Note the direction: members point AT their community.
+    member_rel: str
+
+    # Property on the community node that holds its stable id. Different
+    # community kinds historically chose different names (``id`` for the
+    # entity-Leiden output, ``community_id`` for the chunk-Louvain output).
+    id_property: str
+
+    # Property on the community node that holds its member count.
+    # Entity-Leiden writes ``entity_count``; chunk-Louvain writes ``size``.
+    size_property: str
+
+    # True for hierarchical clusterings (Leiden) where ``level`` matters,
+    # False for flat clusterings (Louvain) where ``level`` is always None.
+    # Hierarchical kinds also have a ``PARENT_COMMUNITY`` edge between
+    # adjacent levels and a ``parent_id`` property on each community node.
+    hierarchical: bool
+
+    # True when the member relationship has a ``level`` property the
+    # detail-fetch query must match on (entity-Leiden does this; chunk
+    # Louvain does not).
+    member_rel_has_level: bool
+
+    # Celery task name that detects this kind, or None when detection
+    # has not been wired yet (read-only kind). Endpoints return HTTP 405
+    # on POST .../detect when this is None.
+    detector_task_name: str | None
+
+
+# Adding a new community kind: append one entry below. No other change
+# required — endpoint code, analytics queries, agent tools, and the
+# discovery endpoint all read from this dict.
+COMMUNITY_KINDS: dict[str, CommunityKindSpec] = {
+    "entity": CommunityKindSpec(
+        kind="entity",
+        display_name="Entity community (Leiden, hierarchical)",
+        community_label="__Community__",
+        member_label="__Entity__",
+        member_rel="IN_COMMUNITY",
+        id_property="id",
+        size_property="entity_count",
+        hierarchical=True,
+        member_rel_has_level=True,
+        detector_task_name="community_tasks.detect_communities_task",
+    ),
+    "chunk": CommunityKindSpec(
+        kind="chunk",
+        display_name="Chunk community (Louvain, flat)",
+        community_label="ChunkCommunity",
+        member_label="Chunk",
+        member_rel="IN_CHUNK_COMMUNITY",
+        id_property="community_id",
+        size_property="size",
+        hierarchical=False,
+        member_rel_has_level=False,
+        # Detection not yet wired. The original Louvain run was a one-shot
+        # script during STORY-024 demo prep. Promoting it to a Celery task
+        # is tracked as a follow-up story; until then, only the 59 chunk
+        # communities already in the Eurail graph are visible.
+        detector_task_name=None,
+    ),
+    # Future kinds slot in here without touching endpoint or service code:
+    #
+    # "sub_entity": CommunityKindSpec(
+    #     kind="sub_entity",
+    #     display_name="Within-entity property clustering",
+    #     community_label="SubEntityCluster",
+    #     member_label="EntityProperty",
+    #     member_rel="IN_SUB_ENTITY_COMMUNITY",
+    #     hierarchical=False,
+    #     detector_task_name="community_tasks.detect_sub_entity_clusters_task",
+    # ),
+}
+
+
+class UnknownCommunityKindError(ValueError):
+    """Raised when a caller references a community kind that is not in
+    ``COMMUNITY_KINDS``. Endpoints translate this to HTTP 400 with the
+    valid kind list in the message body."""
+
+    def __init__(self, kind: str) -> None:
+        valid = ", ".join(sorted(COMMUNITY_KINDS.keys()))
+        super().__init__(f"Unknown community kind: {kind!r}. Valid kinds: {valid}")
+        self.kind = kind
+        self.valid_kinds = sorted(COMMUNITY_KINDS.keys())
+
+
+def get_kind(kind: str) -> CommunityKindSpec:
+    """Resolve a kind id. Raises ``UnknownCommunityKindError`` if unknown."""
+    if kind not in COMMUNITY_KINDS:
+        raise UnknownCommunityKindError(kind)
+    return COMMUNITY_KINDS[kind]
+
+
+def all_kinds() -> list[CommunityKindSpec]:
+    """Return every registered kind, in insertion order."""
+    return list(COMMUNITY_KINDS.values())
+
+
+def kind_for_community_label(label: str) -> CommunityKindSpec | None:
+    """Reverse-lookup: given a Neo4j label, return the matching kind spec.
+
+    Used by endpoints that receive a ``community_id`` without a ``?kind=``
+    parameter (the ID is globally unique, so we can sniff the kind by
+    looking at the node's labels in Neo4j).
+    Returns None if no kind matches the label.
+    """
+    for spec in COMMUNITY_KINDS.values():
+        if spec.community_label == label:
+            return spec
+    return None

--- a/knowledge-graph-builder/app/schemas/community_schemas.py
+++ b/knowledge-graph-builder/app/schemas/community_schemas.py
@@ -11,15 +11,31 @@ from pydantic import BaseModel, Field
 
 
 class Community(BaseModel):
-    """A single Leiden community summary.
+    """A single community summary across all registered kinds.
 
-    Field names match the frontend `Community` interface exactly so the
-    API client mounts without remapping.
+    Field names match the frontend `Community` interface for the entity
+    (Leiden) case so the API client mounts without remapping. The added
+    ``kind`` and ``member_label`` fields let new clients distinguish
+    entity-level from chunk-level communities; older clients can ignore
+    them since both default-back to entity behavior.
     """
 
     community_id: str = Field(..., description="Stable community identifier")
+    kind: str = Field(
+        default="entity",
+        description=(
+            "Community kind from the registry. ``entity`` is the Leiden "
+            "output over `__Entity__` nodes (hierarchical, multi-level); "
+            "``chunk`` is the Louvain output over `:Chunk` nodes (flat). "
+            "Discover the full list via GET /communities/kinds."
+        ),
+    )
     level: int = Field(
-        ..., description="Hierarchy level (0 = coarsest, higher integers = finer)"
+        ...,
+        description=(
+            "Hierarchy level (0 = coarsest, higher integers = finer). "
+            "Always 0 for flat kinds where the algorithm has no hierarchy."
+        ),
     )
     label: str = Field(
         ...,
@@ -28,8 +44,47 @@ class Community(BaseModel):
             "of `summary` when present, otherwise `Community <short-id>`."
         ),
     )
-    size: int = Field(..., ge=0, description="Number of member entities")
+    size: int = Field(..., ge=0, description="Number of members")
+    member_label: str | None = Field(
+        default=None,
+        description=(
+            "Neo4j label of the member nodes of this community "
+            "(`__Entity__` for entity communities, `Chunk` for chunk "
+            "communities). Lets callers route lookups without consulting "
+            "the kinds registry."
+        ),
+    )
     summary: str | None = Field(
         default=None,
         description="Optional LLM-generated summary of the community's members",
+    )
+
+
+class CommunityKindInfo(BaseModel):
+    """Registry-facing description of one community kind.
+
+    Returned from ``GET /communities/kinds`` so clients can drive their UI
+    off the same source of truth that backend services use, instead of
+    hardcoding kind names or labels in JS.
+    """
+
+    kind: str = Field(..., description="Stable wire identifier for the kind")
+    display_name: str = Field(..., description="Human-readable name for UI labels")
+    community_label: str = Field(
+        ..., description="Neo4j label of the community node itself"
+    )
+    member_label: str = Field(..., description="Neo4j label of the member nodes")
+    hierarchical: bool = Field(
+        ...,
+        description=(
+            "True when the algorithm produces multiple hierarchy levels "
+            "(Leiden); False for flat clusterings (Louvain)."
+        ),
+    )
+    detection_supported: bool = Field(
+        ...,
+        description=(
+            "False when the kind is read-only — i.e., no Celery task is "
+            "wired yet and POST /communities/detect returns HTTP 405."
+        ),
     )

--- a/knowledge-graph-builder/app/schemas/graph_schemas.py
+++ b/knowledge-graph-builder/app/schemas/graph_schemas.py
@@ -858,27 +858,44 @@ class CommunityDetectRequest(BaseModel):
     min_entities: int | None = Field(
         None, description="Override minimum entity threshold"
     )
+    kind: str = Field(
+        "entity",
+        description=(
+            "Community kind to detect. Must be a kind from GET "
+            "/communities/kinds whose ``detection_supported`` is True; "
+            "read-only kinds return HTTP 405."
+        ),
+    )
 
 
 class CommunityDetectResponse(BaseModel):
     job_id: str
     graph_id: str
+    kind: str = Field(
+        default="entity",
+        description="The community kind being detected.",
+    )
     status: str
     estimated_entities: int | None = None
 
 
 class CommunityItem(BaseModel):
     community_id: str
-    level: int
+    kind: str = Field(default="entity", description="Community kind from the registry")
+    level: int | None = Field(
+        default=None,
+        description="Hierarchy level (None for flat kinds)",
+    )
     entity_count: int
     weight: float | None = None
     summary: str | None = None
     parent_id: str | None = None
-    status: str
+    status: str | None = None
 
 
 class CommunityListResponse(BaseModel):
     communities: list[CommunityItem]
+    kind: str = Field(default="entity", description="Community kind in the list")
     total: int
     detection_status: str
     last_detected_at: str | None = None
@@ -892,7 +909,10 @@ class CommunityMember(BaseModel):
 
 class CommunityDetailResponse(BaseModel):
     community_id: str
-    level: int
+    kind: str = Field(default="entity", description="Community kind from the registry")
+    level: int | None = Field(
+        default=None, description="Hierarchy level (None for flat kinds)"
+    )
     summary: str | None = None
     entity_count: int
     algorithm: str | None = None
@@ -905,11 +925,13 @@ class CommunityDetailResponse(BaseModel):
 
 
 class CommunityStatusResponse(BaseModel):
+    kind: str = Field(default="entity", description="Community kind being reported on")
     status: str
     last_detected_at: str | None = None
     communities_by_level: dict[str, int] = {}
     entity_count_at_detection: int = 0
     current_entity_count: int = 0
+    staleness_pct: float = 0.0
 
 
 # ==================== VERSIONING SCHEMAS ====================

--- a/knowledge-graph-builder/app/services/agent_tools.py
+++ b/knowledge-graph-builder/app/services/agent_tools.py
@@ -104,17 +104,39 @@ class AgentToolkit:
     async def community_members(
         self, graph_id: str, community_id: str, max_results: int = 50
     ) -> list[NodeResult]:
-        """Return all nodes belonging to a Leiden community."""
+        """Return all member nodes of a community across any registered kind.
+
+        Each registered kind in ``COMMUNITY_KINDS`` is probed in order until
+        a match for ``community_id`` is found. This avoids forcing the
+        calling LLM to know whether ``community_id`` points at an entity
+        community or a chunk community.
+        """
         self._require("community_members")
-        result = await self._driver.execute_query(
-            """
-            MATCH (n {graph_id: $gid})-[:BELONGS_TO]->(:Community {community_id: $cid})
-            RETURN n
-            LIMIT $max_results
-            """,
-            {"gid": graph_id, "cid": community_id, "max_results": max_results},
-        )
-        return [_node_to_result(dict(rec["n"])) for rec in result.records]
+        # Imported lazily so the toolkit can still be used in tests that
+        # don't have the full app package wired up.
+        from app.schemas.community_kinds import all_kinds
+
+        for spec in all_kinds():
+            # Labels, relationship types, and property names come from the
+            # compile-time registry — never from user input — so f-string
+            # interpolation here is safe. Identifiers wrapped in backticks
+            # for defense-in-depth.
+            query = (
+                f"MATCH (n:`{spec.member_label}` {{graph_id: $gid}})"
+                f"-[:`{spec.member_rel}`]->"
+                f"(c:`{spec.community_label}` "
+                f"{{`{spec.id_property}`: $cid, graph_id: $gid}}) "
+                "RETURN n "
+                "LIMIT $max_results"
+            )
+            result = await self._driver.execute_query(
+                query,
+                {"gid": graph_id, "cid": community_id, "max_results": max_results},
+            )
+            if result.records:
+                return [_node_to_result(dict(rec["n"])) for rec in result.records]
+
+        return []
 
     async def neighbors(
         self,

--- a/knowledge-graph-builder/app/services/analytics_service.py
+++ b/knowledge-graph-builder/app/services/analytics_service.py
@@ -23,8 +23,55 @@ from sqlalchemy.pool import NullPool
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.neo4j_client import neo4j_client
+from app.schemas.community_kinds import CommunityKindSpec, get_kind
 
 logger = get_logger(__name__)
+
+
+# Neo4j cannot parameterize labels or relationship types, so the registry's
+# label/rel/property names are interpolated into Cypher via f-strings. This
+# is safe because the values come from ``COMMUNITY_KINDS`` (compile-time
+# constants), never from request input. Callers always resolve a kind via
+# ``get_kind(...)`` which raises ``UnknownCommunityKindError`` for anything
+# off the registry.
+
+
+def _coerce_neo4j_datetime(value: Any) -> Any:
+    """Convert Neo4j DateTime / Date values to ISO-8601 strings.
+
+    Pydantic v2 cannot serialize ``neo4j.time.DateTime`` directly. Rows
+    that the analytics service returns to FastAPI must be flat JSON, so
+    coerce these properties before they reach the response model.
+    """
+    if value is None:
+        return None
+    if hasattr(value, "to_native"):
+        try:
+            return value.to_native().isoformat()
+        except Exception:
+            return str(value)
+    return value
+
+
+def _pick_entity_type(labels: list[str] | None, member_label: str) -> str:
+    """Pick the most domain-meaningful label from a Neo4j node's labels list.
+
+    Skips internal/utility labels — both the generic ``__Entity__`` tag and
+    neo4j_graphrag's `:__KGBuilder__` marker — and the member-label itself
+    (which is already implied by the community kind). Falls back to the
+    member label when no domain label survives the filter.
+    """
+    if not labels:
+        return member_label
+    skip = {"__Entity__", "__KGBuilder__", member_label}
+    for lbl in labels:
+        if lbl in skip:
+            continue
+        # Skip any other "__Foo__" Neo4j-internal-style marker labels.
+        if lbl.startswith("__") and lbl.endswith("__"):
+            continue
+        return lbl
+    return member_label
 
 
 class GraphAnalyticsService:
@@ -105,90 +152,147 @@ class GraphAnalyticsService:
         graph_id: UUID,
         levels: int = 3,
         force_rebuild: bool = False,
+        kind: str = "entity",
     ) -> dict[str, Any]:
         """
         Queue a Celery community detection job and return the task ID.
 
         Args:
             graph_id: Target graph
-            levels: Number of hierarchy levels (1-5)
+            levels: Number of hierarchy levels (1-5). Ignored for flat
+                community kinds (Louvain over chunks does not have levels).
             force_rebuild: Run even if status == 'active'
+            kind: Which community kind to detect. Must be in the registry
+                AND have ``detector_task_name`` set. Read-only kinds (e.g.,
+                chunk-Louvain today) raise ``NotImplementedError`` which
+                the API endpoint maps to HTTP 405.
 
         Returns:
-            Dict with job_id, graph_id, status
+            Dict with job_id, graph_id, kind, status
         """
-        from app.tasks.community_tasks import detect_communities_task
+        spec = get_kind(kind)
+        if spec.detector_task_name is None:
+            raise NotImplementedError(
+                f"Community detection for kind {kind!r} is not implemented "
+                f"yet. Existing {spec.community_label} nodes remain readable "
+                "via the list/detail endpoints."
+            )
 
-        level_indices = list(range(levels))
-        resolutions = [0.5, 1.0, 2.0, 3.0, 4.0][:levels]
+        # The registry's detector_task_name is "module.task" form. We only
+        # have one detector wired today (entity-Leiden); rather than build
+        # a generic dotted-path importer that adds attack surface for the
+        # ~one extra task we expect, just resolve the known case here. If
+        # a second wired kind ever lands, swap this for an importlib lookup.
+        if spec.detector_task_name == "community_tasks.detect_communities_task":
+            from app.tasks.community_tasks import detect_communities_task
 
-        result = detect_communities_task.apply_async(
-            args=[str(graph_id)],
-            kwargs={
-                "levels": level_indices,
-                "resolutions": resolutions,
-                "force_rebuild": force_rebuild,
-            },
-            countdown=0,
+            level_indices = list(range(levels))
+            resolutions = [0.5, 1.0, 2.0, 3.0, 4.0][:levels]
+            result = detect_communities_task.apply_async(
+                args=[str(graph_id)],
+                kwargs={
+                    "levels": level_indices,
+                    "resolutions": resolutions,
+                    "force_rebuild": force_rebuild,
+                },
+                countdown=0,
+            )
+            return {
+                "job_id": result.id,
+                "graph_id": str(graph_id),
+                "kind": kind,
+                "status": "queued",
+            }
+
+        # Defensive — should never hit; means a registry entry declared a
+        # detector name we don't know how to dispatch.
+        raise NotImplementedError(
+            f"Detector {spec.detector_task_name!r} for kind {kind!r} is "
+            "registered but no dispatch path is wired in detect_communities_async."
         )
 
-        return {
-            "job_id": result.id,
-            "graph_id": str(graph_id),
-            "status": "queued",
-        }
+    async def get_community_status(
+        self,
+        graph_id: UUID,
+        kind: str = "entity",
+    ) -> dict[str, Any]:
+        """Return current community detection status for a graph.
 
-    async def get_community_status(self, graph_id: UUID) -> dict[str, Any]:
-        """Return current community detection status for a graph."""
-        # Count communities per level
-        level_query = """
-        MATCH (c:__Community__ {graph_id: $graph_id})
-        RETURN c.level AS level, count(c) AS cnt, c.status AS status
-        ORDER BY level
+        For hierarchical kinds (entity-Leiden), reports per-level counts and
+        consults the Postgres ``knowledge_graphs`` row for the
+        detected-at / staleness metadata which only the entity-Leiden
+        detector currently writes.
+
+        For flat kinds (chunk-Louvain), reports a single bucket under
+        level "0", returns ``status="read_only"`` to signal there's no
+        detector to drive a status machine, and skips the Postgres lookup.
         """
-        level_results = await neo4j_client.execute_query(
-            level_query, {"graph_id": str(graph_id)}
-        )
+        spec = get_kind(kind)
+        community_label = spec.community_label
 
-        communities_by_level: dict[str, int] = {}
-        detected_status = "not_detected"
-        for r in level_results:
-            communities_by_level[str(r["level"])] = r["cnt"]
-            if r["status"] == "active":
-                detected_status = "active"
-            elif r["status"] == "rebuilding":
-                detected_status = "rebuilding"
-            elif detected_status == "not_detected" and r["status"] == "stale":
-                detected_status = "stale"
+        if spec.hierarchical:
+            level_query = (
+                f"MATCH (c:`{community_label}` {{graph_id: $graph_id}}) "
+                "RETURN c.level AS level, count(c) AS cnt, c.status AS status "
+                "ORDER BY level"
+            )
+            level_results = await neo4j_client.execute_query(
+                level_query, {"graph_id": str(graph_id)}
+            )
 
-        # Entity counts from Postgres
+            communities_by_level: dict[str, int] = {}
+            detected_status = "not_detected"
+            for r in level_results:
+                communities_by_level[str(r["level"])] = r["cnt"]
+                if r["status"] == "active":
+                    detected_status = "active"
+                elif r["status"] == "rebuilding":
+                    detected_status = "rebuilding"
+                elif detected_status == "not_detected" and r["status"] == "stale":
+                    detected_status = "stale"
+        else:
+            # Flat kinds have no per-level breakdown; report a single bucket.
+            count_query = (
+                f"MATCH (c:`{community_label}` {{graph_id: $graph_id}}) "
+                "RETURN count(c) AS cnt"
+            )
+            count_results = await neo4j_client.execute_query(
+                count_query, {"graph_id": str(graph_id)}
+            )
+            cnt = count_results[0]["cnt"] if count_results else 0
+            communities_by_level = {"0": cnt}
+            detected_status = "read_only" if cnt > 0 else "not_detected"
+
+        # Postgres detection-history columns only track entity-Leiden today;
+        # skip the lookup for flat read-only kinds.
         entity_count_at_detection = 0
         last_detected_at = None
         current_entity_count = 0
-        try:
-            pg_engine = create_engine(
-                settings.POSTGRES_URL.replace("+asyncpg", ""),
-                poolclass=NullPool,
-            )
-            with pg_engine.connect() as conn:
-                row = conn.execute(
-                    text(
-                        "SELECT communities_detected_at, entity_count_at_detection, "
-                        "entity_delta_since_detection, communities_status "
-                        "FROM knowledge_graphs WHERE id = :gid"
-                    ),
-                    {"gid": str(graph_id)},
-                ).fetchone()
-                if row:
-                    last_detected_at = row[0]
-                    entity_count_at_detection = row[1] or 0
-                    delta = row[2] or 0
-                    current_entity_count = entity_count_at_detection + delta
-                    if row[3]:
-                        detected_status = row[3]
-            pg_engine.dispose()
-        except Exception as exc:
-            logger.warning(f"Postgres community status lookup failed: {exc}")
+        if spec.hierarchical and spec.detector_task_name is not None:
+            try:
+                pg_engine = create_engine(
+                    settings.POSTGRES_URL.replace("+asyncpg", ""),
+                    poolclass=NullPool,
+                )
+                with pg_engine.connect() as conn:
+                    row = conn.execute(
+                        text(
+                            "SELECT communities_detected_at, entity_count_at_detection, "
+                            "entity_delta_since_detection, communities_status "
+                            "FROM knowledge_graphs WHERE id = :gid"
+                        ),
+                        {"gid": str(graph_id)},
+                    ).fetchone()
+                    if row:
+                        last_detected_at = row[0]
+                        entity_count_at_detection = row[1] or 0
+                        delta = row[2] or 0
+                        current_entity_count = entity_count_at_detection + delta
+                        if row[3]:
+                            detected_status = row[3]
+                pg_engine.dispose()
+            except Exception as exc:
+                logger.warning(f"Postgres community status lookup failed: {exc}")
 
         staleness_pct = 0.0
         if entity_count_at_detection > 0:
@@ -197,6 +301,7 @@ class GraphAnalyticsService:
             ) / entity_count_at_detection
 
         return {
+            "kind": kind,
             "status": detected_status,
             "last_detected_at": (
                 last_detected_at.isoformat() if last_detected_at else None
@@ -215,31 +320,86 @@ class GraphAnalyticsService:
         limit: int = 50,
         offset: int = 0,
         include_summary: bool = True,
+        kind: str = "entity",
     ) -> dict[str, Any]:
-        """Return paginated list of communities for a graph."""
-        where_clauses = ["c.graph_id = $graph_id", "c.entity_count >= $min_size"]
+        """Return paginated list of communities for a graph.
+
+        The shape of each list entry is uniform across kinds: ``community_id``,
+        ``kind``, ``level``, ``entity_count`` (renamed at the result level to
+        match the existing API even when the underlying property is ``size``
+        for chunk-Louvain), ``weight``, ``parent_id``, ``status``, and
+        optionally ``summary``. Fields not present on a given kind come back
+        as ``None``.
+
+        ``level`` filter is only applied when the kind is hierarchical.
+        """
+        spec = get_kind(kind)
+        community_label = spec.community_label
+        id_prop = spec.id_property
+        size_prop = spec.size_property
+
+        where_clauses = [
+            "c.graph_id = $graph_id",
+            f"c.{size_prop} >= $min_size",
+        ]
         params: dict[str, Any] = {
             "graph_id": str(graph_id),
             "min_size": min_size,
             "limit": limit,
             "offset": offset,
         }
-        if level is not None:
+        if level is not None and spec.hierarchical:
             where_clauses.append("c.level = $level")
             params["level"] = level
 
         where = " AND ".join(where_clauses)
-        fields = "c.id AS community_id, c.level AS level, c.entity_count AS entity_count, c.weight AS weight, c.parent_id AS parent_id, c.status AS status"
-        if include_summary:
-            fields += ", c.summary AS summary"
 
-        count_query = f"MATCH (c:__Community__) WHERE {where} RETURN count(c) AS total"
-        list_query = f"""
-        MATCH (c:__Community__) WHERE {where}
-        RETURN {fields}
-        ORDER BY c.level, c.entity_count DESC
-        SKIP $offset LIMIT $limit
-        """
+        # Build the RETURN list. For hierarchical kinds we pull the
+        # additional metadata properties (level/weight/parent_id/status);
+        # for flat kinds those come back as NULL.
+        return_fields = [
+            f"c.{id_prop} AS community_id",
+            f"c.{size_prop} AS entity_count",
+        ]
+        if spec.hierarchical:
+            return_fields.extend(
+                [
+                    "c.level AS level",
+                    "c.weight AS weight",
+                    "c.parent_id AS parent_id",
+                    "c.status AS status",
+                ]
+            )
+        else:
+            return_fields.extend(
+                [
+                    "NULL AS level",
+                    "NULL AS weight",
+                    "NULL AS parent_id",
+                    "NULL AS status",
+                ]
+            )
+        if include_summary:
+            return_fields.append("c.summary AS summary")
+        fields = ", ".join(return_fields)
+
+        # ORDER BY: hierarchical kinds sort by level first (so callers can
+        # walk the hierarchy); flat kinds sort by size descending only.
+        order_by = (
+            f"c.level, c.{size_prop} DESC"
+            if spec.hierarchical
+            else f"c.{size_prop} DESC"
+        )
+
+        count_query = (
+            f"MATCH (c:`{community_label}`) WHERE {where} RETURN count(c) AS total"
+        )
+        list_query = (
+            f"MATCH (c:`{community_label}`) WHERE {where} "
+            f"RETURN {fields} "
+            f"ORDER BY {order_by} "
+            "SKIP $offset LIMIT $limit"
+        )
 
         total_results = await neo4j_client.execute_query(count_query, params)
         total = total_results[0]["total"] if total_results else 0
@@ -250,6 +410,7 @@ class GraphAnalyticsService:
         for r in list_results:
             item = {
                 "community_id": r["community_id"],
+                "kind": kind,
                 "level": r["level"],
                 "entity_count": r["entity_count"],
                 "weight": r["weight"],
@@ -260,92 +421,213 @@ class GraphAnalyticsService:
                 item["summary"] = r.get("summary")
             communities.append(item)
 
-        # Detection status
-        status_info = await self.get_community_status(graph_id)
+        status_info = await self.get_community_status(graph_id, kind=kind)
 
         return {
             "communities": communities,
+            "kind": kind,
             "total": total,
             "detection_status": status_info["status"],
             "last_detected_at": status_info["last_detected_at"],
         }
 
     async def get_community_detail(
-        self, graph_id: UUID, community_id: str
+        self,
+        graph_id: UUID,
+        community_id: str,
+        kind: str | None = None,
     ) -> dict[str, Any] | None:
-        """Return full community detail with members and parent/child links."""
-        community_query = """
-        MATCH (c:__Community__ {id: $community_id, graph_id: $graph_id})
-        RETURN c.id AS community_id, c.level AS level, c.summary AS summary,
-               c.entity_count AS entity_count, c.algorithm AS algorithm,
-               c.parent_id AS parent_id, c.created_at AS created_at,
-               c.last_updated AS last_updated, c.status AS status
+        """Return full community detail with members and parent/child links.
+
+        When ``kind`` is ``None`` (legacy callers), each registered kind is
+        probed in turn — entity-Leiden first so the common case stays a
+        single round trip. The first kind whose ``community_label`` and
+        ``id_property`` match the given ``community_id`` wins.
         """
-        result = await neo4j_client.execute_query(
-            community_query,
-            {
-                "community_id": community_id,
-                "graph_id": str(graph_id),
-            },
-        )
-        if not result:
+        candidate_specs: list[CommunityKindSpec]
+        if kind is None:
+            from app.schemas.community_kinds import all_kinds
+
+            candidate_specs = all_kinds()
+        else:
+            candidate_specs = [get_kind(kind)]
+
+        spec: CommunityKindSpec | None = None
+        community_row: dict[str, Any] | None = None
+        for candidate in candidate_specs:
+            row = await self._fetch_community_row(
+                graph_id=graph_id,
+                community_id=community_id,
+                spec=candidate,
+            )
+            if row is not None:
+                spec = candidate
+                community_row = row
+                break
+
+        if spec is None or community_row is None:
             return None
 
-        r = result[0]
-
-        # Members
-        members_query = """
-        MATCH (e:__Entity__)-[:IN_COMMUNITY {graph_id: $graph_id, level: $level}]->(c:__Community__ {id: $cid, graph_id: $graph_id})
-        RETURN e.id AS entity_id, e.name AS entity_name, labels(e) AS entity_labels
-        LIMIT 100
-        """
-        members_result = await neo4j_client.execute_query(
-            members_query,
-            {
-                "graph_id": str(graph_id),
-                "level": r["level"],
-                "cid": community_id,
-            },
+        members = await self._fetch_community_members(
+            graph_id=graph_id,
+            community_id=community_id,
+            spec=spec,
+            level=community_row.get("level"),
         )
-        members = [
+
+        parent_community = None
+        child_communities: list[dict[str, Any]] = []
+        if spec.hierarchical:
+            parent_community = await self._fetch_parent_community(
+                graph_id=graph_id,
+                parent_id=community_row.get("parent_id"),
+                spec=spec,
+            )
+            child_communities = await self._fetch_child_communities(
+                graph_id=graph_id,
+                community_id=community_id,
+                spec=spec,
+            )
+
+        return {
+            "community_id": community_row["community_id"],
+            "kind": spec.kind,
+            "level": community_row.get("level"),
+            "summary": community_row.get("summary"),
+            "entity_count": community_row.get("entity_count"),
+            "algorithm": community_row.get("algorithm"),
+            "status": community_row.get("status"),
+            "parent_community": parent_community,
+            "child_communities": child_communities,
+            "members": members,
+            "created_at": _coerce_neo4j_datetime(community_row.get("created_at")),
+            "last_updated": _coerce_neo4j_datetime(community_row.get("last_updated")),
+        }
+
+    async def _fetch_community_row(
+        self,
+        graph_id: UUID,
+        community_id: str,
+        spec: CommunityKindSpec,
+    ) -> dict[str, Any] | None:
+        """Pull the community node for one kind. Returns None if absent."""
+        # Build RETURN list. Fields that don't exist on the kind come back
+        # as NULL so the caller can treat the result shape uniformly.
+        if spec.hierarchical:
+            extra_fields = (
+                "c.level AS level, c.algorithm AS algorithm, "
+                "c.parent_id AS parent_id, c.status AS status, "
+                "c.last_updated AS last_updated"
+            )
+        else:
+            # Flat kinds may not have these — return NULLs to keep callers simple.
+            extra_fields = (
+                "NULL AS level, NULL AS algorithm, NULL AS parent_id, "
+                "NULL AS status, c.updated_at AS last_updated"
+            )
+
+        query = (
+            f"MATCH (c:`{spec.community_label}` "
+            f"{{`{spec.id_property}`: $community_id, graph_id: $graph_id}}) "
+            f"RETURN c.`{spec.id_property}` AS community_id, "
+            f"c.summary AS summary, "
+            f"c.`{spec.size_property}` AS entity_count, "
+            f"c.created_at AS created_at, "
+            f"{extra_fields}"
+        )
+        rows = await neo4j_client.execute_query(
+            query,
+            {"community_id": community_id, "graph_id": str(graph_id)},
+        )
+        return rows[0] if rows else None
+
+    async def _fetch_community_members(
+        self,
+        graph_id: UUID,
+        community_id: str,
+        spec: CommunityKindSpec,
+        level: int | None,
+    ) -> list[dict[str, Any]]:
+        """Pull up to 100 members of one community."""
+        # Member-rel filter: hierarchical kinds (Leiden) tag the rel with
+        # {graph_id, level} so we can isolate one level; flat kinds (Louvain)
+        # have no rel properties and we just walk the edge.
+        if spec.member_rel_has_level and level is not None:
+            rel_filter = (
+                f"[:`{spec.member_rel}` {{graph_id: $graph_id, level: $level}}]"
+            )
+            params: dict[str, Any] = {
+                "graph_id": str(graph_id),
+                "level": level,
+                "cid": community_id,
+            }
+        else:
+            rel_filter = f"[:`{spec.member_rel}`]"
+            params = {"graph_id": str(graph_id), "cid": community_id}
+
+        members_query = (
+            f"MATCH (m:`{spec.member_label}` {{graph_id: $graph_id}})"
+            f"-{rel_filter}->"
+            f"(c:`{spec.community_label}` "
+            f"{{`{spec.id_property}`: $cid, graph_id: $graph_id}}) "
+            "RETURN coalesce(m.id, elementId(m)) AS entity_id, "
+            "coalesce(m.name, m.text, '') AS entity_name, "
+            "labels(m) AS entity_labels "
+            "LIMIT 100"
+        )
+        members_result = await neo4j_client.execute_query(members_query, params)
+        return [
             {
                 "entity_id": m["entity_id"],
                 "entity_name": m["entity_name"],
-                "entity_type": next(
-                    (lbl for lbl in (m["entity_labels"] or []) if lbl != "__Entity__"),
-                    "Entity",
-                ),
+                "entity_type": _pick_entity_type(m["entity_labels"], spec.member_label),
             }
             for m in members_result
         ]
 
-        # Parent community
-        parent_community = None
-        if r.get("parent_id"):
-            parent_result = await neo4j_client.execute_query(
-                "MATCH (p:__Community__ {id: $pid, graph_id: $gid}) RETURN p.id AS community_id, p.summary AS summary",
-                {"pid": r["parent_id"], "gid": str(graph_id)},
-            )
-            if parent_result:
-                parent_community = {
-                    "community_id": parent_result[0]["community_id"],
-                    "summary": parent_result[0]["summary"],
-                }
-
-        # Child communities
-        child_query = """
-        MATCH (child:__Community__ {graph_id: $graph_id})-[:PARENT_COMMUNITY]->(parent:__Community__ {id: $cid, graph_id: $graph_id})
-        RETURN child.id AS community_id, child.summary AS summary, child.entity_count AS entity_count
-        LIMIT 20
-        """
-        child_results = await neo4j_client.execute_query(
-            child_query,
-            {
-                "graph_id": str(graph_id),
-                "cid": community_id,
-            },
+    async def _fetch_parent_community(
+        self,
+        graph_id: UUID,
+        parent_id: str | None,
+        spec: CommunityKindSpec,
+    ) -> dict[str, Any] | None:
+        if not parent_id:
+            return None
+        query = (
+            f"MATCH (p:`{spec.community_label}` "
+            f"{{`{spec.id_property}`: $pid, graph_id: $gid}}) "
+            f"RETURN p.`{spec.id_property}` AS community_id, p.summary AS summary"
         )
-        child_communities = [
+        result = await neo4j_client.execute_query(
+            query, {"pid": parent_id, "gid": str(graph_id)}
+        )
+        if not result:
+            return None
+        return {
+            "community_id": result[0]["community_id"],
+            "summary": result[0]["summary"],
+        }
+
+    async def _fetch_child_communities(
+        self,
+        graph_id: UUID,
+        community_id: str,
+        spec: CommunityKindSpec,
+    ) -> list[dict[str, Any]]:
+        query = (
+            f"MATCH (child:`{spec.community_label}` {{graph_id: $graph_id}})"
+            "-[:PARENT_COMMUNITY]->"
+            f"(parent:`{spec.community_label}` "
+            f"{{`{spec.id_property}`: $cid, graph_id: $graph_id}}) "
+            f"RETURN child.`{spec.id_property}` AS community_id, "
+            "child.summary AS summary, "
+            f"child.`{spec.size_property}` AS entity_count "
+            "LIMIT 20"
+        )
+        child_results = await neo4j_client.execute_query(
+            query, {"graph_id": str(graph_id), "cid": community_id}
+        )
+        return [
             {
                 "community_id": c["community_id"],
                 "summary": c["summary"],
@@ -353,20 +635,6 @@ class GraphAnalyticsService:
             }
             for c in child_results
         ]
-
-        return {
-            "community_id": r["community_id"],
-            "level": r["level"],
-            "summary": r["summary"],
-            "entity_count": r["entity_count"],
-            "algorithm": r["algorithm"],
-            "status": r["status"],
-            "parent_community": parent_community,
-            "child_communities": child_communities,
-            "members": members,
-            "created_at": r["created_at"],
-            "last_updated": r["last_updated"],
-        }
 
     async def get_simple_community_context(
         self, entities: list[dict[str, Any]], graph_id: UUID
@@ -432,7 +700,10 @@ class GraphAnalyticsService:
         1. Fetches __Entity__ nodes and relationships for the graph from Neo4j
         2. Builds an igraph graph in-process (no GDS dependency)
         3. Runs leidenalg.find_partition at 5 resolutions (0.25, 0.5, 1.0, 2.0, 4.0)
-        4. Writes __Community__ nodes with MEMBER_OF and PARENT_OF edges to Neo4j
+        4. Writes __Community__ nodes with IN_COMMUNITY and PARENT_COMMUNITY
+           edges to Neo4j (same edge names the Celery detector and all
+           readers use — see ``community_tasks.py`` and the
+           ``CommunityKindSpec`` registry).
 
         Args:
             graph_id: UUID of the specific graph to analyze
@@ -528,7 +799,10 @@ class GraphAnalyticsService:
                 "membership": partition.membership,  # list: vertex_index -> community_id
             }
 
-        # Step 5 — Write __Community__ nodes and MEMBER_OF / PARENT_OF edges
+        # Step 5 — Write __Community__ nodes and IN_COMMUNITY / PARENT_COMMUNITY
+        # edges. These names match the Celery production detector
+        # (community_tasks.py) and every reader path; the registry's
+        # ``CommunityKindSpec.member_rel`` is also ``"IN_COMMUNITY"``.
         total_communities = 0
         total_relationships = 0
 
@@ -568,14 +842,16 @@ class GraphAnalyticsService:
                 )
                 total_communities += 1
 
-                # Link entity members via MEMBER_OF
+                # Link entity members via IN_COMMUNITY (matches the
+                # Celery detector + every reader; carries graph_id+level
+                # on the relationship so per-level queries can filter).
                 for entity_id in member_entity_ids:
                     await neo4j_client.execute_query(
                         """
                         MATCH (e:__Entity__ {graph_id: $graph_id})
                         WHERE e.id = $entity_id OR elementId(e) = $entity_id
                         MATCH (c:__Community__ {id: $community_id, graph_id: $graph_id})
-                        MERGE (e)-[:MEMBER_OF {graph_id: $graph_id, level: $level}]->(c)
+                        MERGE (e)-[:IN_COMMUNITY {graph_id: $graph_id, level: $level}]->(c)
                         """,
                         {
                             "graph_id": graph_id_str,
@@ -586,7 +862,9 @@ class GraphAnalyticsService:
                     )
                     total_relationships += 1
 
-                # Link to parent community (level - 1) via PARENT_OF
+                # Link to parent community (level - 1) via PARENT_COMMUNITY,
+                # direction child->parent — matches community_tasks.py
+                # _upsert_communities and the analytics readers.
                 if level > 0:
                     first_idx = next(
                         (
@@ -607,7 +885,7 @@ class GraphAnalyticsService:
                             """
                             MATCH (child:__Community__ {id: $child_id, graph_id: $graph_id})
                             MATCH (parent:__Community__ {id: $parent_id, graph_id: $graph_id})
-                            MERGE (parent)-[:PARENT_OF {graph_id: $graph_id}]->(child)
+                            MERGE (child)-[:PARENT_COMMUNITY {graph_id: $graph_id}]->(parent)
                             """,
                             {
                                 "child_id": community_node_id,

--- a/knowledge-graph-builder/tests/unit/test_communities_endpoint.py
+++ b/knowledge-graph-builder/tests/unit/test_communities_endpoint.py
@@ -57,11 +57,15 @@ class TestCommunitySchema:
             summary="Tech companies",
         )
         data = c.model_dump(mode="json")
+        # kind defaults to "entity"; member_label is optional and stays None
+        # unless an explicit value is passed.
         assert data == {
             "community_id": "c-1",
+            "kind": "entity",
             "level": 0,
             "label": "Tech",
             "size": 10,
+            "member_label": None,
             "summary": "Tech companies",
         }
 
@@ -74,3 +78,19 @@ class TestCommunitySchema:
     def test_size_must_be_non_negative(self):
         with pytest.raises(ValidationError):
             Community(community_id="c-1", level=0, label="x", size=-1)
+
+    @pytest.mark.unit
+    def test_kind_and_member_label_round_trip(self):
+        """A chunk-kind payload preserves kind + member_label through serialization."""
+        c = Community(
+            community_id="cc_12_abcdef",
+            kind="chunk",
+            level=0,
+            label="Cluster 12",
+            size=276,
+            member_label="Chunk",
+        )
+        data = c.model_dump(mode="json")
+        assert data["kind"] == "chunk"
+        assert data["member_label"] == "Chunk"
+        assert data["level"] == 0

--- a/knowledge-graph-builder/tests/unit/test_community_edge_names.py
+++ b/knowledge-graph-builder/tests/unit/test_community_edge_names.py
@@ -1,0 +1,69 @@
+"""Pin community edge names so writer/reader can't drift again.
+
+The bug this guards against: the sync ``_run_leiden_community_detection``
+in ``analytics_service.py`` and the Celery detector in
+``community_tasks.py`` used to write *different* relationship types
+(``MEMBER_OF`` / ``PARENT_OF`` vs ``IN_COMMUNITY`` / ``PARENT_COMMUNITY``),
+silently breaking every reader path on whichever subset of graphs the
+sync detector wrote.
+
+These tests grep the actual Cypher in those two writers and the
+registry, asserting they all agree.
+"""
+
+import pytest
+
+
+def _read(path: str) -> str:
+    with open(path) as f:
+        return f.read()
+
+
+@pytest.mark.unit
+def test_celery_detector_writes_in_community_and_parent_community():
+    src = _read("app/tasks/community_tasks.py")
+    # Member edge
+    assert "[r:IN_COMMUNITY {graph_id: $graph_id, level: $level}]" in src, (
+        "Celery detector must write IN_COMMUNITY edges with graph_id+level"
+    )
+    # Parent edge with direction (child)-[:PARENT_COMMUNITY]->(parent)
+    assert "(child)-[:PARENT_COMMUNITY {graph_id: $graph_id}]->(parent)" in src, (
+        "Celery detector must write PARENT_COMMUNITY from child to parent"
+    )
+
+
+@pytest.mark.unit
+def test_sync_detector_writes_in_community_and_parent_community():
+    src = _read("app/services/analytics_service.py")
+    # The sync ``_run_leiden_community_detection`` path
+    assert "[:IN_COMMUNITY {graph_id: $graph_id, level: $level}]" in src
+    assert "(child)-[:PARENT_COMMUNITY {graph_id: $graph_id}]->(parent)" in src
+
+
+@pytest.mark.unit
+def test_no_legacy_member_of_or_parent_of_in_community_writers():
+    """Reject any reintroduction of MEMBER_OF/PARENT_OF to __Community__.
+
+    ``MEMBER_OF`` and ``PARENT_OF`` are used elsewhere — entity dedup in
+    ``entity_resolver.py`` and user-team ReBAC in ``rebac_service.py``.
+    Those are different features; they must never re-enter the community
+    detection paths.
+    """
+    analytics = _read("app/services/analytics_service.py")
+    tasks = _read("app/tasks/community_tasks.py")
+    for src, label in ((analytics, "analytics_service"), (tasks, "community_tasks")):
+        assert ":MEMBER_OF" not in src.replace("[:MEMBER_OF]", ""), (
+            f"{label} contains a community-context :MEMBER_OF edge — "
+            "use IN_COMMUNITY instead"
+        )
+        assert ":PARENT_OF" not in src, (
+            f"{label} contains a :PARENT_OF edge — use PARENT_COMMUNITY instead"
+        )
+
+
+@pytest.mark.unit
+def test_registry_member_rel_matches_writers():
+    """The kind registry must agree with the writer/reader convention."""
+    from app.schemas.community_kinds import get_kind
+
+    assert get_kind("entity").member_rel == "IN_COMMUNITY"

--- a/knowledge-graph-builder/tests/unit/test_community_kinds_registry.py
+++ b/knowledge-graph-builder/tests/unit/test_community_kinds_registry.py
@@ -1,0 +1,125 @@
+"""Unit tests for the community-kind registry (STORY-4a).
+
+The registry is the source of truth for which community kinds the platform
+can read and detect. These tests pin the contract: keys present, helpers
+behave deterministically, unknown kinds raise the expected error.
+"""
+
+import pytest
+
+from app.schemas.community_kinds import (
+    COMMUNITY_KINDS,
+    CommunityKindSpec,
+    UnknownCommunityKindError,
+    all_kinds,
+    get_kind,
+    kind_for_community_label,
+)
+
+
+class TestRegistryEntries:
+    @pytest.mark.unit
+    def test_entity_kind_is_registered_with_expected_shape(self):
+        spec = COMMUNITY_KINDS["entity"]
+        assert spec.community_label == "__Community__"
+        assert spec.member_label == "__Entity__"
+        assert spec.member_rel == "IN_COMMUNITY"
+        assert spec.id_property == "id"
+        assert spec.size_property == "entity_count"
+        assert spec.hierarchical is True
+        assert spec.member_rel_has_level is True
+        assert spec.detector_task_name is not None
+
+    @pytest.mark.unit
+    def test_chunk_kind_is_registered_with_expected_shape(self):
+        spec = COMMUNITY_KINDS["chunk"]
+        assert spec.community_label == "ChunkCommunity"
+        assert spec.member_label == "Chunk"
+        assert spec.member_rel == "IN_CHUNK_COMMUNITY"
+        assert spec.id_property == "community_id"
+        assert spec.size_property == "size"
+        assert spec.hierarchical is False
+        assert spec.member_rel_has_level is False
+        # Read-only kind today
+        assert spec.detector_task_name is None
+
+    @pytest.mark.unit
+    def test_registry_keys_match_kind_field(self):
+        """The dict key must equal the spec's own ``kind`` field — otherwise
+        ``all_kinds()`` consumers will get inconsistent identifiers."""
+        for key, spec in COMMUNITY_KINDS.items():
+            assert key == spec.kind, (
+                f"Registry key {key!r} doesn't match spec.kind {spec.kind!r}"
+            )
+
+    @pytest.mark.unit
+    def test_specs_are_frozen(self):
+        """Mutation of a registered spec is rejected so callers can't
+        accidentally rewrite the registry at runtime."""
+        spec = COMMUNITY_KINDS["entity"]
+        with pytest.raises((AttributeError, Exception)):
+            spec.community_label = "Mutated"  # type: ignore[misc]
+
+
+class TestGetKind:
+    @pytest.mark.unit
+    def test_returns_registered_spec(self):
+        spec = get_kind("entity")
+        assert isinstance(spec, CommunityKindSpec)
+        assert spec.kind == "entity"
+
+    @pytest.mark.unit
+    def test_raises_unknown_community_kind_error(self):
+        with pytest.raises(UnknownCommunityKindError) as exc_info:
+            get_kind("bogus")
+        # The error must enumerate valid kinds so callers can correct the bug
+        assert "bogus" in str(exc_info.value)
+        assert "entity" in str(exc_info.value)
+        assert "chunk" in str(exc_info.value)
+        # ValueError lineage lets endpoints catch with a single except
+        assert isinstance(exc_info.value, ValueError)
+
+    @pytest.mark.unit
+    def test_error_exposes_kind_and_valid_kinds(self):
+        try:
+            get_kind("nope")
+        except UnknownCommunityKindError as exc:
+            assert exc.kind == "nope"
+            assert "entity" in exc.valid_kinds
+            assert "chunk" in exc.valid_kinds
+
+
+class TestAllKinds:
+    @pytest.mark.unit
+    def test_returns_every_registered_spec(self):
+        kinds = all_kinds()
+        names = [spec.kind for spec in kinds]
+        assert "entity" in names
+        assert "chunk" in names
+
+    @pytest.mark.unit
+    def test_preserves_insertion_order(self):
+        """Insertion order matters for endpoints that probe kinds in order
+        (e.g., get_community_detail without ?kind=). Entity must come first
+        so the common path stays a single round trip."""
+        kinds = all_kinds()
+        first_two = [spec.kind for spec in kinds[:2]]
+        assert first_two == ["entity", "chunk"]
+
+
+class TestKindForCommunityLabel:
+    @pytest.mark.unit
+    def test_entity_label_resolves_to_entity_kind(self):
+        spec = kind_for_community_label("__Community__")
+        assert spec is not None
+        assert spec.kind == "entity"
+
+    @pytest.mark.unit
+    def test_chunk_label_resolves_to_chunk_kind(self):
+        spec = kind_for_community_label("ChunkCommunity")
+        assert spec is not None
+        assert spec.kind == "chunk"
+
+    @pytest.mark.unit
+    def test_unknown_label_returns_none(self):
+        assert kind_for_community_label("Foo") is None


### PR DESCRIPTION
## Summary

Makes the platform's community-detection paths consistent end-to-end, and unlocks the 59 already-existing `:ChunkCommunity` nodes for API consumption (they were silently invisible before).

- **New** `CommunityKindSpec` registry (`app/schemas/community_kinds.py`) — single source of truth for community labels, member labels, relationship types, property names (`id` vs `community_id`, `entity_count` vs `size`), hierarchical-ness, and detector-task name. Adding a new kind is one entry in `COMMUNITY_KINDS`.
- **New** `GET /api/v1/communities/kinds` discovery endpoint so the frontend's kind picker stays metadata-driven.
- **Extended** existing endpoints to accept `?kind=`:
  - `GET /graphs/{id}/communities`
  - `GET /graphs/{id}/communities/status`
  - `GET /graphs/{id}/communities/{community_id}` (also accepts the legacy no-`?kind=` form — server probes the registry)
  - `POST /graphs/{id}/communities/detect` (kind in request body; read-only kinds → HTTP 405)
- **Refactored** `analytics_service.py` to drive Cypher labels / rels / property names from the registry.
- **Unified** the sync `_run_leiden_community_detection` writer to emit `:IN_COMMUNITY` / `:PARENT_COMMUNITY` matching the Celery detector and every reader. Pre-existing inconsistency — verified 0 orphan `:MEMBER_OF` / `:PARENT_OF` edges across all tenants before changing.
- **Fixed** `AgentToolkit.community_members` — was querying `:Community` / `:BELONGS_TO`, neither of which exists in any tenant. Silently broken; every research-mode agent call returned empty. Now probes the registry.
- **Tests** — 22 new unit tests (12 for the registry + 4 regression-guard for edge names + 2 schema, 4 docs); 135 total pass in the touched surface; the 10 unrelated failures on develop (test_agents_crud, test_chat_ownership, test_chat_service) are pre-existing and confirmed via stash-test.

## Live verification (Eurail graph `86e2f6a2-...`)

| Endpoint | Result |
|---|---|
| `GET /communities/kinds` | both kinds with full metadata |
| `GET /graphs/{id}/communities` (default) | 18 entity communities, kind=entity ✓ regression preserved |
| `?kind=chunk` | 59 chunk communities, member_label=Chunk ✓ **NEW** |
| `GET /communities/{id}` (no `?kind=`) | auto-detects, returns 100 chunk members |
| `POST /communities/detect` `{"kind":"chunk"}` | HTTP 405 ✓ |
| `?kind=bogus` | HTTP 400 ✓ |

## Test plan

- [ ] `make test` runs registry + community + analytics + agent_tools + integration tests
- [ ] Frontend community panel renders both kinds when wired (separate frontend PR)
- [ ] Live smoke against another tenant's graph (regression for entity-only graphs)

## Out of scope (follow-ups)

- **STORY-4b** — generate `summary` for the 59 chunk communities (they have no summaries today)
- **STORY-4c** — summary embeddings + vector index for chunk communities
- **STORY-4d** — new agent tools `find_communities`, `community_for_node`
- The 10 pre-existing unit failures on develop (separate cleanup PR)
- The non-existent `PARENT_COMMUNITY` edges in live data (Celery detector writes them but `parent_id` isn't populated on the community nodes — entity-Leiden hierarchy is effectively flat in live data despite supporting hierarchy)