### PR TITLE
STORY-4d: find_communities + describe_community agent tools

### DIFF
--- a/knowledge-graph-builder/app/schemas/agent_schemas.py
+++ b/knowledge-graph-builder/app/schemas/agent_schemas.py
@@ -4,19 +4,19 @@ from typing import Literal
 
 from pydantic import BaseModel, field_validator
 
-# Valid tool names — enforced at creation time so no invalid tool can be persisted.
-VALID_TOOLS = frozenset(
-    {
-        "graph_search",
-        "community_members",
-        "neighbors",
-        "degree_centrality",
-        "shortest_path",
-        "taint_trace",
-        "temporal_slice",
-        "cypher_query",
-    }
-)
+
+# Valid tool names — enforced at creation time so no invalid tool can be
+# persisted. Sourced from the agent_tool_schemas registry so adding a new
+# tool is one-touch (add a schema entry; the validator picks it up
+# automatically and the LLM-facing JSON schemas + this server-side
+# validator never drift apart).
+def _load_valid_tools() -> frozenset[str]:
+    from app.services.agent_tool_schemas import registered_tool_names
+
+    return frozenset(registered_tool_names())
+
+
+VALID_TOOLS = _load_valid_tools()
 
 ReasoningMode = Literal["direct", "research", "analytical", "conversational"]
 RetrieverStrategy = Literal["hybrid", "similarity", "entity"]

--- a/knowledge-graph-builder/app/services/agent_tool_schemas.py
+++ b/knowledge-graph-builder/app/services/agent_tool_schemas.py
@@ -283,6 +283,77 @@ _TOOL_SCHEMAS: dict[str, _ToolSchema] = {
             "required": ["node_label", "at_time"],
         },
     ),
+    # STORY-4d: community discovery + description
+    "find_communities": _ToolSchema(
+        name="find_communities",
+        description=(
+            "Find communities (clusters of related nodes) in the graph "
+            "via vector search over their summaries. Use this to answer "
+            "'what topics does this graph cover' or 'find clusters about "
+            "X'. Each result includes a summary, key entities, a "
+            "representative excerpt, and a similarity score.\n\n"
+            "Omit ``kind`` to search across all community kinds and rank "
+            "by similarity. Pass ``kind='chunk'`` for chunk-level clusters "
+            "(richer per-cluster metadata) or ``kind='entity'`` for "
+            "entity-level Leiden communities. The full list of supported "
+            "kinds is published at GET /communities/kinds."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Natural-language query to match against community summaries."
+                    ),
+                },
+                "kind": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Optional community-kind filter. Omit to search "
+                        "every kind and merge by score."
+                    ),
+                },
+                "top_k": _int_param(
+                    "How many top-scoring communities to return.",
+                    default=5,
+                    minimum=1,
+                    maximum=20,
+                ),
+            },
+            "required": ["query"],
+        },
+    ),
+    "describe_community": _ToolSchema(
+        name="describe_community",
+        description=(
+            "Return metadata for one community: its summary, key "
+            "entities/concepts, a representative excerpt, the member "
+            "count, and up to 5 sample member names so you can cite "
+            "concrete evidence. Use this after ``find_communities`` "
+            "spots a relevant cluster, or when another tool returns a "
+            "community_id you want to investigate.\n\n"
+            "Call ``community_members`` when you need the full member "
+            "list (this tool caps at 5 to keep the response compact)."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "community_id": {
+                    "type": "string",
+                    "description": ("Stable id of the community to describe."),
+                },
+                "kind": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Optional kind hint. Omit to let the server "
+                        "auto-detect across registered kinds."
+                    ),
+                },
+            },
+            "required": ["community_id"],
+        },
+    ),
 }
 
 

--- a/knowledge-graph-builder/app/services/agent_tools.py
+++ b/knowledge-graph-builder/app/services/agent_tools.py
@@ -317,3 +317,230 @@ class AgentToolkit:
             query, {"gid": graph_id, "at_time": at_time, "max_results": max_results}
         )
         return [_node_to_result(dict(rec["n"])) for rec in result.records]
