### PR TITLE
STORY-4c: community summary embeddings + vector indexes

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
@@ -1657,6 +1657,21 @@ async def summarize_communities(
     except UnknownCommunityKindError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None
 
+    # STORY-4c — embed any community that now has a summary but no
+    # embedding yet. Embedding failures don't roll back the summary write;
+    # they're surfaced in failed_embeddings and the caller can retry.
+    try:
+        embed_report = await summarizer.embed_summaries(
+            str(graph_id),
+            request.kind,
+            force_rebuild=request.force_rebuild,
+        )
+        report.embedded = embed_report.embedded
+        report.skipped_existing_embeddings = embed_report.skipped_existing
+        report.failed_embeddings = embed_report.failed
+    except UnknownCommunityKindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
     return CommunitySummarizeResponse(
         kind=report.kind,
         total=report.total,
@@ -1664,6 +1679,9 @@ async def summarize_communities(
         skipped_existing=report.skipped_existing,
         skipped_singleton=report.skipped_singleton,
         failed=report.failed,
+        embedded=report.embedded,
+        skipped_existing_embeddings=report.skipped_existing_embeddings,
+        failed_embeddings=report.failed_embeddings,
     )
 
 

--- a/knowledge-graph-builder/app/main.py
+++ b/knowledge-graph-builder/app/main.py
@@ -74,6 +74,15 @@ async def lifespan(app: FastAPI):
 
         await ensure_memory_indexes()
 
+        # Ensure community summary vector indexes (STORY-4c, idempotent).
+        # One index per registered community kind so find_communities
+        # (STORY-4d) can do vector search over summary embeddings.
+        from app.services.community_summarizer import (
+            ensure_community_vector_indexes,
+        )
+
+        await ensure_community_vector_indexes()
+
         # Initialize Database Connector Neo4j constraints + indexes (ORA-77)
         from app.services.database_connector_service import database_connector_service
 

--- a/knowledge-graph-builder/app/schemas/community_kinds.py
+++ b/knowledge-graph-builder/app/schemas/community_kinds.py
@@ -81,6 +81,19 @@ class CommunityKindSpec:
     # on POST .../detect when this is None.
     detector_task_name: str | None
 
+    # Property on the community node that holds the summary embedding
+    # (STORY-4c). Entity-Leiden uses ``embedding`` (the Celery detector's
+    # convention, predates STORY-4b); chunk uses ``summary_embedding``
+    # (under the ``summary_*`` namespace alongside ``summary_keywords``).
+    # The vector index over this property is named ``{index_name}``.
+    embedding_property: str
+
+    # Name of the Neo4j vector index over the community node, scoped to
+    # the kind. ``ensure_community_vector_indexes`` creates this index on
+    # startup if it doesn't exist. ``find_communities`` agent tool
+    # (STORY-4d) queries it via ``db.index.vector.queryNodes``.
+    index_name: str
+
 
 # Adding a new community kind: append one entry below. No other change
 # required — endpoint code, analytics queries, agent tools, and the
@@ -97,6 +110,8 @@ COMMUNITY_KINDS: dict[str, CommunityKindSpec] = {
         hierarchical=True,
         member_rel_has_level=True,
         detector_task_name="community_tasks.detect_communities_task",
+        embedding_property="embedding",
+        index_name="community_embeddings_entity",
     ),
     "chunk": CommunityKindSpec(
         kind="chunk",
@@ -113,6 +128,8 @@ COMMUNITY_KINDS: dict[str, CommunityKindSpec] = {
         # is tracked as a follow-up story; until then, only the 59 chunk
         # communities already in the Eurail graph are visible.
         detector_task_name=None,
+        embedding_property="summary_embedding",
+        index_name="community_embeddings_chunk",
     ),
     # Future kinds slot in here without touching endpoint or service code:
     #

--- a/knowledge-graph-builder/app/schemas/graph_schemas.py
+++ b/knowledge-graph-builder/app/schemas/graph_schemas.py
@@ -1001,6 +1001,28 @@ class CommunitySummarizeResponse(BaseModel):
             "or zero-content sample)."
         ),
     )
+    # STORY-4c — embedding stats (the endpoint also computes embeddings)
+    embedded: int = Field(
+        default=0,
+        description=(
+            "Communities for which a summary embedding was computed and "
+            "written. STORY-4c."
+        ),
+    )
+    skipped_existing_embeddings: int = Field(
+        default=0,
+        description=(
+            "Communities skipped during embedding because they already had "
+            "an embedding stored and force_rebuild was False."
+        ),
+    )
+    failed_embeddings: int = Field(
+        default=0,
+        description=(
+            "Communities where the embedding call failed (provider error, "
+            "network glitch, etc.). Their summary is still written."
+        ),
+    )
 
 
 # ==================== VERSIONING SCHEMAS ====================

--- a/knowledge-graph-builder/app/services/community_summarizer.py
+++ b/knowledge-graph-builder/app/services/community_summarizer.py
@@ -48,7 +48,11 @@ from openai import AsyncOpenAI
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.neo4j_client import neo4j_client
-from app.schemas.community_kinds import UnknownCommunityKindError, get_kind
+from app.schemas.community_kinds import (
+    COMMUNITY_KINDS,
+    UnknownCommunityKindError,
+    get_kind,
+)
 
 logger = get_logger(__name__)
 
@@ -92,6 +96,10 @@ class SummarizeReport:
     skipped_singleton: int = 0
     failed: int = 0
     per_level: dict[str, int] = field(default_factory=dict)
+    # STORY-4c — when the endpoint embeds summaries in the same call:
+    embedded: int = 0
+    skipped_existing_embeddings: int = 0
+    failed_embeddings: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -102,7 +110,21 @@ class SummarizeReport:
             "skipped_singleton": self.skipped_singleton,
             "failed": self.failed,
             "per_level": self.per_level,
+            "embedded": self.embedded,
+            "skipped_existing_embeddings": self.skipped_existing_embeddings,
+            "failed_embeddings": self.failed_embeddings,
         }
