### PR TITLE
STORY-7: SIMILAR_TO edges between chunks and entities

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
@@ -66,6 +66,8 @@ from app.schemas.graph_schemas import (
     RollbackJobResponse,
     RollbackRequest,
     RollbackResponse,
+    SimilarityBuildRequest,
+    SimilarityBuildResponse,
     TimelineEvent,
     TimelineResponse,
     UpdateTemporalBoundsRequest,
@@ -1425,6 +1427,7 @@ from app.schemas.community_kinds import (
 )
 from app.services.analytics_service import GraphAnalyticsService
 from app.services.community_summarizer import CommunitySummarizer
+from app.services.similarity_service import similarity_service
 from app.tasks.community_tasks import COMMUNITY_DETECTION_MIN_ENTITIES
 
 
@@ -1682,6 +1685,68 @@ async def summarize_communities(
         embedded=report.embedded,
         skipped_existing_embeddings=report.skipped_existing_embeddings,
         failed_embeddings=report.failed_embeddings,
+    )
+
+
+# ==================== STORY-7: SIMILARITY ENDPOINT ====================
+
+
+@router.post(
+    "/graphs/{graph_id}/similarity/build",
+    response_model=SimilarityBuildResponse,
+    summary="Build SIMILAR_TO edges between nodes via vector index lookup",
+    responses={
+        400: {"description": "Unknown target"},
+    },
+)
+async def build_similarity(
+    graph_id: UUID,
+    request: SimilarityBuildRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Compute SIMILAR_TO edges between :Chunk pairs and/or :__Entity__
+    pairs whose vector-index cosine similarity is above a threshold.
+
+    Synchronous. For an Eurail-sized graph (~970 chunks, ~2900 entities)
+    expect under 30 seconds. Larger graphs may want Celery wrapping —
+    out of scope for STORY-7.
+
+    Idempotent: re-running without ``force_rebuild`` MERGE-updates each
+    edge's ``score`` and ``updated_at`` but does not duplicate edges.
+    With ``force_rebuild=True`` the prior edges are deleted first.
+    """
+    await _verify_graph_ownership(graph_id, user_id)
+
+    if request.target not in ("chunks", "entities", "all"):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unknown target {request.target!r}. "
+                "Valid: 'chunks', 'entities', or 'all'."
+            ),
+        )
+
+    try:
+        report = await similarity_service.build_similarities(
+            graph_id=str(graph_id),
+            target=request.target,
+            threshold_chunks=request.threshold_chunks,
+            threshold_entities=request.threshold_entities,
+            top_k=request.top_k,
+            force_rebuild=request.force_rebuild,
+            job_id=request.job_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+    return SimilarityBuildResponse(
+        target=report.target,
+        chunk_edges_created=report.chunk_edges_created,
+        entity_edges_created=report.entity_edges_created,
+        chunks_processed=report.chunks_processed,
+        entities_processed=report.entities_processed,
+        elapsed_seconds=report.elapsed_seconds,
+        force_rebuild=report.force_rebuild,
     )
 
 

--- a/knowledge-graph-builder/app/core/config.py
+++ b/knowledge-graph-builder/app/core/config.py
@@ -80,8 +80,17 @@ class Settings(BaseSettings):
     LLM_SUMMARY_CONCURRENCY: int = 5
 
     # Legacy flags (disabled for modern approach)
-    ENABLE_SIMILARITY_PROCESSING: bool = True
     ENABLE_COMMUNITY_DETECTION: bool = True
+
+    # STORY-7: SIMILAR_TO edge generation. The historic
+    # ``ENABLE_SIMILARITY_PROCESSING`` flag was set to True but never
+    # consumed anywhere in the code — no SIMILAR_TO edges ever materialised.
+    # ``similarity_service.build_similarities`` is now the explicit
+    # entry point (via POST /graphs/{id}/similarity/build). This setting
+    # gates whether the ingest pipeline should call that service after
+    # entity deduplication. Default False so existing ingest performance
+    # is unchanged; opt-in per deployment.
+    SIMILARITY_AUTO_TRIGGER_ON_INGEST: bool = False
 
     # Performance Settings
     MAX_CONCURRENT_EXTRACTIONS: int = 5

--- a/knowledge-graph-builder/app/schemas/graph_schemas.py
+++ b/knowledge-graph-builder/app/schemas/graph_schemas.py
@@ -1025,6 +1025,76 @@ class CommunitySummarizeResponse(BaseModel):
     )
 
 
+# ==================== STORY-7 SIMILARITY SCHEMAS ====================
+
+
+class SimilarityBuildRequest(BaseModel):
+    """POST /graphs/{id}/similarity/build body."""
+
+    target: str = Field(
+        "all",
+        description=(
+            "Which node kind to compute SIMILAR_TO edges for. "
+            "'chunks' = :Chunk; 'entities' = :__Entity__; "
+            "'all' = both."
+        ),
+    )
+    threshold_chunks: float | None = Field(
+        None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Cosine threshold for :Chunk pairs. Default 0.85. Chunk text "
+            "embeddings are semantically uniform so this catches genuinely "
+            "similar passages."
+        ),
+    )
+    threshold_entities: float | None = Field(
+        None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Cosine threshold for :__Entity__ pairs. Default 0.92 (tighter "
+            "than chunks because short entity-name embeddings false-positive "
+            "easily)."
+        ),
+    )
+    top_k: int = Field(
+        5,
+        ge=1,
+        le=20,
+        description=(
+            "Max neighbours considered per source node. Higher = denser "
+            "graph but more edges to store."
+        ),
+    )
+    force_rebuild: bool = Field(
+        False,
+        description=(
+            "When True, delete all existing SIMILAR_TO edges for the "
+            "target(s) before computing fresh ones."
+        ),
+    )
+    job_id: str | None = Field(
+        None,
+        description=(
+            "Optional ingestion job id. When provided, the resulting "
+            "edge count is added to the job's similarity_relationships "
+            "Postgres column."
+        ),
+    )
+
+
+class SimilarityBuildResponse(BaseModel):
+    target: str
+    chunk_edges_created: int
+    entity_edges_created: int
+    chunks_processed: int
+    entities_processed: int
+    elapsed_seconds: float
+    force_rebuild: bool
+
+
 # ==================== VERSIONING SCHEMAS ====================
 
 

--- a/knowledge-graph-builder/app/services/similarity_service.py
+++ b/knowledge-graph-builder/app/services/similarity_service.py
@@ -1,0 +1,296 @@
+"""SIMILAR_TO edge generator (STORY-7).
+
+Walks the existing Neo4j vector indexes (``text_embeddings_primary`` on
+``:Chunk``, ``entity_embeddings`` on ``:__Entity__``) to find pairs of
+nodes whose cosine similarity is above a threshold, and writes a
+``:SIMILAR_TO`` edge between them.
+
+Design choices
+--------------
+- **Undirected pairs**: SIMILAR_TO is semantically undirected but Neo4j
+  edges are directed. We dedupe by always storing the edge from the
+  node with the lexicographically-smaller id to the larger one
+  (``a.id < b.id`` filter). Means agents must traverse in both
+  directions when walking SIMILAR_TO.
+- **Score on the edge**: stored as ``r.score`` so downstream callers
+  (community detection, future find_similar agent tool) can rank by
+  similarity strength.
+- **Tenant isolation**: ``graph_id`` is filtered on the source node, on
+  the neighbour, AND stored on the edge. Three layers because the
+  vector index has no per-graph partitioning, so a neighbour from
+  another tenant could leak through if we didn't filter.
+- **Different thresholds per target**: chunks (long-form text) are
+  semantically uniform and we use 0.85; entities (short names) embed
+  more noisily and need 0.92 to avoid false-positive merges.
+- **`a.id < b.id` ordering** depends on every node having a stable ``id``
+  property. :Chunk and :__Entity__ both do — chunks via
+  neo4j_graphrag's chunk_id, entities via the deduplicator.
+
+Not in scope for STORY-7
+------------------------
+- Auto-triggering on ingest — kept explicit via the endpoint. The
+  ``SIMILARITY_AUTO_TRIGGER_ON_INGEST`` setting (default False) is a
+  hook for a future commit to add pipeline-side scheduling without
+  breaking existing ingest performance.
+- Reciprocal (``a→b`` AND ``b→a``) edges — single edge per pair only.
+- Multi-graph similarity (federation) — that's federation_service's job.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.core.neo4j_client import neo4j_client
+
+logger = get_logger(__name__)
+
+# Expected embedding dimensionality. Matches what ensure_community_vector_indexes
+# and the legacy create_vector_indexes script configure for every embedding
+# index in the deployment. Nodes whose ``embedding`` doesn't match this
+# dimension are filtered out at query time so a single corrupt row doesn't
+# crash the whole build (the vector index call raises IllegalArgumentException
+# when dimensions disagree).
+_EXPECTED_EMBEDDING_DIM = getattr(settings, "EMBEDDING_DIMENSIONS", 3072)
+
+
+# Target catalog — explicit so adding a new node-type target is one entry.
+@dataclass(frozen=True, slots=True)
+class _SimilarityTarget:
+    label: str
+    index_name: str
+    default_threshold: float
+
+
+_TARGETS: dict[str, _SimilarityTarget] = {
+    "chunks": _SimilarityTarget(
+        label="Chunk",
+        index_name="text_embeddings_primary",
+        default_threshold=0.85,
+    ),
+    "entities": _SimilarityTarget(
+        label="__Entity__",
+        index_name="entity_embeddings",
+        default_threshold=0.92,
+    ),
+}
+
+
+TargetLiteral = Literal["chunks", "entities", "all"]
+
+
+@dataclass(slots=True)
+class SimilarityReport:
+    """Outcome of one build_similarities run."""
+
+    target: str
+    chunk_edges_created: int = 0
+    entity_edges_created: int = 0
+    chunks_processed: int = 0
+    entities_processed: int = 0
+    elapsed_seconds: float = 0.0
+    force_rebuild: bool = False
+
+    def total_edges(self) -> int:
+        return self.chunk_edges_created + self.entity_edges_created
+
+
+class SimilarityService:
+    """Compute SIMILAR_TO edges between nodes in the same graph."""
+
+    async def build_similarities(
+        self,
+        graph_id: str,
+        target: TargetLiteral = "all",
+        threshold_chunks: float | None = None,
+        threshold_entities: float | None = None,
+        top_k: int = 5,
+        force_rebuild: bool = False,
+        job_id: str | None = None,
+    ) -> SimilarityReport:
+        """Build SIMILAR_TO edges for one or both targets.
+
+        Args:
+            graph_id: Tenant graph id (scoped on source, neighbour, and
+                edge property for defense-in-depth).
+            target: "chunks", "entities", or "all".
+            threshold_chunks: Override default 0.85 for chunk pairs.
+            threshold_entities: Override default 0.92 for entity pairs.
+            top_k: Max neighbours considered per source node. We query
+                ``top_k+1`` against the vector index because the source
+                node itself comes back at score=1.0.
+            force_rebuild: When True, delete all existing SIMILAR_TO
+                edges for the target(s) before computing fresh ones.
+            job_id: Optional ingestion job id. When provided, the
+                resulting edge counts are added to the job's
+                ``similarity_relationships`` Postgres column.
+        """
+        start = time.time()
+        report = SimilarityReport(target=target, force_rebuild=force_rebuild)
+
+        targets_to_run: list[str] = (
+            ["chunks", "entities"] if target == "all" else [target]
+        )
+        if target != "all" and target not in _TARGETS:
+            raise ValueError(
+                f"Unknown similarity target {target!r}. "
+                f"Valid: {list(_TARGETS.keys())} or 'all'."
+            )
+
+        threshold_overrides = {
+            "chunks": threshold_chunks,
+            "entities": threshold_entities,
+        }
+
+        for tname in targets_to_run:
+            spec = _TARGETS[tname]
+            t_threshold = (
+                threshold_overrides[tname]
+                if threshold_overrides[tname] is not None
+                else spec.default_threshold
+            )
+
+            if force_rebuild:
+                await self._delete_existing(graph_id, spec)
+
+            counts = await self._build_for_target(
+                graph_id=graph_id,
+                spec=spec,
+                threshold=t_threshold,
+                top_k=top_k,
+            )
+
+            if tname == "chunks":
+                report.chunk_edges_created = counts["edges_created"]
+                report.chunks_processed = counts["nodes_processed"]
+            else:
+                report.entity_edges_created = counts["edges_created"]
+                report.entities_processed = counts["nodes_processed"]
+
+        report.elapsed_seconds = round(time.time() - start, 2)
+
+        # Mirror to the IngestionJob counter if a job_id was provided.
+        # Best-effort — failure here doesn't fail the whole call.
+        if job_id and report.total_edges() > 0:
+            try:
+                await self._increment_job_counter(job_id, report.total_edges())
+            except Exception as exc:
+                logger.warning(
+                    "similarity_service: failed to update job_id=%s counter: %s",
+                    job_id,
+                    exc,
+                )
+
+        logger.info(
+            "similarity build complete graph_id=%s target=%s "
+            "chunks=%d entities=%d elapsed=%.2fs",
+            graph_id,
+            target,
+            report.chunk_edges_created,
+            report.entity_edges_created,
+            report.elapsed_seconds,
+        )
+        return report
+
+    # ── private ──────────────────────────────────────────────────────────────
+
+    async def _build_for_target(
+        self,
+        graph_id: str,
+        spec: _SimilarityTarget,
+        threshold: float,
+        top_k: int,
+    ) -> dict[str, int]:
+        """Run the vector-search loop for one target label.
+
+        Labels, index names, and property names come from the compile-time
+        ``_TARGETS`` catalog — never from request input — so f-string
+        interpolation is safe. The ``graph_id`` is parameterized, as are
+        threshold and top_k.
+
+        The query is one round trip — Neo4j handles the per-source
+        vector lookup and pair-dedup via the ``a.id < b.id`` filter.
+        """
+        # ``top_k + 1`` because the source node itself comes back at
+        # score=1.0 in the vector index result, so we strip it via the
+        # elementId-inequality filter.
+        #
+        # ``size(a.embedding) = $expected_dim`` defends against corrupt
+        # rows whose ``embedding`` property holds something other than a
+        # proper 3072-dim vector. Without this filter, a single corrupt
+        # row would crash the entire build (the vector index raises
+        # IllegalArgumentException on dimension mismatch).
+        #
+        # Pair-dedup uses ``elementId()`` rather than ``a.id`` because not
+        # every label has a user-facing ``id`` property (e.g. :Chunk in
+        # this deployment only has ``index`` / ``text`` / ``embedding``).
+        # elementId is always unique within Neo4j.
+        query = (
+            f"MATCH (a:`{spec.label}` {{graph_id: $gid}}) "
+            "WHERE a.embedding IS NOT NULL "
+            "  AND size(a.embedding) = $expected_dim "
+            f"CALL db.index.vector.queryNodes('{spec.index_name}', "
+            "$top_k_plus_one, a.embedding) "
+            "YIELD node AS b, score "
+            f"WHERE b:`{spec.label}` AND b.graph_id = $gid "
+            "  AND size(b.embedding) = $expected_dim "
+            "  AND elementId(a) < elementId(b) "
+            "  AND score >= $threshold "
+            "MERGE (a)-[r:SIMILAR_TO {graph_id: $gid}]->(b) "
+            "ON CREATE SET r.score = score, r.created_at = datetime() "
+            "ON MATCH SET r.score = score, r.updated_at = datetime() "
+            "RETURN count(DISTINCT r) AS edges_created, "
+            "       count(DISTINCT a) AS nodes_processed"
+        )
+        rows = await neo4j_client.execute_query(
+            query,
+            {
+                "gid": graph_id,
+                "top_k_plus_one": top_k + 1,
+                "threshold": threshold,
+                "expected_dim": _EXPECTED_EMBEDDING_DIM,
+            },
+        )
+        if not rows:
+            return {"edges_created": 0, "nodes_processed": 0}
+        return {
+            "edges_created": rows[0].get("edges_created") or 0,
+            "nodes_processed": rows[0].get("nodes_processed") or 0,
+        }
+
+    async def _delete_existing(self, graph_id: str, spec: _SimilarityTarget) -> None:
+        """Delete all SIMILAR_TO edges for this label + tenant. Used by
+        force_rebuild before the fresh pass."""
+        query = (
+            f"MATCH (:`{spec.label}` {{graph_id: $gid}})"
+            "-[r:SIMILAR_TO {graph_id: $gid}]->"
+            f"(:`{spec.label}` {{graph_id: $gid}}) "
+            "DELETE r"
+        )
+        await neo4j_client.execute_write_query(query, {"gid": graph_id})
+
+    async def _increment_job_counter(self, job_id: str, increment: int) -> None:
+        """Add to ``IngestionJob.similarity_relationships`` for one job."""
+        from sqlalchemy import update
+
+        from app.core.database import async_session_maker
+        from app.models.graph import IngestionJob
+
+        async with async_session_maker() as session:
+            await session.execute(
+                update(IngestionJob)
+                .where(IngestionJob.id == job_id)
+                .values(
+                    similarity_relationships=(
+                        IngestionJob.similarity_relationships + increment
+                    )
+                )
+            )
+            await session.commit()
+
+
+# Module-level singleton — service is stateless.
+similarity_service = SimilarityService()

--- a/knowledge-graph-builder/tests/unit/test_similarity_service.py
+++ b/knowledge-graph-builder/tests/unit/test_similarity_service.py
@@ -1,0 +1,248 @@
+"""Unit tests for SimilarityService (STORY-7).
+
+Verifies the SIMILAR_TO edge generator:
+- Per-target Cypher uses the right label + index name
+- Threshold and top_k passed via params
+- Tenant-isolation filter (graph_id) on source, neighbour, AND edge
+- Pair-dedup via ``a.id < b.id``
+- force_rebuild deletes existing edges first
+- Unknown target raises ValueError
+- IngestionJob counter only touched when job_id provided
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.similarity_service import (
+    SimilarityReport,
+    SimilarityService,
+)
+
+
+def _make_report_rows(edges: int = 0, processed: int = 0) -> list[dict]:
+    """Build the rows a successful build_similarities call returns."""
+    return [{"edges_created": edges, "nodes_processed": processed}]
+
+
+class TestUnknownTarget:
+    @pytest.mark.unit
+    async def test_unknown_target_raises_value_error(self):
+        svc = SimilarityService()
+        with pytest.raises(ValueError, match="Unknown similarity target"):
+            await svc.build_similarities("g1", target="bogus")
+
+
+class TestPerTargetCypher:
+    @pytest.mark.unit
+    async def test_chunks_target_uses_chunk_label_and_text_index(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(
+            return_value=_make_report_rows(edges=42, processed=100)
+        )
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            report = await svc.build_similarities("g1", target="chunks")
+        # One execute_query call (the target loop) — no delete because
+        # force_rebuild defaults False.
+        cypher = mock_client.execute_query.call_args[0][0]
+        assert "`Chunk`" in cypher
+        assert "text_embeddings_primary" in cypher
+        assert report.chunk_edges_created == 42
+        assert report.entity_edges_created == 0
+
+    @pytest.mark.unit
+    async def test_entities_target_uses_entity_label_and_entity_index(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(
+            return_value=_make_report_rows(edges=7, processed=18)
+        )
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            report = await svc.build_similarities("g1", target="entities")
+        cypher = mock_client.execute_query.call_args[0][0]
+        assert "`__Entity__`" in cypher
+        assert "entity_embeddings" in cypher
+        assert report.entity_edges_created == 7
+        assert report.chunk_edges_created == 0
+
+    @pytest.mark.unit
+    async def test_all_target_runs_both_loops(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(
+            side_effect=[
+                _make_report_rows(edges=10, processed=20),
+                _make_report_rows(edges=5, processed=8),
+            ]
+        )
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            report = await svc.build_similarities("g1", target="all")
+        # Two queries — one per target — no deletes
+        assert mock_client.execute_query.await_count == 2
+        assert report.chunk_edges_created == 10
+        assert report.entity_edges_created == 5
+
+
+class TestTenantIsolation:
+    @pytest.mark.unit
+    async def test_graph_id_in_params_and_filtered_three_ways(self):
+        """graph_id must appear on the source node, the neighbour, AND
+        be stored on the edge — three lines of defense for tenant
+        isolation since the vector index has no per-graph partition."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows())
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("my-graph", target="chunks")
+        cypher = mock_client.execute_query.call_args[0][0]
+        params = mock_client.execute_query.call_args[0][1]
+        # Source filter
+        assert "a:`Chunk` {graph_id: $gid}" in cypher
+        # Neighbour filter
+        assert "b.graph_id = $gid" in cypher
+        # Edge property
+        assert "SIMILAR_TO {graph_id: $gid}" in cypher
+        # Graph id parameter
+        assert params["gid"] == "my-graph"
+
+
+class TestPairDedup:
+    @pytest.mark.unit
+    async def test_filter_uses_element_id_for_pair_dedup(self):
+        """One edge per unordered pair: enforce by elementId ordering.
+        Two SIMILAR_TO edges between the same nodes is a bug.
+
+        ``elementId()`` is used rather than ``a.id`` because not every
+        node label has a user-facing ``id`` property (e.g. :Chunk only
+        has ``index`` / ``text`` / ``embedding`` in the current
+        deployment), while elementId is always unique within Neo4j.
+        """
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows())
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("g", target="chunks")
+        cypher = mock_client.execute_query.call_args[0][0]
+        assert "elementId(a) < elementId(b)" in cypher
+
+
+class TestEmbeddingDimFilter:
+    @pytest.mark.unit
+    async def test_source_and_neighbour_filtered_by_expected_dim(self):
+        """Both ``a`` and ``b`` must pass the dimension check — a single
+        corrupt 6035-dim row on either side would crash the vector
+        index call with IllegalArgumentException without this filter."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows())
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("g", target="chunks")
+        cypher = mock_client.execute_query.call_args[0][0]
+        params = mock_client.execute_query.call_args[0][1]
+        assert "size(a.embedding) = $expected_dim" in cypher
+        assert "size(b.embedding) = $expected_dim" in cypher
+        assert params["expected_dim"] == 3072
+
+
+class TestThresholdsAndTopK:
+    @pytest.mark.unit
+    async def test_default_chunk_threshold_is_085(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows())
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("g", target="chunks")
+        params = mock_client.execute_query.call_args[0][1]
+        assert params["threshold"] == 0.85
+
+    @pytest.mark.unit
+    async def test_default_entity_threshold_is_092(self):
+        """Entities need tighter — short name embeddings false-positive."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows())
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("g", target="entities")
+        params = mock_client.execute_query.call_args[0][1]
+        assert params["threshold"] == 0.92
+
+    @pytest.mark.unit
+    async def test_threshold_overrides_take_effect(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(
+            side_effect=[_make_report_rows(), _make_report_rows()]
+        )
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities(
+                "g",
+                target="all",
+                threshold_chunks=0.7,
+                threshold_entities=0.99,
+            )
+        # Two calls — first chunks (0.7), then entities (0.99)
+        chunk_call = mock_client.execute_query.call_args_list[0]
+        entity_call = mock_client.execute_query.call_args_list[1]
+        assert chunk_call.args[1]["threshold"] == 0.7
+        assert entity_call.args[1]["threshold"] == 0.99
+
+    @pytest.mark.unit
+    async def test_top_k_plus_one_passed_to_vector_index(self):
+        """The vector index returns the source node at score=1.0, so we
+        request ``top_k+1`` and rely on the id-inequality filter to
+        strip it. Off-by-one here would silently drop one real
+        neighbour."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows())
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("g", target="chunks", top_k=5)
+        params = mock_client.execute_query.call_args[0][1]
+        assert params["top_k_plus_one"] == 6
+
+
+class TestForceRebuild:
+    @pytest.mark.unit
+    async def test_force_rebuild_deletes_first_then_rebuilds(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows(edges=3))
+        mock_client.execute_write_query = AsyncMock(return_value=None)
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("g", target="chunks", force_rebuild=True)
+        # One delete + one rebuild
+        delete_cypher = mock_client.execute_write_query.call_args[0][0]
+        assert "DELETE r" in delete_cypher
+        assert "`Chunk`" in delete_cypher
+
+    @pytest.mark.unit
+    async def test_no_force_rebuild_no_delete(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=_make_report_rows())
+        mock_client.execute_write_query = AsyncMock(return_value=None)
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            await svc.build_similarities("g", target="chunks")
+        mock_client.execute_write_query.assert_not_called()
+
+
+class TestReport:
+    @pytest.mark.unit
+    def test_total_edges_sums_chunks_and_entities(self):
+        report = SimilarityReport(
+            target="all", chunk_edges_created=10, entity_edges_created=4
+        )
+        assert report.total_edges() == 14
+
+    @pytest.mark.unit
+    async def test_no_neo4j_response_yields_zero_counts(self):
+        """If the driver returns empty rows, the service shouldn't
+        crash — it should report zero edges."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.similarity_service.neo4j_client", mock_client):
+            svc = SimilarityService()
+            report = await svc.build_similarities("g", target="chunks")
+        assert report.chunk_edges_created == 0
+        assert report.chunks_processed == 0


### PR DESCRIPTION
## Summary

Wires up the long-dormant SIMILAR_TO edge generation. Pre-STORY-7 zero such edges existed across all tenants despite `ENABLE_SIMILARITY_PROCESSING=True` in config — the flag was never consumed anywhere in the code. This PR adds a real `SimilarityService` + a `POST /graphs/{id}/similarity/build` endpoint and removes the dead flag.

## Live verification (Eurail graph)

**Before:** 0 SIMILAR_TO edges anywhere.

**After (`POST /similarity/build {"target":"all"}` in 4.2s):**
```
{
  "target": "all",
  "chunk_edges_created": 2283,
  "entity_edges_created": 624,
  "chunks_processed": 823,
  "entities_processed": 274,
  "elapsed_seconds": 4.2
}
```

| Source label | Count | Avg score | Min | Max |
|---|---|---|---|---|
| `:Chunk` | 2,283 | 0.902 | 0.85 | 1.00 |
| `:__Entity__` | 624 | 0.969 | 0.92 | 0.99 |

Top score-1.0 chunk pairs were near-duplicates of the same evidence record template — exactly the kind of structural duplicate the future `find_similar` agent tool needs to surface.

**Idempotency:** re-run reports the same edge count (MERGE is idempotent).
**Reject paths:** `target=bogus` → HTTP 400.

## Bugs discovered in the live audit (out of scope, but worked around)

- **Eurail has 326 entities with corrupt embeddings** — non-3072 dims (4500-12000 range). Separate ingestion bug. The service filters them out via `size(e.embedding) = $expected_dim` so they don't crash the vector-index call.
- **`:Chunk` nodes have no `id` property** in this deployment (they have `index`, `text`, `embedding`). The pair-dedup uses `elementId()` instead, which is always unique within Neo4j.

## Changes

- **NEW** [knowledge-graph-builder/app/services/similarity_service.py](knowledge-graph-builder/app/services/similarity_service.py) — `SimilarityService` with one MERGE Cypher per target. Tenant isolation defended three ways (source filter, neighbour filter, edge property). Score stored on `r.score` for future ranking.
- **NEW** `POST /api/v1/graphs/{id}/similarity/build` in [graphs.py](knowledge-graph-builder/app/api/v1/endpoints/graphs.py). Synchronous. Returns chunk/entity edge counts + elapsed seconds.
- **NEW** `SimilarityBuildRequest` / `SimilarityBuildResponse` schemas.
- **REMOVED** dead `ENABLE_SIMILARITY_PROCESSING` setting in [config.py](knowledge-graph-builder/app/core/config.py); replaced with `SIMILARITY_AUTO_TRIGGER_ON_INGEST: bool = False` (hook for a future commit that wants to auto-call the service after entity dedup, without changing existing ingest performance).
- **15 unit tests** in [test_similarity_service.py](knowledge-graph-builder/tests/unit/test_similarity_service.py) covering: per-target Cypher shape, threshold + top_k + top_k+1 param passing, tenant-isolation triple filter, elementId pair-dedup, embedding-dim filter, force_rebuild delete-then-rebuild, unknown target raises ValueError, empty Neo4j response → zero counts.
- Full unit suite: **1403 pass** (was 1388 — 15 new), same 10 pre-existing unrelated failures.

## Threshold tuning

| Target | Default | Rationale |
|---|---|---|
| `:Chunk` | 0.85 | Long-form text embeddings are semantically uniform; this catches genuinely-similar chunks |
| `:__Entity__` | 0.92 | Short entity-name embeddings false-positive easily; needs tighter cutoff |

Both overridable per request (`threshold_chunks` / `threshold_entities`).

## Note on the response shape

`chunk_edges_created` / `entity_edges_created` count MERGED edges (created OR matched). On an idempotent re-run the counts stay stable because MERGE doesn't double-write — that stability IS the idempotency signal. Distinguishing created-vs-matched would require splitting the Cypher RETURN with ON CREATE / ON MATCH counters; deferred as a follow-up if the observability tradeoff matters to callers.

## What STORY-7 unlocks

- A future `find_similar(node_id, depth=1, top_k=5)` agent tool that walks SIMILAR_TO edges
- Better grounding for chat: when `graph_search` returns a chunk, the agent can surface near-duplicates
- Densified graph for community detection re-runs

## Out of scope (follow-ups)

- Auto-trigger after ingest (the new `SIMILARITY_AUTO_TRIGGER_ON_INGEST=True` flag is a 5-line wire-up in `pipeline_service` when wanted)
- Fix the 326 corrupt entity embeddings on Eurail (separate ingestion bug)
- Celery wrapping for very large graphs (Eurail-sized completes synchronously in 4s)
- A `find_similar` agent tool (STORY-8 or a follow-up)