+
+    # ── STORY-4d: community discovery + description tools ────────────────────
+
+    async def find_communities(
+        self,
+        graph_id: str,
+        query: str,
+        kind: str | None = None,
+        top_k: int = 5,
+    ) -> list[NodeResult]:
+        """Find communities related to a query via vector search over summaries.
+
+        ``kind=None`` searches every registered kind that has a populated
+        vector index, then merges results by score. ``kind="chunk"`` or
+        ``kind="entity"`` restricts to one kind.
+
+        Each result's ``properties`` carries ``kind``, ``score``,
+        ``summary``, ``keywords`` (chunk only), ``excerpt`` (chunk only),
+        ``size``. The ``label`` field surfaces the summary preview so
+        agent prompts can read the result in a glance.
+        """
+        self._require("find_communities")
+        from app.schemas.community_kinds import all_kinds, get_kind
+
+        if kind is not None:
+            specs = [get_kind(kind)]
+        else:
+            specs = list(all_kinds())
+
+        embedding = await self._embed(query)
+        per_index_k = max(top_k, 10) if len(specs) > 1 else top_k
+
+        merged: list[tuple[float, dict[str, Any]]] = []
+        for spec in specs:
+            # Index name, label, and property names come from the registry —
+            # compile-time constants, safe for f-string interpolation. The
+            # graph_id filter is parameterized so tenant isolation holds.
+            cypher = (
+                f"CALL db.index.vector.queryNodes('{spec.index_name}', "
+                f"$top_k, $embedding) YIELD node, score "
+                f"WHERE node.graph_id = $gid AND node.summary IS NOT NULL "
+                f"RETURN node.`{spec.id_property}` AS community_id, "
+                f"node.summary AS summary, "
+                f"node.`{spec.size_property}` AS size, "
+                "node.summary_keywords AS keywords, "
+                "node.summary_excerpt AS excerpt, "
+                "score "
+                "ORDER BY score DESC"
+            )
+            try:
+                result = await self._driver.execute_query(
+                    cypher,
+                    {
+                        "gid": graph_id,
+                        "top_k": per_index_k,
+                        "embedding": embedding,
+                    },
+                )
+            except Exception as exc:
+                # An index missing on one kind shouldn't break the whole
+                # query — log and try the next kind. The LLM-facing tool
+                # result is still useful if at least one kind responded.
+                logger.warning(
+                    "find_communities index %s failed: %s", spec.index_name, exc
+                )
+                continue
+
+            for rec in result.records:
+                # Parse keywords JSON for chunk; entity returns NULL.
+                kw_raw = rec.get("keywords")
+                keywords: list[str] | None = None
+                if kw_raw:
+                    try:
+                        import json as _json
+
+                        parsed = _json.loads(kw_raw)
+                        if isinstance(parsed, list):
+                            keywords = parsed
+                    except (ValueError, TypeError):
+                        keywords = None
+                community_id = rec["community_id"]
+                merged.append(
+                    (
+                        rec["score"],
+                        {
+                            "id": community_id,
+                            "label": (rec.get("summary") or "")[:160],
+                            "qualified_name": None,
+                            "properties": {
+                                "kind": spec.kind,
+                                "score": rec["score"],
+                                "summary": rec.get("summary"),
+                                "keywords": keywords,
+                                "excerpt": rec.get("excerpt"),
+                                "size": rec.get("size"),
+                            },
+                        },
+                    )
+                )
+
+        # Highest score first; cap at top_k overall when multi-kind.
+        merged.sort(key=lambda x: x[0], reverse=True)
+        return [
+            NodeResult(
+                id=p["id"],
+                qualified_name=p["qualified_name"],
+                label=p["label"],
+                properties=p["properties"],
+            )
+            for _score, p in merged[:top_k]
+        ]
+
+    async def describe_community(
+        self,
+        graph_id: str,
+        community_id: str,
+        kind: str | None = None,
+    ) -> list[NodeResult]:
+        """Return metadata for one community: summary, keywords, excerpt,
+        size, plus up to 5 sample member names.
+
+        Auto-detects kind by probing the registry (entity first → one
+        round trip on the common case) when ``kind`` is None. The agent
+        can also pass ``kind`` explicitly to skip the probe.
+
+        Returns a single-element ``list[NodeResult]`` for shape
+        consistency with the other agent tools. The result's
+        ``properties`` carry every relevant field; the ``label`` is a
+        summary preview.
+        """
+        self._require("describe_community")
+        from app.schemas.community_kinds import all_kinds, get_kind
+
+        if kind is not None:
+            specs = [get_kind(kind)]
+        else:
+            specs = list(all_kinds())
+
+        for spec in specs:
+            # Fetch core community fields. Property names come from the
+            # registry; the chunk-only fields (keywords/excerpt) are
+            # selected with NULL fallbacks so the result shape is uniform.
+            if spec.kind == "chunk":
+                summary_extras = (
+                    "c.summary_keywords AS keywords, c.summary_excerpt AS excerpt"
+                )
+            else:
+                summary_extras = "NULL AS keywords, NULL AS excerpt"
+
+            cypher = (
+                f"MATCH (c:`{spec.community_label}` "
+                f"{{`{spec.id_property}`: $cid, graph_id: $gid}}) "
+                f"RETURN c.`{spec.id_property}` AS community_id, "
+                "c.summary AS summary, "
+                f"c.`{spec.size_property}` AS size, "
+                f"{summary_extras}"
+            )
+            result = await self._driver.execute_query(
+                cypher, {"cid": community_id, "gid": graph_id}
+            )
+            if not result.records:
+                continue
+
+            rec = result.records[0]
+
+            # Top-5 sample members. For entity, use ``name``; for chunk,
+            # use a short text snippet so the agent has concrete evidence
+            # without calling community_members for the full list.
+            if spec.kind == "chunk":
+                members_cypher = (
+                    f"MATCH (m:`{spec.member_label}` {{graph_id: $gid}})"
+                    f"-[:`{spec.member_rel}`]->"
+                    f"(c:`{spec.community_label}` "
+                    f"{{`{spec.id_property}`: $cid, graph_id: $gid}}) "
+                    "RETURN m.id AS member_id, "
+                    "substring(coalesce(m.text, ''), 0, 80) AS member_preview "
+                    "ORDER BY m.id LIMIT 5"
+                )
+            else:
+                members_cypher = (
+                    f"MATCH (m:`{spec.member_label}` {{graph_id: $gid}})"
+                    f"-[:`{spec.member_rel}`]->"
+                    f"(c:`{spec.community_label}` "
+                    f"{{`{spec.id_property}`: $cid, graph_id: $gid}}) "
+                    "RETURN coalesce(m.id, elementId(m)) AS member_id, "
+                    "coalesce(m.name, '') AS member_preview "
+                    "ORDER BY m.name LIMIT 5"
+                )
+            mres = await self._driver.execute_query(
+                members_cypher, {"cid": community_id, "gid": graph_id}
+            )
+            sample_members = [
+                {"id": m["member_id"], "preview": m["member_preview"]}
+                for m in mres.records
+            ]
+
+            # Parse keywords (chunk only).
+            kw_raw = rec.get("keywords")
+            keywords: list[str] | None = None
+            if kw_raw:
+                try:
+                    import json as _json
+
+                    parsed = _json.loads(kw_raw)
+                    if isinstance(parsed, list):
+                        keywords = parsed
+                except (ValueError, TypeError):
+                    keywords = None
+
+            return [
+                NodeResult(
+                    id=rec["community_id"],
+                    qualified_name=None,
+                    label=(rec.get("summary") or "")[:160],
+                    properties={
+                        "kind": spec.kind,
+                        "summary": rec.get("summary"),
+                        "keywords": keywords,
+                        "excerpt": rec.get("excerpt"),
+                        "size": rec.get("size"),
+                        "sample_members": sample_members,
+                    },
+                )
+            ]
+
+        # No kind matched
+        return []