+
+
+@dataclass(slots=True)
+class EmbedReport:
+    """What happened when embed_summaries ran for one graph + kind."""
+
+    kind: str
+    total: int = 0
+    embedded: int = 0
+    skipped_existing: int = 0
+    failed: int = 0
 
 
 class CommunitySummarizer:
@@ -351,6 +373,119 @@ class CommunitySummarizer:
         # fields empty so callers can detect partial output.
         return {"summary": str(raw)[:2000], "keywords": [], "excerpt": ""}
 
+    # ── Embedding (STORY-4c) ─────────────────────────────────────────────────
+
+    async def embed_summaries(
+        self,
+        graph_id: str,
+        kind: str,
+        *,
+        force_rebuild: bool = False,
+    ) -> EmbedReport:
+        """Compute summary embeddings for the given kind.
+
+        Looks up the per-kind ``embedding_property`` from the registry —
+        entity uses ``embedding`` (Celery-detector convention, pre-existing),
+        chunk uses ``summary_embedding`` (under the ``summary_*`` namespace).
+        Skips communities that already have an embedding unless
+        ``force_rebuild`` is True.
+
+        The vector index ``spec.index_name`` should already exist (created
+        on app startup via ``ensure_community_vector_indexes``).
+        """
+        spec = get_kind(kind)
+        emb_prop = spec.embedding_property
+        community_label = spec.community_label
+        id_property = spec.id_property
+
+        # Pull communities that have a summary AND (no embedding OR force).
+        # Property names come from the registry — compile-time constants,
+        # safe for f-string interpolation.
+        condition = f"AND c.`{emb_prop}` IS NULL"
+        if force_rebuild:
+            condition = ""
+        rows = await neo4j_client.execute_query(
+            (
+                f"MATCH (c:`{community_label}` {{graph_id: $graph_id}}) "
+                f"WHERE c.summary IS NOT NULL {condition} "
+                f"RETURN c.`{id_property}` AS community_id, "
+                "c.summary AS summary"
+            ),
+            {"graph_id": graph_id},
+        )
+        report = EmbedReport(kind=kind, total=len(rows))
+
+        # Count communities that already have an embedding so the response
+        # is informative even when there's nothing left to do. Always
+        # compute this when not force_rebuild — it's the diagnostic that
+        # tells the caller "you already ran this".
+        if not force_rebuild:
+            counts = await neo4j_client.execute_query(
+                (
+                    f"MATCH (c:`{community_label}` {{graph_id: $graph_id}}) "
+                    f"WHERE c.summary IS NOT NULL AND "
+                    f"c.`{emb_prop}` IS NOT NULL "
+                    "RETURN count(c) AS cnt"
+                ),
+                {"graph_id": graph_id},
+            )
+            report.skipped_existing = counts[0]["cnt"] if counts else 0
+
+        if not rows:
+            return report
+
+        embedder = self._get_embedder()
+
+        async def _embed_one(community_id: str, summary_text: str) -> bool:
+            async with self._semaphore:
+                try:
+                    # Embedder may be sync or async depending on SDK
+                    raw = embedder.embed_query(summary_text)
+                    embedding = await raw if hasattr(raw, "__await__") else raw
+                except Exception as exc:
+                    logger.warning(
+                        "embedding failed for %s/%s: %s", kind, community_id, exc
+                    )
+                    return False
+                await neo4j_client.execute_query(
+                    (
+                        f"MATCH (c:`{community_label}` "
+                        f"{{`{id_property}`: $community_id, graph_id: $graph_id}}) "
+                        f"SET c.`{emb_prop}` = $embedding, "
+                        "    c.summary_embedded_at = datetime()"
+                    ),
+                    {
+                        "community_id": community_id,
+                        "graph_id": graph_id,
+                        "embedding": embedding,
+                    },
+                )
+                return True
+
+        results = await asyncio.gather(
+            *(_embed_one(r["community_id"], r["summary"]) for r in rows),
+            return_exceptions=True,
+        )
+        report.embedded = sum(1 for x in results if x is True)
+        report.failed = sum(
+            1 for x in results if x is False or isinstance(x, Exception)
+        )
+        return report
+
+    def _get_embedder(self):
+        """Lazy-construct the embedder. neo4j_graphrag.OpenAIEmbeddings
+        is the same path the chat retriever and entity-Leiden detector use,
+        so we match dimensions (3072 for text-embedding-3-large) and
+        provider routing."""
+        if getattr(self, "_embedder", None) is None:
+            from neo4j_graphrag.embeddings import OpenAIEmbeddings
+
+            model = getattr(settings, "EMBEDDING_MODEL", "text-embedding-3-large")
+            self._embedder = OpenAIEmbeddings(
+                api_key=settings.OPENAI_API_KEY, model=model
+            )
+        return self._embedder
+
     # ── LLM call plumbing ─────────────────────────────────────────────────────
 
     async def _call_llm_json(self, prompt: str) -> str:
