### PR TITLE
STORY-5: native tool-use protocol for agent reasoning

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -399,7 +399,7 @@
         "filename": "knowledge-graph-builder/tests/unit/test_agent_executor.py",
         "hashed_secret": "31cb31929f20d4dc26d29d3b03323e38a72978db",
         "is_verified": false,
-        "line_number": 372
+        "line_number": 433
       }
     ],
     "knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py": [
@@ -415,21 +415,21 @@
         "filename": "knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py",
         "hashed_secret": "035774df1383d44df6a3343cd316ada6f41a97b6",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 65
       },
       {
         "type": "Secret Keyword",
         "filename": "knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py",
         "hashed_secret": "6d5e7baf4ba7767cd583d12c78de54f28d805598",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 81
       },
       {
         "type": "Secret Keyword",
         "filename": "knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py",
         "hashed_secret": "a54bd88e2bd740338cfb19160c0686c70facc590",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 105
       }
     ],
     "knowledge-graph-builder/tests/unit/test_background_jobs.py": [
@@ -676,5 +676,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T17:02:25Z"
+  "generated_at": "2026-05-14T19:45:55Z"
 }

--- a/knowledge-graph-builder/app/schemas/agent_schemas.py
+++ b/knowledge-graph-builder/app/schemas/agent_schemas.py
@@ -117,6 +117,12 @@ class ProvenancePayload(BaseModel):
     total_nodes_traversed: int = 0
     reasoning_steps: int = 0
     tools_called: list[str] = []
+    # One entry per dispatched tool call. Each is {"id", "name", "node_count"}.
+    # Lets the frontend reconstruct the LLM's actual call chain instead of
+    # just seeing the flat tool-name list. ``id`` mirrors the LLM-provided
+    # tool_call_id when the native tool-use protocol is in use; falls back
+    # to a synthetic id for legacy (direct-mode graph_search) dispatches.
+    tool_calls: list[dict] = []
 
 
 class AgentChatResponse(BaseModel):

--- a/knowledge-graph-builder/app/services/agent_executor.py
+++ b/knowledge-graph-builder/app/services/agent_executor.py
@@ -1,4 +1,4 @@
-"""Agent execution engine — four reasoning modes (TASK-034 / STORY-020).
+"""Agent execution engine — four reasoning modes (TASK-034 / STORY-020, STORY-5).
 
 AgentExecutor is instantiated per chat request. It loads the agent definition
 from Neo4j, resolves the LLM client via the three-level LLMConfig chain
@@ -9,13 +9,30 @@ returns alongside the agent's response.
 Reasoning modes
 ---------------
 direct          Single retrieval pass → generate (≤ 2 LLM calls)
-research        ReAct loop: retrieve → think → retrieve → generate (≤ 5 iterations)
-analytical      CoT reasoning section prepended before the final answer
-conversational  Full session history injected; warm tone system prompt suffix
+research        Native tool-use loop: model emits tool_calls, we dispatch
+                them, return tool results, model may call more or answer.
+                Up to 5 iterations.
+analytical      Same loop as research with a structured-reasoning system
+                prompt nudging the model to lay out its analysis.
+conversational  Full session history injected; warm-tone system prompt suffix
+
+STORY-5 — Real tool-use protocol
+-------------------------------
+Previously ``_research`` prompted the model to emit JSON describing tool
+calls and parsed the raw text with regex-based parsers. Claude (and most
+modern models) are trained on a native tool-use protocol where the SDK
+returns structured ``tool_calls`` and accepts ``role: tool`` results.
+This module now uses that protocol directly via both the Anthropic
+native SDK and the OpenAI-compatible SDK (which OpenRouter and Azure
+OpenAI also serve).
+
+Tool schemas live in ``app/services/agent_tool_schemas.py`` and are
+formatted per-provider; the executor never hand-writes them inline.
 """
 
 import json
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
 
@@ -26,6 +43,7 @@ from app.core.config import settings
 from app.core.logging import get_logger
 from app.schemas.agent_schemas import AgentChatResponse, NodeResult, PathResult
 from app.services.agent_service import AgentService
+from app.services.agent_tool_schemas import tool_schemas_for
 from app.services.agent_tools import AgentToolkit, ToolNotPermittedError
 from app.services.credential_broker_client import (
     CredentialBrokerClient,
@@ -41,154 +59,19 @@ logger = get_logger(__name__)
 # key: session_id, value: list of {"role": ..., "content": ...} dicts
 _sessions: dict[str, list[dict]] = {}
 
-_REACT_SYSTEM = """You are a graph-native research agent. To answer the question you \
-may call tools one at a time. After each tool result you will decide whether to call \
-another tool or produce a final answer.
 
-OUTPUT FORMAT — STRICTLY ONE JSON OBJECT, NOTHING ELSE:
-  - To call a tool, emit ONLY: {{"action": "<tool_name>", "args": {{...}}}}
-  - To produce the final answer, emit ONLY: {{"action": "answer", "text": "<your response>"}}
+# Max iterations of the tool-use loop. Each iteration = one LLM call +
+# zero or more dispatched tools. Cap protects against pathological loops.
+_MAX_TOOL_ITERATIONS = 5
 