--- a/knowledge-graph-builder/tests/unit/test_agent_tools.py
+++ b/knowledge-graph-builder/tests/unit/test_agent_tools.py
@@ -415,3 +415,270 @@ class TestTemporalSlice:
         )
         params = driver.execute_query.call_args[0][1]
         assert params["max_results"] == 25
+
+
+# ── find_communities (STORY-4d) ──────────────────────────────────────────────
+
+
+def _vector_rec(community_id, score, summary, size=10, keywords=None, excerpt=None):
+    """Mock one row from db.index.vector.queryNodes."""
+    return {
+        "community_id": community_id,
+        "summary": summary,
+        "size": size,
+        "keywords": keywords,
+        "excerpt": excerpt,
+        "score": score,
+    }
+
+
+class TestFindCommunities:
+    async def test_blocked_when_not_in_allowlist(self):
+        driver, _ = _make_driver()
+        embedder = MagicMock()
+        embedder.embed_query = MagicMock(return_value=[0.0] * 3072)
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, [], embedder=embedder).find_communities(
+                "g1", "query"
+            )
+
+    async def test_searches_all_kinds_by_default(self):
+        """``kind=None`` issues one Cypher call per registered kind."""
+        driver, _ = _make_driver()
+        # Each call returns one match
+        results = [
+            MagicMock(records=[_vector_rec("c-entity", 0.9, "entity sum")]),
+            MagicMock(
+                records=[
+                    _vector_rec(
+                        "cc-chunk", 0.95, "chunk sum", keywords='["x"]', excerpt="e"
+                    )
+                ]
+            ),
+        ]
+        driver.execute_query = AsyncMock(side_effect=results)
+        embedder = MagicMock()
+        embedder.embed_query = MagicMock(return_value=[0.0] * 3072)
+        out = await _toolkit(
+            driver, ["find_communities"], embedder=embedder
+        ).find_communities("g1", "test query")
+
+        # Two calls: one per kind
+        assert driver.execute_query.await_count == 2
+        # Merged by score descending — chunk first (0.95) then entity (0.9)
+        assert len(out) == 2
+        assert out[0].id == "cc-chunk"
+        assert out[1].id == "c-entity"
+
+    async def test_explicit_kind_restricts_to_one_index(self):
+        driver, _ = _make_driver()
+        driver.execute_query = AsyncMock(
+            return_value=MagicMock(records=[_vector_rec("cc-1", 0.8, "s")])
+        )
+        embedder = MagicMock()
+        embedder.embed_query = MagicMock(return_value=[0.0] * 3072)
+        out = await _toolkit(
+            driver, ["find_communities"], embedder=embedder
+        ).find_communities("g1", "q", kind="chunk")
+        # Only one call — the chunk index
+        assert driver.execute_query.await_count == 1
+        cypher = driver.execute_query.call_args[0][0]
+        assert "community_embeddings_chunk" in cypher
+        assert len(out) == 1
+
+    async def test_graph_id_passed_via_params(self):
+        driver, _ = _make_driver()
+        driver.execute_query = AsyncMock(return_value=MagicMock(records=[]))
+        embedder = MagicMock()
+        embedder.embed_query = MagicMock(return_value=[0.0] * 3072)
+        await _toolkit(
+            driver, ["find_communities"], embedder=embedder
+        ).find_communities("my-graph", "q", kind="chunk")
+        params = driver.execute_query.call_args[0][1]
+        assert params["gid"] == "my-graph"
+
+    async def test_keywords_parsed_from_json(self):
+        driver, _ = _make_driver()
+        driver.execute_query = AsyncMock(
+            return_value=MagicMock(
+                records=[
+                    _vector_rec(
+                        "cc-1", 0.9, "s", keywords='["k1","k2","k3"]', excerpt="e"
+                    )
+                ]
+            )
+        )
+        embedder = MagicMock()
+        embedder.embed_query = MagicMock(return_value=[0.0] * 3072)
+        out = await _toolkit(
+            driver, ["find_communities"], embedder=embedder
+        ).find_communities("g", "q", kind="chunk")
+        assert out[0].properties["keywords"] == ["k1", "k2", "k3"]
+
+    async def test_index_failure_does_not_abort_other_kinds(self):
+        """If one kind's vector index doesn't exist, the others still
+        succeed — log + continue rather than crash the tool call."""
+        driver, _ = _make_driver()
+        driver.execute_query = AsyncMock(
+            side_effect=[
+                RuntimeError("entity index missing"),
+                MagicMock(records=[_vector_rec("cc-1", 0.7, "chunk")]),
+            ]
+        )
+        embedder = MagicMock()
+        embedder.embed_query = MagicMock(return_value=[0.0] * 3072)
+        out = await _toolkit(
+            driver, ["find_communities"], embedder=embedder
+        ).find_communities("g", "q")
+        # Entity errored, chunk succeeded
+        assert len(out) == 1
+        assert out[0].id == "cc-1"
+
+    async def test_top_k_caps_merged_result(self):
+        driver, _ = _make_driver()
+        # Return 4 from each kind
+        rec = lambda cid, s: _vector_rec(cid, s, "x")  # noqa: E731
+        driver.execute_query = AsyncMock(
+            side_effect=[
+                MagicMock(records=[rec(f"e{i}", 0.5 + i * 0.01) for i in range(4)]),
+                MagicMock(records=[rec(f"c{i}", 0.6 + i * 0.01) for i in range(4)]),
+            ]
+        )
+        embedder = MagicMock()
+        embedder.embed_query = MagicMock(return_value=[0.0] * 3072)
+        out = await _toolkit(
+            driver, ["find_communities"], embedder=embedder
+        ).find_communities("g", "q", top_k=3)
+        assert len(out) == 3
+
+
+# ── describe_community (STORY-4d) ────────────────────────────────────────────
+
+
+class TestDescribeCommunity:
+    async def test_blocked_when_not_in_allowlist(self):
+        driver, _ = _make_driver()
+        with pytest.raises(ToolNotPermittedError):
+            await _toolkit(driver, []).describe_community("g", "cc-1")
+
+    async def test_probes_registry_when_kind_omitted(self):
+        """No kind hint → entity probed first; if it returns no rows
+        the chunk path is tried."""
+        driver, _ = _make_driver()
+        # First call (entity probe) → no records. Second call (chunk
+        # probe) → one record. Third call (chunk member fetch) → empty.
+        driver.execute_query = AsyncMock(
+            side_effect=[
+                MagicMock(records=[]),
+                MagicMock(
+                    records=[
+                        {
+                            "community_id": "cc-1",
+                            "summary": "Test cluster",
+                            "size": 42,
+                            "keywords": '["x"]',
+                            "excerpt": "ex",
+                        }
+                    ]
+                ),
+                MagicMock(records=[]),
+            ]
+        )
+        out = await _toolkit(driver, ["describe_community"]).describe_community(
+            "g", "cc-1"
+        )
+        assert len(out) == 1
+        assert out[0].id == "cc-1"
+        assert out[0].properties["kind"] == "chunk"
+        assert out[0].properties["keywords"] == ["x"]
+        assert out[0].properties["excerpt"] == "ex"
+        assert out[0].properties["size"] == 42
+
+    async def test_explicit_kind_skips_probe(self):
+        driver, _ = _make_driver()
+        driver.execute_query = AsyncMock(
+            side_effect=[
+                MagicMock(
+                    records=[
+                        {
+                            "community_id": "cc-1",
+                            "summary": "s",
+                            "size": 5,
+                            "keywords": None,
+                            "excerpt": None,
+                        }
+                    ]
+                ),
+                MagicMock(records=[]),
+            ]
+        )
+        await _toolkit(driver, ["describe_community"]).describe_community(
+            "g", "cc-1", kind="chunk"
+        )
+        # Only 2 calls: 1 for the chunk row, 1 for members. No entity probe.
+        assert driver.execute_query.await_count == 2
+
+    async def test_returns_empty_when_no_kind_matches(self):
+        driver, _ = _make_driver()
+        # Both probes return no records
+        driver.execute_query = AsyncMock(
+            side_effect=[MagicMock(records=[]), MagicMock(records=[])]
+        )
+        out = await _toolkit(driver, ["describe_community"]).describe_community(
+            "g", "nonexistent"
+        )
+        assert out == []
+
+    async def test_sample_members_capped_at_5(self):
+        driver, _ = _make_driver()
+        driver.execute_query = AsyncMock(
+            side_effect=[
+                MagicMock(
+                    records=[
+                        {
+                            "community_id": "cc-1",
+                            "summary": "s",
+                            "size": 100,
+                            "keywords": None,
+                            "excerpt": None,
+                        }
+                    ]
+                ),
+                # 5 members returned (the Cypher LIMIT 5 already capped)
+                MagicMock(
+                    records=[
+                        {"member_id": f"m{i}", "member_preview": f"text-{i}"}
+                        for i in range(5)
+                    ]
+                ),
+            ]
+        )
+        out = await _toolkit(driver, ["describe_community"]).describe_community(
+            "g", "cc-1", kind="chunk"
+        )
+        assert len(out[0].properties["sample_members"]) == 5
+
+    async def test_graph_id_passed_via_params(self):
+        driver, _ = _make_driver()
+        driver.execute_query = AsyncMock(
+            side_effect=[
+                MagicMock(
+                    records=[
+                        {
+                            "community_id": "cc-1",
+                            "summary": "s",
+                            "size": 5,
+                            "keywords": None,
+                            "excerpt": None,
+                        }
+                    ]
+                ),
+                MagicMock(records=[]),
+            ]
+        )
+        await _toolkit(driver, ["describe_community"]).describe_community(
+            "my-graph", "cc-1", kind="chunk"
+        )
+        # The first call is the community-row fetch
+        params = driver.execute_query.call_args_list[0][0][1]
+        assert params["gid"] == "my-graph"