@@ -375,3 +510,44 @@ class CommunitySummarizer:
                 response_format={"type": "json_object"},
             )
             return (resp.choices[0].message.content or "").strip()
+
+
+# ── Vector index ensure (called on app startup) ─────────────────────────────
+
+
+async def ensure_community_vector_indexes() -> None:
+    """Create the vector index for every registered community kind.
+
+    Idempotent (``CREATE VECTOR INDEX … IF NOT EXISTS``). Called from
+    ``main.py`` lifespan so the index exists by the time the first
+    summarize / embed / find_communities call lands.
+
+    Dimensions match ``text-embedding-3-large`` (3072) — the embedding
+    model used by every other path in the codebase. If a deployment uses
+    a different embedding model, this is the place to thread that in
+    (the registry could carry ``embedding_dim`` too, but a single
+    deployment-wide model is the only configuration we support today).
+    """
+    dim = getattr(settings, "EMBEDDING_DIMENSIONS", 3072)
+    for spec in COMMUNITY_KINDS.values():
+        query = (
+            f"CREATE VECTOR INDEX {spec.index_name} IF NOT EXISTS "
+            f"FOR (c:`{spec.community_label}`) "
+            f"ON (c.`{spec.embedding_property}`) "
+            "OPTIONS {indexConfig: { "
+            f"`vector.dimensions`: {dim}, "
+            "`vector.similarity_function`: 'cosine' "
+            "}}"
+        )
+        try:
+            await neo4j_client.execute_write_query(query)
+            logger.info(
+                "Ensured community vector index %s on :%s(%s)",
+                spec.index_name,
+                spec.community_label,
+                spec.embedding_property,
+            )
+        except Exception as exc:
+            # Index creation failures during startup shouldn't crash the
+            # whole service — log + continue. Subsequent runs retry.
+            logger.warning("Could not create %s vector index: %s", spec.index_name, exc)