-Hard rules about output:
-  - No prose before or after the JSON.
-  - No markdown code fences (```).
-  - No <function_calls> tags, no <invoke> tags, no XML of any kind.
-  - No comments inside the JSON.
-  - Exactly one JSON object per turn.
-
-The tool will be executed by the system. You will see its result in the next turn \
-as a user message labeled "Tool 'X' result:". Then decide your next move with \
-another single JSON object.
-
-Available tools: {tools}
-"""
-
-
-import re as _re
-
-_FUNCTION_CALLS_BLOCK = _re.compile(
-    r"<function_calls>\s*(\[.+?\]|\{.+?\})\s*</function_calls>", _re.DOTALL
+# System-prompt suffix that nudges analytical mode to lay out its reasoning
+# before the final answer. Combined with the agent's configured system
+# prompt and the tool-use protocol.
+_ANALYTICAL_SUFFIX = (
+    "\n\nReasoning style: think step by step. Use the available tools to "
+    "gather evidence, then lay out your analysis explicitly in the final "
+    "answer (e.g. 'Step 1:', 'Step 2:', then 'Conclusion:')."
 )
-_FENCED_JSON = _re.compile(r"```(?:json)?\s*(\{.+?\})\s*```", _re.DOTALL)
-
-
-def _scan_json_object(s: str, start: int) -> str | None:
-    """Return the substring of s starting at s[start] (must be '{') that
-    spans the matching closing '}' with string-aware bracket counting.
-    Returns None if no balanced object is found."""
-    if start >= len(s) or s[start] != "{":
-        return None
-    depth = 0
-    i = start
-    in_str = False
-    str_quote = ""
-    escape = False
-    while i < len(s):
-        ch = s[i]
-        if in_str:
-            if escape:
-                escape = False
-            elif ch == "\\":
-                escape = True
-            elif ch == str_quote:
-                in_str = False
-        else:
-            if ch in ('"', "'"):
-                in_str = True
-                str_quote = ch
-            elif ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    return s[start : i + 1]
-        i += 1
-    return None
-
-
-def _find_first_json_object(s: str) -> str | None:
-    """Find the first balanced JSON object substring in s, handling nested
-    braces inside strings (e.g. Cypher queries with `{prop: value}` literals)."""
-    pos = 0
-    while True:
-        idx = s.find("{", pos)
-        if idx == -1:
-            return None
-        candidate = _scan_json_object(s, idx)
-        if candidate is not None:
-            return candidate
-        pos = idx + 1
-
-
-def _normalize_decision(obj: dict) -> dict:
-    """Map Claude's native tool-use shape onto the ReAct shape we dispatch on.
-
-    Claude sometimes emits {"type": "tool", "id": "<tool_name>", "args": {...}}
-    or {"name": "<tool_name>", "input": {...}} instead of {"action": ..., "args": ...}.
-    """
-    if "action" in obj:
-        return obj
-    if obj.get("type") == "tool" and obj.get("id"):
-        return {"action": obj["id"], "args": obj.get("args") or obj.get("input") or {}}
-    if "name" in obj and ("input" in obj or "args" in obj):
-        return {
-            "action": obj["name"],
-            "args": obj.get("args") or obj.get("input") or {},
-        }
-    return obj
-
-
-def _parse_react_decision(raw: str) -> dict | None:
-    """Robustly parse the agent's decision JSON.
-
-    Handles five shapes:
-      1. Pure JSON object.
-      2. Claude tool-use wrapper: <function_calls>[{...}]</function_calls>.
-      3. Markdown-fenced JSON: ```json {...} ```.
-      4. JSON object embedded in prose (Cypher-safe bracket counting).
-      5. Normalizes Anthropic-style tool-use fields ({"type":"tool","id":...}
-         or {"name":...,"input":...}) to the expected {"action":...,"args":...}.
-    Returns None if no JSON object can be recovered.
-    """
-    s = raw.strip()
-    try:
-        obj = json.loads(s)
-        if isinstance(obj, dict):
-            return _normalize_decision(obj)
-        if isinstance(obj, list) and obj and isinstance(obj[0], dict):
-            return _normalize_decision(obj[0])
-    except json.JSONDecodeError:
-        pass
-    m = _FUNCTION_CALLS_BLOCK.search(s)
-    if m:
-        try:
-            inner = json.loads(m.group(1))
-            if isinstance(inner, list) and inner and isinstance(inner[0], dict):
-                return _normalize_decision(inner[0])
-            if isinstance(inner, dict):
-                return _normalize_decision(inner)
-        except json.JSONDecodeError:
-            pass
-    m = _FENCED_JSON.search(s)
-    if m:
-        try:
-            obj = json.loads(m.group(1))
-            if isinstance(obj, dict):
-                return _normalize_decision(obj)
-        except json.JSONDecodeError:
-            pass
-    candidate = _find_first_json_object(s)
-    if candidate:
-        try:
-            obj = json.loads(candidate)
-            if isinstance(obj, dict):
-                normalized = _normalize_decision(obj)
-                if "action" in normalized or "text" in normalized:
-                    return normalized
-        except json.JSONDecodeError:
-            pass
-    return None
-
 
 _CONVERSATIONAL_SUFFIX = (
     "\n\nYou are having a friendly, ongoing conversation. "
@@ -196,35 +79,97 @@ _CONVERSATIONAL_SUFFIX = (
 )
 
 
-def _format_nodes(nodes: list[NodeResult]) -> str:
+# ── Tool-use protocol types ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolCall:
+    """One tool invocation the LLM wants the executor to dispatch."""
+
+    id: str
+    name: str
+    args: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _LLMResponse:
+    """A single LLM completion. Either text-only or includes tool_calls.
+
+    When tool_calls is non-empty, ``text`` may still hold reasoning the
+    model emitted alongside the calls. Callers that detect tool_calls
+    should dispatch them and feed results back via a new completion.
+    """
+
+    text: str
+    tool_calls: list[_ToolCall] = field(default_factory=list)
+    # Raw assistant-message payload to echo back in the next turn. SDK-
+    # specific (Anthropic uses content blocks, OpenAI uses str+tool_calls)
+    # so we keep it opaque here and reconstruct in ``_append_assistant``.
+    raw_assistant_payload: Any = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _node_to_jsonable(n: NodeResult) -> dict[str, Any]:
+    """Project a NodeResult down to a small JSON-safe dict for tool
+    results. Drops the embedding (huge) and keeps id, label,
+    qualified_name, and a trimmed properties bag including the text/
+    content excerpt if present."""
+    props = dict(getattr(n, "properties", {}) or {})
+    # Don't ship embeddings or huge blobs back to the LLM
+    props.pop("embedding", None)
+    text = props.get("text") or props.get("content")
+    if isinstance(text, str) and len(text) > 1500:
+        props["text"] = text[:1500] + "…"
+    return {
+        "id": n.id,
+        "label": n.label,
+        "qualified_name": n.qualified_name,
+        "properties": props,
+    }
+
+
+def _format_tool_result_json(nodes: list[NodeResult]) -> str:
+    """Serialize tool output to JSON the LLM can read.
+
+    Empty-result cases are explicit so the model doesn't second-guess
+    whether the tool ran. Truncates to top 20 nodes per call (the agent
+    can ask for more via max_results on the next call if needed).
+    """
     if not nodes:
-        return "(no results)"
-    lines = []
-    for n in nodes:
-        # Chunks have no id/label/name; the substance lives in properties['text'].
-        # Surface that text so the agent's LLM has grounded content to cite.
-        props = getattr(n, "properties", {}) or {}
-        chunk_text = props.get("text") or props.get("content") or ""
-        identifier = n.id or props.get("element_id") or ""
-        label = (
-            n.label or (props.get("nodeLabels") or [""])[0]
-            if isinstance(props.get("nodeLabels"), list)
-            else (n.label or "")
-        )
-        qn = f" ({n.qualified_name})" if n.qualified_name else ""
-        header = f"- [{identifier}] {label}{qn}".rstrip()
-        if chunk_text:
-            # Limit to 1500 chars per chunk to keep prompt within budget for top_k=10
-            preview = chunk_text[:1500].strip()
-            lines.append(f"{header}\n  {preview}")
-        else:
-            lines.append(header)
-    return "\n".join(lines)
+        return json.dumps({"results": [], "count": 0})
+    capped = nodes[:20]
+    return json.dumps(
+        {
+            "results": [_node_to_jsonable(n) for n in capped],
+            "count": len(capped),
+            "truncated": len(nodes) > len(capped),
+        },
+        default=str,
+    )
 
 
 def _extract_cited_nodes(response: str, nodes: list[dict]) -> list[str]:
     """Return IDs of nodes whose id string appears literally in the response."""
     return [n["id"] for n in nodes if n["id"] in response]
+
+
+def _is_anthropic_client(llm: Any) -> bool:
+    """True if ``llm`` is an AsyncAnthropic instance.
+
+    Done lazily so test mocks that don't import the anthropic SDK still
+    work — and so the executor doesn't crash if anthropic isn't installed
+    in a deployment that only uses OpenRouter / OpenAI.
+    """
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError:
+        return False
+    return isinstance(llm, AsyncAnthropic)
+
+
+# ── Executor ─────────────────────────────────────────────────────────────────
 
 
 class AgentExecutor:
@@ -326,56 +271,115 @@ class AgentExecutor:
     # ── LLM helpers ───────────────────────────────────────────────────────────
 
     async def _call_llm(
-        self, messages: list[dict], system_prompt: str | None = None
-    ) -> str:
-        sp = system_prompt or self._agent.get(
-            "system_prompt", "You are a helpful assistant."
-        )
+        self,
+        messages: list[dict],
+        system_prompt: str | None = None,
+        tools: list[dict] | None = None,
+    ) -> _LLMResponse:
+        """Single LLM completion.
 
-        try:
-            from anthropic import AsyncAnthropic
+        - ``tools`` is the per-provider-formatted tool list (from
+          ``tool_schemas_for``). When provided, the response may contain
+          ``tool_calls`` — the executor dispatches each and feeds back
+          the result on the next call.
+        - When ``tools`` is None, behaves as a pure text completion.
 
-            _is_anthropic = isinstance(self._llm, AsyncAnthropic)
-        except ImportError:
-            _is_anthropic = False
-
-        if _is_anthropic:
-            resp = await self._llm.messages.create(
-                model=self._model,
-                max_tokens=4096,
-                system=sp,
-                messages=messages,
-            )
-            return resp.content[0].text or ""
-        else:
-            all_msgs = [{"role": "system", "content": sp}] + messages
-            resp = await self._llm.chat.completions.create(
-                model=self._model,
-                messages=all_msgs,
-                temperature=0.7,
-            )
-            return resp.choices[0].message.content or ""
-
-    async def _call_llm_stream(
-        self, messages: list[dict], system_prompt: str | None = None
-    ) -> AsyncGenerator[str, None]:
-        """Yield LLM response tokens one at a time.
-
-        Phase 1: direct mode only. For Anthropic uses the streaming context manager;
-        for OpenAI-compatible uses stream=True. Non-direct modes use run() instead.
+        Two SDK paths share the same _LLMResponse shape.
         """
         sp = system_prompt or self._agent.get(
             "system_prompt", "You are a helpful assistant."
         )
 
-        try:
-            from anthropic import AsyncAnthropic
+        if _is_anthropic_client(self._llm):
+            return await self._call_anthropic(messages, sp, tools)
+        return await self._call_openai_compatible(messages, sp, tools)
 
-            _is_anthropic = isinstance(self._llm, AsyncAnthropic)
-        except ImportError:
-            _is_anthropic = False
+    async def _call_anthropic(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        tools: list[dict] | None,
+    ) -> _LLMResponse:
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": 4096,
+            "system": system_prompt,
+            "messages": messages,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        resp = await self._llm.messages.create(**kwargs)
 
-        if _is_anthropic:
+        text_parts: list[str] = []
+        tool_calls: list[_ToolCall] = []
+        for block in resp.content:
+            btype = getattr(block, "type", None)
+            if btype == "text":
+                text_parts.append(getattr(block, "text", "") or "")
+            elif btype == "tool_use":
+                tool_calls.append(
+                    _ToolCall(
+                        id=getattr(block, "id", "") or "",
+                        name=getattr(block, "name", "") or "",
+                        args=dict(getattr(block, "input", {}) or {}),
+                    )
+                )
+        return _LLMResponse(
+            text="".join(text_parts),
+            tool_calls=tool_calls,
+            raw_assistant_payload=resp.content,
+        )
+
+    async def _call_openai_compatible(
+        self,
+        messages: list[dict],
+        system_prompt: str,
+        tools: list[dict] | None,
+    ) -> _LLMResponse:
+        all_msgs = [{"role": "system", "content": system_prompt}] + messages
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": all_msgs,
+            "temperature": 0.7,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        resp = await self._llm.chat.completions.create(**kwargs)
+        msg = resp.choices[0].message
+        text = msg.content or ""
+        tool_calls: list[_ToolCall] = []
+        for raw_tc in getattr(msg, "tool_calls", None) or []:
+            fn = getattr(raw_tc, "function", None)
+            fn_name = getattr(fn, "name", "") if fn else ""
+            fn_args_raw = getattr(fn, "arguments", "") if fn else ""
+            try:
+                fn_args = json.loads(fn_args_raw) if fn_args_raw else {}
+            except (json.JSONDecodeError, TypeError):
+                fn_args = {}
+            tool_calls.append(
+                _ToolCall(
+                    id=getattr(raw_tc, "id", "") or "",
+                    name=fn_name,
+                    args=fn_args,
+                )
+            )
+        return _LLMResponse(text=text, tool_calls=tool_calls, raw_assistant_payload=msg)
+
+    async def _call_llm_stream(
+        self,
+        messages: list[dict],
+        system_prompt: str | None = None,
+    ) -> AsyncGenerator[str, None]:
+        """Yield LLM response tokens one at a time (no tool use).
+
+        Used for the final-answer streaming pass after a tool-use loop
+        has concluded, and for direct mode where there are no tool calls.
+        """
+        sp = system_prompt or self._agent.get(
+            "system_prompt", "You are a helpful assistant."
+        )
+
+        if _is_anthropic_client(self._llm):
             async with self._llm.messages.stream(
                 model=self._model,
                 max_tokens=4096,
@@ -397,13 +401,151 @@ class AgentExecutor:
                     if delta:
                         yield delta
 
+    # ── Tool-use loop primitives ──────────────────────────────────────────────
+
+    def _provider_format(self) -> str:
+        return "anthropic" if _is_anthropic_client(self._llm) else "openai"
+
+    def _append_assistant_turn(self, messages: list[dict], resp: _LLMResponse) -> None:
+        """Append the assistant turn to the running messages list in the
+        shape the provider expects on the next call."""
+        if _is_anthropic_client(self._llm):
+            # Anthropic wants the content blocks back verbatim
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": resp.raw_assistant_payload,
+                }
+            )
+        else:
+            entry: dict[str, Any] = {
+                "role": "assistant",
+                "content": resp.text or None,
+            }
+            if resp.tool_calls:
+                entry["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": json.dumps(tc.args),
+                        },
+                    }
+                    for tc in resp.tool_calls
+                ]
+            messages.append(entry)
+
+    def _append_tool_result(
+        self,
+        messages: list[dict],
+        tool_call: _ToolCall,
+        content: str,
+        is_error: bool = False,
+    ) -> None:
+        """Append a tool-result turn in the provider's expected shape."""
+        if _is_anthropic_client(self._llm):
+            messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_call.id,
+                            "content": content,
+                            "is_error": is_error,
+                        }
+                    ],
+                }
+            )
+        else:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": content,
+                }
+            )
+
+    async def _tool_use_loop(
+        self,
+        message: str,
+        prov: ProvenanceCollector,
+        system_prompt: str,
+    ) -> tuple[str, list[dict]]:
+        """Drive the native tool-use loop.
+
+        Returns ``(final_text, messages)`` once the model produces a turn
+        with no tool_calls, or when the iteration cap is hit (in which
+        case ``final_text`` is whatever text was last produced — caller
+        may want to re-prompt for a definitive answer).
+        """
+        tools = tool_schemas_for(
+            self._agent.get("tools", []) or [], self._provider_format()
+        )
+        messages: list[dict] = [{"role": "user", "content": message}]
+
+        last_text = ""
+        for _ in range(_MAX_TOOL_ITERATIONS):
+            resp = await self._call_llm(
+                messages, system_prompt=system_prompt, tools=tools or None
+            )
+            last_text = resp.text
+
+            if not resp.tool_calls:
+                return resp.text, messages
+
+            self._append_assistant_turn(messages, resp)
+
+            for tc in resp.tool_calls:
+                try:
+                    nodes = await self._dispatch(tc.name, tc.args, prov, tc.id)
+                    self._append_tool_result(
+                        messages, tc, _format_tool_result_json(nodes), is_error=False
+                    )
+                except ToolNotPermittedError as exc:
+                    self._append_tool_result(
+                        messages,
+                        tc,
+                        json.dumps({"error": "tool_not_permitted", "detail": str(exc)}),
+                        is_error=True,
+                    )
+                except (TypeError, ValueError) as exc:
+                    self._append_tool_result(
+                        messages,
+                        tc,
+                        json.dumps({"error": "bad_arguments", "detail": str(exc)}),
+                        is_error=True,
+                    )
+                except Exception as exc:
+                    # Backend/DB errors (e.g. CypherSyntaxError from a malformed
+                    # cypher_query) — feed back so the agent can retry.
+                    self._append_tool_result(
+                        messages,
+                        tc,
+                        json.dumps(
+                            {
+                                "error": type(exc).__name__,
+                                "detail": str(exc),
+                            }
+                        ),
+                        is_error=True,
+                    )
+        return last_text, messages
+
+    # ── run_stream ────────────────────────────────────────────────────────────
+
     async def run_stream(
         self, message: str, session_id: str | None
     ) -> AsyncGenerator[tuple[str | None, Any], None]:
-        """Streaming variant of run(). Yields (token, None) pairs, then (None, provenance).
+        """Streaming variant of run(). Yields (token, None) pairs, then
+        (None, provenance).
 
-        Only direct mode streams token-by-token. Other modes yield the full response
-        as a single token then the provenance payload.
+        - direct: token-by-token from a single LLM call after optional graph_search.
+        - research: runs the tool-use loop non-streamed; once the model
+          produces a turn with no tool_calls, re-runs that final turn
+          streamed so the user sees tokens flow.
+        - analytical / conversational: non-streamed (fall back to run()).
         """
         prov = ProvenanceCollector()
         mode = self._agent.get("reasoning_mode", "direct")
@@ -412,7 +554,7 @@ class AgentExecutor:
             context = ""
             if "graph_search" in self._agent.get("tools", []):
                 nodes = await self._dispatch("graph_search", {"query": message}, prov)
-                context = _format_nodes(nodes)
+                context = _format_tool_result_json(nodes)
 
             user_content = (
                 f"Context:\n{context}\n\nQuestion: {message}" if context else message
@@ -430,16 +572,45 @@ class AgentExecutor:
                 full_response, prov._nodes
             )
             yield None, prov.to_payload()
-        else:
-            # Non-direct modes: collect full response then yield once
-            chat_resp = await self.run(message, session_id)
-            yield chat_resp.response, None
-            yield None, chat_resp.provenance
+            return
+
+        if mode == "research":
+            system = (self._agent.get("system_prompt") or "").strip() or (
+                "You are a helpful research agent."
+            )
+            # Drive the tool-use loop first to gather evidence + decide a
+            # final answer. The model's last (no-tool_calls) turn is what
+            # we want to stream — re-issue it with streaming.
+            _final_text, messages = await self._tool_use_loop(message, prov, system)
+
+            # The loop already accumulated all messages; the last call
+            # produced a no-tool_calls response which we want streamed.
+            # Re-call without tools to get a streaming completion of the
+            # final answer.
+            full_response = ""
+            async for token in self._call_llm_stream(messages, system_prompt=system):
+                full_response += token
+                yield token, None
+
+            prov.nodes_used_in_response = _extract_cited_nodes(
+                full_response, prov._nodes
+            )
+            yield None, prov.to_payload()
+            return
+
+        # analytical / conversational / unknown — non-streamed fallback
+        chat_resp = await self.run(message, session_id)
+        yield chat_resp.response, None
+        yield None, chat_resp.provenance
 
     # ── Tool dispatch ─────────────────────────────────────────────────────────
 
     async def _dispatch(
-        self, name: str, args: dict, prov: ProvenanceCollector
+        self,
+        name: str,
+        args: dict,
+        prov: ProvenanceCollector,
+        tool_call_id: str | None = None,
     ) -> list[NodeResult]:
         graph_id = self._agent["graph_id"]
         method = getattr(self._toolkit, name, None)
@@ -455,7 +626,7 @@ class AgentExecutor:
         else:
             nodes = result
 
-        prov.record_tool(name, nodes)
+        prov.record_tool(name, nodes, tool_call_id=tool_call_id)
         return nodes
 
     # ── Reasoning modes ───────────────────────────────────────────────────────
@@ -464,95 +635,36 @@ class AgentExecutor:
         context = ""
         if "graph_search" in self._agent.get("tools", []):
             nodes = await self._dispatch("graph_search", {"query": message}, prov)
-            context = _format_nodes(nodes)
+            context = _format_tool_result_json(nodes)
 
         user_content = (
             f"Context:\n{context}\n\nQuestion: {message}" if context else message
         )
-        return await self._call_llm([{"role": "user", "content": user_content}])
+        resp = await self._call_llm([{"role": "user", "content": user_content}])
+        return resp.text
 
     async def _research(self, message: str, prov: ProvenanceCollector) -> str:
-        tools_list = ", ".join(self._agent.get("tools", []))
-        react_block = _REACT_SYSTEM.format(tools=tools_list)
-        # Prepend the agent's own system_prompt (grounding rules, refusal phrase,
-        # citation requirement, etc.) so research-mode answers still follow the
-        # configured persona instead of pure ReAct defaults.
-        configured = (self._agent.get("system_prompt") or "").strip()
-        system = f"{configured}\n\n{react_block}" if configured else react_block
-        messages: list[dict] = [{"role": "user", "content": message}]
-
-        for _ in range(5):
-            raw = await self._call_llm(messages, system_prompt=system)
-            messages.append({"role": "assistant", "content": raw})
-
-            decision = _parse_react_decision(raw)
-            if decision is None:
-                # Unparseable response — treat as final answer
-                return raw
-
-            action = decision.get("action", "answer")
-            if action == "answer":
-                return decision.get("text", raw)
-
-            # Tool call
-            args = decision.get("args", {})
-            try:
-                nodes = await self._dispatch(action, args, prov)
-            except (ToolNotPermittedError, TypeError, ValueError) as exc:
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": f"Tool error: {exc}. Try a different tool or fix the args.",
-                    }
-                )
-                continue
-            except Exception as exc:
-                # Backend/DB errors (e.g. CypherSyntaxError from a malformed
-                # cypher_query) — feed back to the agent so it can retry with
-                # corrected args rather than crashing the whole request.
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": (
-                            f"Tool '{action}' raised an error: {type(exc).__name__}: {exc}. "
-                            f"Fix the arguments and try again."
-                        ),
-                    }
-                )
-                continue
-
-            tool_result = _format_nodes(nodes)
-            messages.append(
-                {"role": "user", "content": f"Tool '{action}' result:\n{tool_result}"}
-            )
-
-        # Iteration cap reached — generate final answer with accumulated context
-        messages.append(
-            {
-                "role": "user",
-                "content": "Please provide your final answer based on the information gathered so far.",
-            }
+        """Native tool-use loop. The model decides which tools to call
+        and when to stop, using each tool result as input to its next
+        decision."""
+        system = (self._agent.get("system_prompt") or "").strip() or (
+            "You are a helpful research agent."
         )
-        return await self._call_llm(messages, system_prompt=system)
+        final_text, _messages = await self._tool_use_loop(message, prov, system)
+        return final_text or "(no final answer produced)"
 
     async def _analytical(self, message: str, prov: ProvenanceCollector) -> str:
-        context = ""
-        if "graph_search" in self._agent.get("tools", []):
-            nodes = await self._dispatch("graph_search", {"query": message}, prov)
-            context = _format_nodes(nodes)
+        """Tool-use loop with a structured-reasoning system-prompt suffix.
 
-        user_content = (
-            (
-                f"Context:\n{context}\n\nQuestion: {message}\n\n"
-                "Think step by step before giving your final answer.\n\n"
-                "Reasoning:\n"
-            )
-            if context
-            else (
-                f"{message}\n\nThink step by step before giving your final answer.\n\nReasoning:\n"
-            )
+        Same mechanics as research; the suffix nudges the model to lay
+        out its analysis explicitly in the final answer.
+        """
+        configured = (self._agent.get("system_prompt") or "").strip() or (
+            "You are a careful analytical assistant."
         )
-        return await self._call_llm([{"role": "user", "content": user_content}])
+        system = configured + _ANALYTICAL_SUFFIX
+        final_text, _messages = await self._tool_use_loop(message, prov, system)
+        return final_text or "(no final answer produced)"
 
     async def _conversational(
         self, message: str, session_id: str | None, prov: ProvenanceCollector
@@ -565,7 +677,7 @@ class AgentExecutor:
         context = ""
         if "graph_search" in self._agent.get("tools", []):
             nodes = await self._dispatch("graph_search", {"query": message}, prov)
-            context = _format_nodes(nodes)
+            context = _format_tool_result_json(nodes)
 
         user_content = (
             f"Context:\n{context}\n\nQuestion: {message}" if context else message
@@ -574,11 +686,11 @@ class AgentExecutor:
         sp = self._agent.get("system_prompt", "You are a helpful assistant.")
         system = sp + _CONVERSATIONAL_SUFFIX
         messages = history + [{"role": "user", "content": user_content}]
-        response = await self._call_llm(messages, system_prompt=system)
+        resp = await self._call_llm(messages, system_prompt=system)
 
         _sessions[session_id] = history + [
             {"role": "user", "content": message},
-            {"role": "assistant", "content": response},
+            {"role": "assistant", "content": resp.text},
         ]
 
-        return response, session_id
+        return resp.text, session_id

--- a/knowledge-graph-builder/app/services/agent_tool_schemas.py
+++ b/knowledge-graph-builder/app/services/agent_tool_schemas.py
@@ -1,0 +1,328 @@
+"""JSON Schemas for ``AgentToolkit`` tools, formatted per-provider.
+
+These schemas drive the LLM's native tool-use protocol. Hand-written
+rather than introspected from method signatures: hand-writing lets us
+craft descriptions optimized for LLM tool-selection accuracy without
+leaking implementation details (e.g. ``graph_id`` is injected by the
+executor, never asked of the LLM).
+
+Two output formats:
+
+- ``openai`` — used by OpenRouter and Azure OpenAI clients (any
+  ``AsyncOpenAI`` instance). Shape:
+  ``{"type": "function", "function": {"name", "description", "parameters"}}``
+
+- ``anthropic`` — used by the native ``AsyncAnthropic`` SDK. Shape:
+  ``{"name", "description", "input_schema"}``
+
+The parameter schemas are identical between formats; only the wrapper
+differs. Adding a new tool: append one ``_ToolSchema`` entry below.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+ProviderFormat = Literal["openai", "anthropic"]
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolSchema:
+    """Canonical schema for one tool, format-agnostic."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any]
+
+
+# JSON Schema fragment reused for ``max_results`` style integer caps.
+def _int_param(
+    description: str,
+    *,
+    default: int,
+    minimum: int = 1,
+    maximum: int | None = None,
+) -> dict[str, Any]:
+    spec: dict[str, Any] = {
+        "type": "integer",
+        "description": description,
+        "default": default,
+        "minimum": minimum,
+    }
+    if maximum is not None:
+        spec["maximum"] = maximum
+    return spec
+
+
+# ── Tool schemas ─────────────────────────────────────────────────────────────
+#
+# ``graph_id`` is intentionally NOT a parameter on any tool. The executor
+# binds it from the agent's configured ``graph_id`` before dispatch, so
+# the LLM cannot accidentally read another tenant's data even if it
+# hallucinated a different value.
+
+_TOOL_SCHEMAS: dict[str, _ToolSchema] = {
+    "graph_search": _ToolSchema(
+        name="graph_search",
+        description=(
+            "Semantic similarity search over the knowledge graph's text "
+            "embeddings. Returns the most relevant chunks/entities for a "
+            "natural-language query. Use this when you need grounding "
+            "context but don't know specific entity ids."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural-language query to embed and match.",
+                },
+                "max_results": _int_param(
+                    "How many top-scoring nodes to return.",
+                    default=10,
+                    minimum=1,
+                    maximum=50,
+                ),
+            },
+            "required": ["query"],
+        },
+    ),
+    "community_members": _ToolSchema(
+        name="community_members",
+        description=(
+            "Return the member nodes of a community, given a community_id. "
+            "Works across every registered community kind (entity-Leiden "
+            "and chunk-Louvain). Use this after find_communities or after "
+            "spotting a community_id in another tool's output."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "community_id": {
+                    "type": "string",
+                    "description": "Stable id of the community to expand.",
+                },
+                "max_results": _int_param(
+                    "How many members to return.",
+                    default=50,
+                    minimum=1,
+                    maximum=200,
+                ),
+            },
+            "required": ["community_id"],
+        },
+    ),
+    "neighbors": _ToolSchema(
+        name="neighbors",
+        description=(
+            "Breadth-first traversal from a known node, optionally "
+            "filtered by relationship type. Use this for 'what's "
+            "connected to X' and multi-hop reasoning (depth 2-3)."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "string",
+                    "description": "Source node id to traverse from.",
+                },
+                "edge_type": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Optional relationship type to filter on (e.g. "
+                        "USES, OWNS). Omit to traverse all edges."
+                    ),
+                },
+                "depth": _int_param(
+                    "Hops from the source. Capped at 20 server-side.",
+                    default=1,
+                    minimum=1,
+                    maximum=20,
+                ),
+            },
+            "required": ["node_id"],
+        },
+    ),
+    "degree_centrality": _ToolSchema(
+        name="degree_centrality",
+        description=(
+            "Return the most-connected nodes of a given Neo4j label. "
+            "Use this to find hub nodes / influential entities."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "node_label": {
+                    "type": "string",
+                    "description": (
+                        "Neo4j label to rank (alphanumeric + underscore "
+                        "only). Examples: Company, Person, __Entity__."
+                    ),
+                },
+                "top_n": _int_param(
+                    "How many top-ranked nodes to return.",
+                    default=10,
+                    minimum=1,
+                    maximum=100,
+                ),
+            },
+            "required": ["node_label"],
+        },
+    ),
+    "shortest_path": _ToolSchema(
+        name="shortest_path",
+        description=(
+            "Find the shortest path between two known nodes by "
+            "qualified_name. Use this to explain how two concepts are "
+            "related in the graph."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "from_qname": {
+                    "type": "string",
+                    "description": "qualified_name of the source node.",
+                },
+                "to_qname": {
+                    "type": "string",
+                    "description": "qualified_name of the target node.",
+                },
+            },
+            "required": ["from_qname", "to_qname"],
+        },
+    ),
+    "taint_trace": _ToolSchema(
+        name="taint_trace",
+        description=(
+            "Follow FLOWS_TO edges from a source (code knowledge graphs "
+            "only). Use this for security/data-flow questions: 'where "
+            "does input X end up'."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "source_qname": {
+                    "type": "string",
+                    "description": "qualified_name of the taint source.",
+                },
+                "depth": _int_param(
+                    "Maximum hops to follow. Capped at 20.",
+                    default=10,
+                    minimum=1,
+                    maximum=20,
+                ),
+            },
+            "required": ["source_qname"],
+        },
+    ),
+    "cypher_query": _ToolSchema(
+        name="cypher_query",
+        description=(
+            "Execute a read-only Cypher query against the graph. Use "
+            "this for counts, aggregations, and structured lookups that "
+            "graph_search can't answer.\n\n"
+            "Hard requirements:\n"
+            "- READ-ONLY: no CREATE / MERGE / DELETE / SET / REMOVE / "
+            "DROP / DETACH DELETE.\n"
+            "- MUST filter by graph_id for tenant isolation. Use the "
+            "parameter $graph_id, e.g. "
+            "'MATCH (n:__Entity__) WHERE n.graph_id = $graph_id RETURN "
+            "count(n) AS total'.\n"
+            "- LIMIT clause auto-injected if absent."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "cypher": {
+                    "type": "string",
+                    "description": (
+                        "Read-only Cypher query. Must reference "
+                        "$graph_id for tenant isolation."
+                    ),
+                },
+                "max_results": _int_param(
+                    "Cap on returned rows. Server enforces ≤ 100.",
+                    default=25,
+                    minimum=1,
+                    maximum=100,
+                ),
+            },
+            "required": ["cypher"],
+        },
+    ),
+    "temporal_slice": _ToolSchema(
+        name="temporal_slice",
+        description=(
+            "Return nodes that were valid at a given point in time "
+            "(bitemporal valid_from / valid_to). Use this for "
+            "'what did the graph look like on date X' questions."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "node_label": {
+                    "type": "string",
+                    "description": (
+                        "Neo4j label to slice (alphanumeric + underscore)."
+                    ),
+                },
+                "at_time": {
+                    "type": "integer",
+                    "description": (
+                        "Unix epoch timestamp (seconds) of the point in time."
+                    ),
+                },
+                "max_results": _int_param(
+                    "Cap on returned nodes.",
+                    default=50,
+                    minimum=1,
+                    maximum=200,
+                ),
+            },
+            "required": ["node_label", "at_time"],
+        },
+    ),
+}
+
+
+def _to_openai(spec: _ToolSchema) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": spec.name,
+            "description": spec.description,
+            "parameters": spec.parameters,
+        },
+    }
+
+
+def _to_anthropic(spec: _ToolSchema) -> dict[str, Any]:
+    return {
+        "name": spec.name,
+        "description": spec.description,
+        "input_schema": spec.parameters,
+    }
+
+
+def tool_schemas_for(
+    allowed_tools: list[str] | set[str], provider_format: ProviderFormat
+) -> list[dict[str, Any]]:
+    """Return the per-provider tool schemas for the agent's allowlist.
+
+    Unknown / unregistered tools in ``allowed_tools`` are silently
+    dropped — the toolkit's ``ToolNotPermittedError`` still guards
+    dispatch, so an unknown tool can't be called anyway. We don't fail
+    here because the agent may legitimately have an allowlist that
+    includes tools we haven't built JSON schemas for yet.
+    """
+    allowed = set(allowed_tools)
+    selected = [s for name, s in _TOOL_SCHEMAS.items() if name in allowed]
+    convert = _to_openai if provider_format == "openai" else _to_anthropic
+    return [convert(s) for s in selected]
+
+
+def registered_tool_names() -> list[str]:
+    """Names of every tool with a JSON schema. Used by tests to assert
+    every AgentToolkit method has a matching schema."""
+    return list(_TOOL_SCHEMAS.keys())

--- a/knowledge-graph-builder/app/services/provenance.py
+++ b/knowledge-graph-builder/app/services/provenance.py
@@ -1,8 +1,10 @@
-"""Provenance tracking for agent execution (TASK-034 / STORY-020).
+"""Provenance tracking for agent execution (TASK-034 / STORY-020, STORY-5).
 
 ProvenanceCollector is passed through all reasoning mode methods and records
 every tool call, node returned, and query executed during a single agent run.
 """
+
+from uuid import uuid4
 
 from app.schemas.agent_schemas import NodeResult, ProvenancePayload
 
@@ -14,10 +16,26 @@ class ProvenanceCollector:
         self._nodes: list[dict] = []
         self._queries: list[str] = []
         self._tools: list[str] = []
+        # One entry per dispatched tool call. Each is {"id", "name", "node_count"}.
+        # ``id`` mirrors the LLM-provided tool_call_id when the native tool-use
+        # protocol is in use; falls back to a synthetic id otherwise.
+        self._tool_calls: list[dict] = []
         self.nodes_used_in_response: list[str] = []
 
-    def record_tool(self, tool_name: str, nodes: list[NodeResult]) -> None:
+    def record_tool(
+        self,
+        tool_name: str,
+        nodes: list[NodeResult],
+        tool_call_id: str | None = None,
+    ) -> None:
         self._tools.append(tool_name)
+        self._tool_calls.append(
+            {
+                "id": tool_call_id or f"synthetic_{uuid4().hex[:12]}",
+                "name": tool_name,
+                "node_count": len(nodes),
+            }
+        )
         for n in nodes:
             self._nodes.append({"id": n.id, "label": n.label})
 
@@ -33,4 +51,5 @@ class ProvenanceCollector:
             total_nodes_traversed=len(self._nodes),
             reasoning_steps=len(self._tools),
             tools_called=list(self._tools),
+            tool_calls=list(self._tool_calls),
         )

--- a/knowledge-graph-builder/tests/unit/test_agent_executor.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_executor.py
@@ -52,13 +52,51 @@ def _make_toolkit(graph_search_returns=None) -> AgentToolkit:
 
 
 def _make_llm(responses: list[str]) -> MagicMock:
-    """Build a mock AsyncOpenAI client returning responses in order."""
+    """Build a mock AsyncOpenAI client returning responses in order.
+
+    Each ``responses`` entry is a plain string with no tool_calls.
+    For tool-use scenarios use ``_make_llm_with_tool_calls`` instead.
+    """
     client = MagicMock()
     completions = []
     for text in responses:
         mock_resp = MagicMock()
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = text
+        mock_resp.choices[0].message.tool_calls = None
+        completions.append(mock_resp)
+    client.chat.completions.create = AsyncMock(side_effect=completions)
+    return client
+
+
+def _tool_call(call_id: str, name: str, args: dict) -> MagicMock:
+    """Build a mock OpenAI-shape tool_call object."""
+    tc = MagicMock()
+    tc.id = call_id
+    tc.function = MagicMock()
+    tc.function.name = name
+    tc.function.arguments = json.dumps(args)
+    return tc
+
+
+def _make_llm_with_tool_calls(turns: list[dict]) -> MagicMock:
+    """Build a mock AsyncOpenAI client where each turn either invokes
+    tools or returns final text.
+
+    Each ``turn`` is one of:
+      - {"text": "...final answer..."}
+      - {"tool_calls": [(call_id, name, args), ...], "text": ""}
+    """
+    client = MagicMock()
+    completions = []
+    for turn in turns:
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = turn.get("text", "") or ""
+        raw_tcs = turn.get("tool_calls") or []
+        mock_resp.choices[0].message.tool_calls = (
+            [_tool_call(*t) for t in raw_tcs] if raw_tcs else None
+        )
         completions.append(mock_resp)
     client.chat.completions.create = AsyncMock(side_effect=completions)
     return client
@@ -170,126 +208,149 @@ class TestDirectMode:
         assert "node-xyz" in result.provenance.nodes_used_in_response
 
 
-# ── Research mode (ReAct) ─────────────────────────────────────────────────────
+# ── Research mode (native tool-use loop, STORY-5) ─────────────────────────────
 
 
 class TestResearchMode:
-    def _react_responses(
-        self, tool_calls: list[tuple[str, dict]], answer: str
-    ) -> list[str]:
-        """Build JSON response sequence for the ReAct loop."""
-        resp = []
-        for name, args in tool_calls:
-            resp.append(json.dumps({"action": name, "args": args}))
-        resp.append(json.dumps({"action": "answer", "text": answer}))
-        return resp
-
     async def test_executes_at_least_two_tool_calls(self):
         tk = _make_toolkit()
-        responses = self._react_responses(
+        llm = _make_llm_with_tool_calls(
             [
-                ("graph_search", {"query": "step1"}),
-                ("graph_search", {"query": "step2"}),
-            ],
-            "Final answer",
+                {"tool_calls": [("c1", "graph_search", {"query": "step1"})]},
+                {"tool_calls": [("c2", "graph_search", {"query": "step2"})]},
+                {"text": "Final answer"},
+            ]
         )
         agent = _make_agent(mode="research", tools=["graph_search"])
-        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
         await ex.run("What is Y?", session_id=None)
         assert tk.graph_search.call_count >= 2
 
-    async def test_returns_answer_from_json(self):
+    async def test_returns_final_text_when_no_tool_calls(self):
         tk = _make_toolkit()
-        responses = self._react_responses(
-            [("graph_search", {"query": "info"})],
-            "The definitive answer.",
+        llm = _make_llm_with_tool_calls(
+            [
+                {"tool_calls": [("c1", "graph_search", {"query": "info"})]},
+                {"text": "The definitive answer."},
+            ]
         )
         agent = _make_agent(mode="research", tools=["graph_search"])
-        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
         result = await ex.run("question", session_id=None)
         assert result.response == "The definitive answer."
 
     async def test_caps_at_five_iterations(self):
         tk = _make_toolkit()
-        # Always call a tool — never answer. Should cap at 5 and generate final answer.
-        looping = [json.dumps({"action": "graph_search", "args": {"query": "x"}})] * 6
-        looping.append("Final fallback answer")  # used when cap is reached
+        # Always emit a tool call — never a no-tool-call turn. Should cap at 5.
+        looping = [
+            {"tool_calls": [(f"c{i}", "graph_search", {"query": "x"})]}
+            for i in range(10)
+        ]
         agent = _make_agent(mode="research", tools=["graph_search"])
-        ex = _executor(agent=agent, toolkit=tk, responses=looping)
-        result = await ex.run("q", session_id=None)
-        # At most 5 tool calls from ReAct + 1 final LLM call
+        ex = _executor(agent=agent, toolkit=tk, llm=_make_llm_with_tool_calls(looping))
+        await ex.run("q", session_id=None)
+        # _MAX_TOOL_ITERATIONS is 5
         assert tk.graph_search.call_count <= 5
-        assert result.response  # non-empty
 
     async def test_provenance_records_all_tool_calls(self):
         tk = _make_toolkit()
-        responses = self._react_responses(
-            [("graph_search", {"query": "a"}), ("graph_search", {"query": "b"})],
-            "Done",
+        llm = _make_llm_with_tool_calls(
+            [
+                {"tool_calls": [("c1", "graph_search", {"query": "a"})]},
+                {"tool_calls": [("c2", "graph_search", {"query": "b"})]},
+                {"text": "Done"},
+            ]
         )
         agent = _make_agent(mode="research", tools=["graph_search"])
-        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
         result = await ex.run("q", session_id=None)
         assert result.provenance.tools_called.count("graph_search") == 2
 
-    async def test_unparseable_llm_response_treated_as_answer(self):
+    async def test_provenance_records_tool_call_id(self):
+        """Each tool_call entry should carry the LLM-provided id."""
         tk = _make_toolkit()
+        llm = _make_llm_with_tool_calls(
+            [
+                {"tool_calls": [("call_abc", "graph_search", {"query": "x"})]},
+                {"text": "Done"},
+            ]
+        )
         agent = _make_agent(mode="research", tools=["graph_search"])
-        ex = _executor(agent=agent, toolkit=tk, responses=["not json at all"])
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
         result = await ex.run("q", session_id=None)
-        assert result.response == "not json at all"
+        ids = [tc["id"] for tc in result.provenance.tool_calls]
+        assert "call_abc" in ids
 
     async def test_tool_error_continues_loop(self):
+        """Tool exception is fed back as a tool-result error; loop continues."""
         tk = _make_toolkit()
         tk.graph_search = AsyncMock(side_effect=ToolNotPermittedError("graph_search"))
-        responses = [
-            json.dumps({"action": "graph_search", "args": {"query": "x"}}),
-            json.dumps({"action": "answer", "text": "Recovered answer"}),
-        ]
+        llm = _make_llm_with_tool_calls(
+            [
+                {"tool_calls": [("c1", "graph_search", {"query": "x"})]},
+                {"text": "Recovered answer"},
+            ]
+        )
         agent = _make_agent(mode="research", tools=[])
-        ex = _executor(agent=agent, toolkit=tk, responses=responses)
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
         result = await ex.run("q", session_id=None)
         assert result.response == "Recovered answer"
 
+    async def test_no_tool_calls_returns_text_immediately(self):
+        """First-turn text answer (no tool_calls) returns directly."""
+        tk = _make_toolkit()
+        llm = _make_llm_with_tool_calls([{"text": "Immediate answer"}])
+        agent = _make_agent(mode="research", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
+        result = await ex.run("q", session_id=None)
+        assert result.response == "Immediate answer"
 
-# ── Analytical mode ───────────────────────────────────────────────────────────
+
+# ── Analytical mode (now a tool-use loop too, STORY-5) ────────────────────────
 
 
 class TestAnalyticalMode:
     async def test_returns_response(self):
         agent = _make_agent(mode="analytical")
         ex = _executor(
-            agent=agent, responses=["Reasoning:\nStep 1...\n\nFinal Answer: X"]
+            agent=agent, responses=["Step 1: examined. Step 2: weighed. Conclusion: X"]
         )
         result = await ex.run("Analyse this.", session_id=None)
-        assert "Reasoning" in result.response or result.response
+        assert result.response
 
-    async def test_prompt_contains_step_by_step_instruction(self):
+    async def test_prompt_contains_structured_reasoning_instruction(self):
+        """System prompt should nudge structured reasoning."""
         tk = _make_toolkit()
-        llm = _make_llm(["analysis result"])
+        llm = _make_llm(["Step 1: ... Conclusion: y"])
         agent = _make_agent(mode="analytical")
         ex = _executor(agent=agent, toolkit=tk, llm=llm)
         await ex.run("q", session_id=None)
-        call_kwargs = llm.chat.completions.create.call_args
-        messages = (
-            call_kwargs[1]["messages"]
-            if "messages" in call_kwargs[1]
-            else call_kwargs[0][0]
-        )
-        full_text = " ".join(m["content"] for m in messages)
-        assert "step by step" in full_text.lower()
+        # System message is the first message in OpenAI-shape calls
+        system_msg = llm.chat.completions.create.call_args[1]["messages"][0]["content"]
+        assert "step by step" in system_msg.lower()
 
-    async def test_calls_graph_search_when_available(self):
+    async def test_does_not_force_graph_search(self):
+        """Unlike pre-STORY-5 analytical, the loop only invokes tools the
+        model chooses. With no tool_calls in the response, graph_search
+        is NOT called automatically."""
         tk = _make_toolkit()
         agent = _make_agent(mode="analytical", tools=["graph_search"])
-        ex = _executor(agent=agent, toolkit=tk, responses=["result"])
+        ex = _executor(agent=agent, toolkit=tk, responses=["analysis result"])
         await ex.run("q", session_id=None)
-        tk.graph_search.assert_called_once()
+        tk.graph_search.assert_not_called()
 
-    async def test_provenance_has_graph_search(self):
-        agent = _make_agent(mode="analytical")
-        ex = _executor(agent=agent, responses=["ok"])
+    async def test_dispatches_tool_when_model_calls_it(self):
+        tk = _make_toolkit()
+        llm = _make_llm_with_tool_calls(
+            [
+                {"tool_calls": [("c1", "graph_search", {"query": "x"})]},
+                {"text": "Analysis complete"},
+            ]
+        )
+        agent = _make_agent(mode="analytical", tools=["graph_search"])
+        ex = _executor(agent=agent, toolkit=tk, llm=llm)
         result = await ex.run("q", session_id=None)
+        assert tk.graph_search.call_count == 1
         assert "graph_search" in result.provenance.tools_called
 
 

--- a/knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_executor_llm_resolution.py
@@ -171,10 +171,13 @@ class TestCallLlmDispatch:
         llm = MagicMock(spec=AsyncOpenAI)
         resp = MagicMock()
         resp.choices[0].message.content = "hello"
+        resp.choices[0].message.tool_calls = None
         llm.chat.completions.create = AsyncMock(return_value=resp)
         ex = self._executor(llm)
         result = await ex._call_llm([{"role": "user", "content": "hi"}])
-        assert result == "hello"
+        # _call_llm now returns _LLMResponse(text, tool_calls)
+        assert result.text == "hello"
+        assert result.tool_calls == []
         llm.chat.completions.create.assert_called_once()
 
     async def test_anthropic_uses_messages_create(self):
@@ -184,13 +187,16 @@ class TestCallLlmDispatch:
             pytest.skip("anthropic SDK not installed")
 
         llm = MagicMock(spec=AsyncAnthropic)
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "anthropic response"
         resp = MagicMock()
-        resp.content = [MagicMock()]
-        resp.content[0].text = "anthropic response"
+        resp.content = [text_block]
         llm.messages.create = AsyncMock(return_value=resp)
         ex = self._executor(llm)
         result = await ex._call_llm([{"role": "user", "content": "hi"}])
-        assert result == "anthropic response"
+        assert result.text == "anthropic response"
+        assert result.tool_calls == []
         llm.messages.create.assert_called_once()
         call_kwargs = llm.messages.create.call_args[1]
         assert "system" in call_kwargs

--- a/knowledge-graph-builder/tests/unit/test_agent_tool_schemas.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_tool_schemas.py
@@ -1,0 +1,138 @@
+"""Unit tests for app/services/agent_tool_schemas.py (STORY-5).
+
+These pin the tool-use contract: every AgentToolkit method that the
+executor can dispatch has a matching JSON schema, schemas convert to
+both provider formats without losing parameters, and graph_id is never
+exposed to the LLM.
+"""
+
+import inspect
+
+import pytest
+
+from app.services.agent_tool_schemas import (
+    _TOOL_SCHEMAS,
+    registered_tool_names,
+    tool_schemas_for,
+)
+from app.services.agent_tools import AgentToolkit
+
+
+class TestRegistrationCoverage:
+    @pytest.mark.unit
+    def test_every_agent_toolkit_method_has_a_schema(self):
+        """If an AgentToolkit public async method is dispatchable by the
+        executor, it must have a JSON schema. New tools without schemas
+        would silently be invisible to the LLM."""
+        dispatchable = {
+            name
+            for name, member in inspect.getmembers(
+                AgentToolkit, predicate=inspect.iscoroutinefunction
+            )
+            if not name.startswith("_")
+        }
+        registered = set(registered_tool_names())
+        missing = dispatchable - registered
+        assert not missing, (
+            f"AgentToolkit methods without JSON schemas: {sorted(missing)}"
+        )
+
+    @pytest.mark.unit
+    def test_no_orphan_schemas(self):
+        """A registered schema must point at a real AgentToolkit method."""
+        toolkit_methods = {
+            name
+            for name, member in inspect.getmembers(
+                AgentToolkit, predicate=inspect.iscoroutinefunction
+            )
+        }
+        for name in registered_tool_names():
+            assert name in toolkit_methods, (
+                f"Schema {name!r} doesn't match any AgentToolkit method"
+            )
+
+
+class TestGraphIdNeverInSchema:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("name", registered_tool_names())
+    def test_graph_id_is_not_a_parameter(self, name):
+        """``graph_id`` is bound by the executor before dispatch — the LLM
+        must never see it as a parameter, even hallucinating one shouldn't
+        be possible. Pin this hard."""
+        spec = _TOOL_SCHEMAS[name]
+        params = spec.parameters
+        assert "graph_id" not in params.get("properties", {}), (
+            f"Tool {name!r} exposes graph_id to the LLM — tenant-isolation risk"
+        )
+        assert "graph_id" not in params.get("required", []), (
+            f"Tool {name!r} requires graph_id from the LLM — tenant-isolation risk"
+        )
+
+
+class TestProviderFormats:
+    @pytest.mark.unit
+    def test_openai_format_shape(self):
+        out = tool_schemas_for(["graph_search"], "openai")
+        assert len(out) == 1
+        s = out[0]
+        assert s["type"] == "function"
+        assert s["function"]["name"] == "graph_search"
+        assert "parameters" in s["function"]
+        assert "description" in s["function"]
+
+    @pytest.mark.unit
+    def test_anthropic_format_shape(self):
+        out = tool_schemas_for(["graph_search"], "anthropic")
+        assert len(out) == 1
+        s = out[0]
+        assert s["name"] == "graph_search"
+        assert "input_schema" in s
+        assert "description" in s
+        # Anthropic format does NOT wrap in "function"
+        assert "function" not in s
+        assert "type" not in s or s.get("type") != "function"
+
+    @pytest.mark.unit
+    def test_filtering_by_allowlist(self):
+        """Only the tools in the allowlist are returned."""
+        out_names = [
+            s["function"]["name"]
+            for s in tool_schemas_for(["graph_search", "neighbors"], "openai")
+        ]
+        assert set(out_names) == {"graph_search", "neighbors"}
+
+    @pytest.mark.unit
+    def test_unknown_tool_silently_dropped(self):
+        """Unknown tools in the allowlist don't crash schema construction —
+        ToolNotPermittedError at dispatch time covers them."""
+        out = tool_schemas_for(["graph_search", "nonexistent_tool"], "openai")
+        names = [s["function"]["name"] for s in out]
+        assert "graph_search" in names
+        assert "nonexistent_tool" not in names
+
+    @pytest.mark.unit
+    def test_empty_allowlist_returns_empty(self):
+        assert tool_schemas_for([], "openai") == []
+        assert tool_schemas_for([], "anthropic") == []
+
+
+class TestParameterShapes:
+    @pytest.mark.unit
+    def test_cypher_query_requires_cypher(self):
+        spec = _TOOL_SCHEMAS["cypher_query"]
+        assert "cypher" in spec.parameters["required"]
+        # Must describe the read-only + graph_id constraints so the LLM
+        # writes correct Cypher on its first try
+        assert "graph_id" in spec.description.lower()
+        assert "read-only" in spec.description.lower()
+
+    @pytest.mark.unit
+    def test_max_results_caps_match_server_side(self):
+        """JSON Schema max should mirror the server-side cap so the model
+        doesn't burn turns asking for more than will be returned."""
+        # cypher_query is capped at 100 in agent_tools.py
+        cypher_params = _TOOL_SCHEMAS["cypher_query"].parameters["properties"]
+        assert cypher_params["max_results"]["maximum"] == 100
+        # graph_search is unbounded server-side; schema caps at 50 conservatively
+        gs_params = _TOOL_SCHEMAS["graph_search"].parameters["properties"]
+        assert gs_params["max_results"]["maximum"] == 50


### PR DESCRIPTION
## Summary

Replaces the band-aid ReAct text-parser in agent_executor with Claude's (and OpenAI's) **native tool-use protocol**. Research and analytical reasoning modes now dispatch tools structurally via the SDK rather than asking the LLM to emit JSON and regex-parsing the raw text.

**The bug being fixed:** Every research-mode agent in production was hallucinating tool results. Claude received the `_REACT_SYSTEM` prompt asking for JSON, but its tool-use training kicked in — it emitted `<function_calls>` XML wrappers and then continued with an imagined result in the same response. The band-aid parsers tried to recover but couldn't actually call the tool. Result: agents fabricated answers and never invoked `cypher_query`, `community_members`, or any other tool.

## Live verification (OpenRouter + `anthropic/claude-haiku-4-5` + Eurail graph)

| Test | Result |
|---|---|
| Research mode: "How many `__Entity__` nodes are in this graph?" | Claude called `cypher_query`, returned exact correct count **2,889**. tool_call_id `toolu_bdrk_01N3...` preserved end-to-end through provenance. |
| Research mode: "What is Eurail?" | Claude called `graph_search`, produced grounded answer about Eurail B.V. |
| Analytical mode: graph structure question | Claude called `cypher_query` 9 times across 5 iterations (was 0 tool calls pre-STORY-5 — analytical was text-only). |

## Changes

- **NEW** [agent_tool_schemas.py](knowledge-graph-builder/app/services/agent_tool_schemas.py) — JSON schemas for all 8 AgentToolkit tools, formatted per-provider (Anthropic native and OpenAI/OpenRouter). `graph_id` deliberately excluded from LLM-visible params; the executor binds it before dispatch, so tenant isolation cannot regress through prompt injection.
- **Rewrote** [agent_executor.py](knowledge-graph-builder/app/services/agent_executor.py) — `_LLMResponse` + `_ToolCall` dataclasses, `_call_llm(tools=...)`, `_tool_use_loop`, per-provider message-shape helpers. `_research` and `_analytical` now both use the loop; `_analytical` previously did unconditional graph_search + text-only "think step by step" — now lets the model choose tools.
- **Deleted** ~140 lines of band-aid parsers: `_REACT_SYSTEM`, `_FUNCTION_CALLS_BLOCK`, `_FENCED_JSON`, `_scan_json_object`, `_find_first_json_object`, `_normalize_decision`, `_parse_react_decision`.
- **Streaming** for research mode added — final answer streams after the tool-use loop concludes.
- **Provenance** — `tool_call_id` recorded per dispatch (`ProvenancePayload.tool_calls`), letting the frontend reconstruct the LLM's actual call chain.
- **Tool result format** — switched from markdown to JSON in `role:tool` messages. Embedding props dropped, text/content trimmed to 1500 chars.

## Tests

- 14 new schema-contract tests in [test_agent_tool_schemas.py](knowledge-graph-builder/tests/unit/test_agent_tool_schemas.py) (coverage guard, orphan guard, parametrized tenant-isolation guard over all 8 tools, provider-format shapes, parameter-shape pins).
- Rewrote `TestResearchMode` and `TestAnalyticalMode` in [test_agent_executor.py](knowledge-graph-builder/tests/unit/test_agent_executor.py) for the new protocol — mocks now build OpenAI-shape `tool_calls`, not ReAct JSON text.
- Updated `_call_llm` dispatch tests for the new `_LLMResponse` return type.
- 55/55 pass on the touched test surface; full unit suite: 1353 pass, 10 pre-existing failures unrelated to STORY-5 (test_agents_crud, test_chat_ownership, test_chat_service — same set as before PR #75).

## Test plan

- [ ] Spot-check a research-mode agent in the frontend after merge
- [ ] Re-run the Eurail adversarial QA (50 questions) against a research-mode copy of `eurail-copilot`
- [ ] Watch for any OpenRouter+model quirks (parallel tool calls, thinking blocks) and tune `_MAX_TOOL_ITERATIONS` if needed

## Out of scope (follow-ups)

- Tool-result truncation policy beyond the 1500-char text trim
- Parallel tool-call optimizations (Claude on OpenRouter supports them; loop handles them but doesn't optimize for them)
- Streaming tool calls (currently the loop is non-streamed; only the final answer streams)
- Re-running adversarial QA gate (manual, post-merge)