### PR DESCRIPTION
## Summary

Final piece of the STORY-4 split. Agents now have first-class access to the chunk-community summaries (STORY-4b) + entity-Leiden communities via the vector indexes (STORY-4c). Together the three community tools (`find_communities`, `describe_community`, `community_members`) cover discovery → metadata → membership.

## Live verification (Eurail graph, via the chat API)

Created a research-mode test agent with the new tools in its allowlist, then asked it real questions:

**Test 1 — discovery:**
> "What are the main themes covered in this knowledge graph?"

Agent called `find_communities` and answered:
```
1. Eurail & AI Integration (cc_12, cc_333, cc_238) — AI tech + governance
2. Eurail AI Customer Support (cc_852)
3. Talent & Capabilities (cc_681)
...
```
Provenance: `tools_called=["find_communities"]`, `tool_call_id=toolu_bdrk_01HwHTHxD4hLcgDV9xyaPTcZ`, 10 communities returned across both kinds.

**Test 2 — drill-down:**
> "Tell me everything about community cc_852_86e2f6a2 in detail."

Agent called `describe_community` and answered with the cluster's theme, keywords, and excerpt. Provenance: `tools_called=["describe_community"]`.

## Changes

- **NEW** `find_communities(query, kind=None, top_k=5)` in [agent_tools.py](knowledge-graph-builder/app/services/agent_tools.py). Vector search via `db.index.vector.queryNodes(spec.index_name, ...)`. When `kind` is omitted, queries every registered kind and merges by score. Individual index failures don't abort the call — partial-coverage setups still return useful data.
- **NEW** `describe_community(community_id, kind=None)`. Returns summary + keywords + excerpt + size + up to 5 sample members. Auto-probes the registry when no kind hint is given (entity first → one round trip on the common case).
- **NEW** JSON schemas for both tools in [agent_tool_schemas.py](knowledge-graph-builder/app/services/agent_tool_schemas.py). The existing coverage-guard test (auto-introspection via `inspect.getmembers`) and parametrized tenant-isolation test (now over 10 tools) pick them up automatically.
- **REFACTOR** [agent_schemas.py](knowledge-graph-builder/app/schemas/agent_schemas.py) — `VALID_TOOLS` is now loaded from `agent_tool_schemas.registered_tool_names()` instead of being a hardcoded set that needs to be synchronised manually. Surfaced during the live test: the new tools were rejected on agent creation until I removed the second source of truth.