--- a/knowledge-graph-builder/tests/unit/test_community_kinds_registry.py
+++ b/knowledge-graph-builder/tests/unit/test_community_kinds_registry.py
@@ -29,6 +29,9 @@ class TestRegistryEntries:
         assert spec.hierarchical is True
         assert spec.member_rel_has_level is True
         assert spec.detector_task_name is not None
+        # STORY-4c — entity uses the existing Celery-detector convention
+        assert spec.embedding_property == "embedding"
+        assert spec.index_name == "community_embeddings_entity"
 
     @pytest.mark.unit
     def test_chunk_kind_is_registered_with_expected_shape(self):
@@ -42,6 +45,18 @@ class TestRegistryEntries:
         assert spec.member_rel_has_level is False
         # Read-only kind today
         assert spec.detector_task_name is None
+        # STORY-4c — chunk uses the summary_* namespace for embeddings
+        assert spec.embedding_property == "summary_embedding"
+        assert spec.index_name == "community_embeddings_chunk"
+
+    @pytest.mark.unit
+    def test_index_names_are_unique_per_kind(self):
+        """Each kind must have a unique vector-index name so the indexes
+        don't collide in Neo4j."""
+        names = [spec.index_name for spec in COMMUNITY_KINDS.values()]
+        assert len(names) == len(set(names)), (
+            f"Index names collide across kinds: {names}"
+        )
 
     @pytest.mark.unit
     def test_registry_keys_match_kind_field(self):

--- a/knowledge-graph-builder/tests/unit/test_community_summarizer.py
+++ b/knowledge-graph-builder/tests/unit/test_community_summarizer.py
@@ -272,5 +272,123 @@ class TestReportShape:
             "skipped_singleton",
             "failed",
             "per_level",
+            # STORY-4c embedding fields
+            "embedded",
+            "skipped_existing_embeddings",
+            "failed_embeddings",
         ):
             assert k in d
+
+
+# ── STORY-4c — embedding tests ────────────────────────────────────────────────
+
+
+class TestEmbedSummaries:
+    @pytest.mark.unit
+    async def test_writes_to_kind_specific_property(self, fake_openai_client):
+        """chunk → cc.summary_embedding; entity → c.embedding. The Cypher
+        SET clause must use the registry's ``embedding_property``, not a
+        hardcoded name."""
+        rows_listing = [
+            {"community_id": "cc_1", "summary": "A summary about X."},
+        ]
+        mock_client = MagicMock()
+        # list → count skipped → write
+        mock_client.execute_query = AsyncMock(
+            side_effect=[rows_listing, [{"cnt": 5}], None]
+        )
+
+        with (
+            patch("app.services.community_summarizer.neo4j_client", mock_client),
+            patch("neo4j_graphrag.embeddings.OpenAIEmbeddings") as MockEmbedder,
+        ):
+            MockEmbedder.return_value.embed_query = MagicMock(return_value=[0.1] * 3072)
+            summ = CommunitySummarizer(openai_client=fake_openai_client)
+            report = await summ.embed_summaries("g1", "chunk")
+
+        assert report.embedded == 1
+        assert report.skipped_existing == 5
+        write_call = mock_client.execute_query.await_args_list[-1]
+        cypher = write_call.args[0]
+        assert "summary_embedding" in cypher
+        params = write_call.args[1]
+        assert params["community_id"] == "cc_1"
+        assert len(params["embedding"]) == 3072
+
+    @pytest.mark.unit
+    async def test_force_rebuild_pulls_all_with_summary(self, fake_openai_client):
+        rows_listing = [
+            {"community_id": "cc_x", "summary": "y"},
+            {"community_id": "cc_z", "summary": "w"},
+        ]
+        mock_client = MagicMock()
+        # No skip-counting call when force=True; one list + two writes
+        mock_client.execute_query = AsyncMock(side_effect=[rows_listing, None, None])
+
+        with (
+            patch("app.services.community_summarizer.neo4j_client", mock_client),
+            patch("neo4j_graphrag.embeddings.OpenAIEmbeddings") as MockEmbedder,
+        ):
+            MockEmbedder.return_value.embed_query = MagicMock(return_value=[0.0] * 3072)
+            summ = CommunitySummarizer(openai_client=fake_openai_client)
+            report = await summ.embed_summaries("g1", "chunk", force_rebuild=True)
+
+        assert report.embedded == 2
+
+    @pytest.mark.unit
+    async def test_embedding_failure_counted_in_failed(self, fake_openai_client):
+        rows_listing = [{"community_id": "cc_y", "summary": "summary text"}]
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(side_effect=[rows_listing, [{"cnt": 0}]])
+        with (
+            patch("app.services.community_summarizer.neo4j_client", mock_client),
+            patch("neo4j_graphrag.embeddings.OpenAIEmbeddings") as MockEmbedder,
+        ):
+            MockEmbedder.return_value.embed_query = MagicMock(
+                side_effect=RuntimeError("boom")
+            )
+            summ = CommunitySummarizer(openai_client=fake_openai_client)
+            report = await summ.embed_summaries("g1", "chunk")
+
+        assert report.failed == 1
+        assert report.embedded == 0
+
+
+class TestEnsureCommunityVectorIndexes:
+    @pytest.mark.unit
+    async def test_creates_one_index_per_registered_kind(self):
+        """For each entry in COMMUNITY_KINDS, exactly one
+        CREATE VECTOR INDEX query runs."""
+        from app.services.community_summarizer import (
+            ensure_community_vector_indexes,
+        )
+
+        mock_client = MagicMock()
+        mock_client.execute_write_query = AsyncMock(return_value=None)
+        with patch("app.services.community_summarizer.neo4j_client", mock_client):
+            await ensure_community_vector_indexes()
+
+        # One call per registered kind (entity + chunk = 2)
+        assert mock_client.execute_write_query.await_count == 2
+        for call in mock_client.execute_write_query.await_args_list:
+            cypher = call.args[0]
+            assert "CREATE VECTOR INDEX" in cypher
+            assert "IF NOT EXISTS" in cypher
+            assert "3072" in cypher
+            assert "cosine" in cypher.lower()
+
+    @pytest.mark.unit
+    async def test_continues_on_individual_index_failure(self):
+        """A single index-creation failure shouldn't crash startup."""
+        from app.services.community_summarizer import (
+            ensure_community_vector_indexes,
+        )
+
+        mock_client = MagicMock()
+        mock_client.execute_write_query = AsyncMock(
+            side_effect=[RuntimeError("first fails"), None]
+        )
+        with patch("app.services.community_summarizer.neo4j_client", mock_client):
+            await ensure_community_vector_indexes()  # should not raise
+
+        assert mock_client.execute_write_query.await_count == 2


### PR DESCRIPTION
## Summary