## Tests

- 13 new unit tests in [test_agent_tools.py](knowledge-graph-builder/tests/unit/test_agent_tools.py) covering: allowlist enforcement, default multi-kind search, explicit kind narrowing, graph_id-via-params, keyword JSON parsing, partial-failure tolerance, top_k cap, registry probing, sample-member cap.
- Full unit suite: **1388 pass** (was 1373 from STORY-4c — 15 new tests added), same 10 pre-existing unrelated failures.

## Test plan

- [ ] Frontend hook-up: surface `find_communities` results in the agent-builder tool picker
- [ ] Adversarial QA: rerun the 50-question Eurail set with research-mode + community tools and compare against the baseline 44/50

## What 4d completes

This closes STORY-4 — chunk-community visibility from 4a is now usable end-to-end:
- 4a: registry + read-only endpoints
- 4b: summaries (prose + keywords + excerpt)
- 4c: embeddings + vector indexes
- 4d: agent tools for search + describe

## Out of scope (follow-ups)

- Wiring chunk-community context into `analytics_service.get_community_context()` for the `chat_service` retrieval path (current path only consults `__Community__`)
- Replicating the keywords / excerpt pipeline for entity-Leiden — entity communities have `summary` + `embedding` today but no structured keywords. The agent tools still work on entity (just with empty `keywords` / `excerpt`).