Closes the loop between STORY-4b (summaries) and STORY-4d (`find_communities` agent tool, coming next): every chunk-community summary now has a 3072-dim embedding stored alongside it, with a Neo4j vector index per kind for fast top-K search.

**Surprise from the audit:** the entity-Leiden Celery detector already writes embeddings (18/18 on Eurail, property name `embedding`). What was missing was the vector index over them. STORY-4c creates both indexes (entity + chunk) on startup so neither is left unusable.

## Live verification (Eurail graph)

**Before:**
- Chunk communities: 6 with summary, 0 with embedding
- Entity communities: 18 with embedding (Celery wrote them), 0 indexes over them

**After (`POST /communities/summarize {"kind":"chunk"}`):**
```
{
  "kind": "chunk", "total": 59,
  "summarized": 0, "skipped_existing": 6, "skipped_singleton": 53, "failed": 0,
  "embedded": 6, "skipped_existing_embeddings": 0, "failed_embeddings": 0
}
```

**Vector indexes on startup:**
```
community_embeddings_chunk   on :ChunkCommunity(summary_embedding)
community_embeddings_entity  on :__Community__(embedding)
```

**Semantic search smoke test** — query `"customer support and AI agents handling user complaints"` against `community_embeddings_chunk`:
| score | community | preview |
|---|---|---|
| **0.7699** | cc_852 (size=33) | AI-driven customer support cluster ✓ |
| 0.7280 | cc_238 (size=212) | AI adoption + customer experience |
| 0.7050 | cc_333 (size=197) | AI adoption + distribution |

Top-1 is the AI customer-support cluster — the index returns semantically correct results.

**Idempotency:** re-running the endpoint reports `summarized=0, embedded=0, skipped_existing=6, skipped_existing_embeddings=6`. No spurious re-work.

## Changes

- **Extended** [CommunityKindSpec](knowledge-graph-builder/app/schemas/community_kinds.py) with `embedding_property` (entity → `embedding`, chunk → `summary_embedding`) and `index_name` (`community_embeddings_{kind}`). The divergence is real (entity-Leiden writes to `embedding`, predating STORY-4b's `summary_*` namespace) so the registry encodes it instead of hiding it.
- **Added** `CommunitySummarizer.embed_summaries(graph_id, kind, force_rebuild)` — uses the registry's `embedding_property` for the SET clause. Reports `embedded`, `skipped_existing`, `failed`.
- **Added** `ensure_community_vector_indexes()` — `CREATE VECTOR INDEX IF NOT EXISTS` for every registered kind, `dim=3072, similarity=cosine` matching every other index in the deployment. Idempotent. Called on app startup in `main.py` lifespan.
- **Endpoint** `POST /communities/summarize` now also embeds after summarising. Response gains `embedded`, `skipped_existing_embeddings`, `failed_embeddings`. Embedding failures don't roll back the summary write — a summary without an embedding is still useful and `force_rebuild` picks up missing embeddings on retry.
- **Tests** — 6 new tests in test_community_summarizer.py covering: per-kind property name in writes, force_rebuild query shape, embedding failures counted, index creation runs once per registered kind, individual index failure doesn't abort. 1 new test in test_community_kinds_registry.py asserts index names are unique. Total: 75 pass on the touched surface, 1373 in full unit suite (was 1367 — 6 new).

## What 4c unlocks

- **STORY-4d** (next): `find_communities(query, kind, top_k)` agent tool calls `db.index.vector.queryNodes(spec.index_name, ...)`. The index is in place, embeddings are present, descriptions for `describe_community` are pre-staged from STORY-4b.

## Test plan

- [ ] Spot-check: hit `POST /communities/summarize` with a fresh chunk community, confirm both summary and embedding land
- [ ] STORY-4d picks up `find_communities` from here

## Out of scope (follow-ups)

- Re-summarizing/re-embedding on entity-Leiden re-runs is still Celery's responsibility (STORY-4c doesn't touch the detector path)
- Chat-engine consumption of chunk-community embeddings — current `analytics_service.get_community_context()` only queries `__Community__`