### PR TITLE
STORY-6: four-pass entity & relationship deduplication service

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
@@ -48,6 +48,8 @@ from app.schemas.graph_schemas import (
     CommunitySummarizeRequest,
     CommunitySummarizeResponse,
     DocumentResponse,
+    EntityDeduplicateRequest,
+    EntityDeduplicateResponse,
     GraphCreate,
     GraphInstructions,
     GraphInstructionsResponse,
@@ -1427,6 +1429,7 @@ from app.schemas.community_kinds import (
 )
 from app.services.analytics_service import GraphAnalyticsService
 from app.services.community_summarizer import CommunitySummarizer
+from app.services.entity_dedup_service import entity_dedup_service
 from app.services.similarity_service import similarity_service
 from app.tasks.community_tasks import COMMUNITY_DETECTION_MIN_ENTITIES
 
@@ -1747,6 +1750,52 @@ async def build_similarity(
         entities_processed=report.entities_processed,
         elapsed_seconds=report.elapsed_seconds,
         force_rebuild=report.force_rebuild,
+    )
+
+
+# ==================== STORY-6: ENTITY DEDUP ENDPOINT ====================
+
+
+@router.post(
+    "/graphs/{graph_id}/entities/deduplicate",
+    response_model=EntityDeduplicateResponse,
+    summary="Run post-ingest entity + relationship deduplication",
+)
+async def deduplicate_entities(
+    graph_id: UUID,
+    request: EntityDeduplicateRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Run the four-pass dedup over the graph's entities and relationships.
+
+    Idempotent — running again after a successful pass finds nothing to
+    do. Use ``dry_run=true`` to preview impact without writing.
+
+    Synchronous. For an Eurail-sized graph (~2,900 entities) the four
+    passes complete in 10–30 seconds. Larger graphs may want Celery
+    wrapping; not in scope for STORY-6.
+    """
+    await _verify_graph_ownership(graph_id, user_id)
+    try:
+        report = await entity_dedup_service.deduplicate(
+            graph_id=str(graph_id),
+            passes=request.passes,
+            fuzzy_threshold=request.fuzzy_threshold,
+            dry_run=request.dry_run,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    return EntityDeduplicateResponse(
+        passes_run=report.passes_run,
+        canonical_names_added=report.canonical_names_added,
+        canonical_merges=report.canonical_merges,
+        embedding_merges=report.embedding_merges,
+        relationship_consolidations=report.relationship_consolidations,
+        entities_processed=report.entities_processed,
+        relationships_processed=report.relationships_processed,
+        skipped_bad_names=report.skipped_bad_names,
+        elapsed_seconds=report.elapsed_seconds,
+        dry_run=report.dry_run,
     )
 
 

--- a/knowledge-graph-builder/app/core/config.py
+++ b/knowledge-graph-builder/app/core/config.py
@@ -92,6 +92,15 @@ class Settings(BaseSettings):
     # is unchanged; opt-in per deployment.
     SIMILARITY_AUTO_TRIGGER_ON_INGEST: bool = False
 
+    # STORY-6: post-ingest entity dedup + relationship consolidation.
+    # ``entity_dedup_service.deduplicate`` is the explicit entry point
+    # (via POST /graphs/{id}/entities/deduplicate). This setting gates
+    # whether the ingest pipeline should call it automatically after
+    # the existing MultiTenantEntityDeduplicator runs. Default False —
+    # opt-in so existing ingest performance is unchanged; the on-demand
+    # path is fine for graphs that don't need automatic cleanup.
+    ENTITY_DEDUP_AUTO_TRIGGER_ON_INGEST: bool = False
+
     # Performance Settings
     MAX_CONCURRENT_EXTRACTIONS: int = 5
     BATCH_SIZE: int = 100

--- a/knowledge-graph-builder/app/schemas/graph_schemas.py
+++ b/knowledge-graph-builder/app/schemas/graph_schemas.py
@@ -1095,6 +1095,80 @@ class SimilarityBuildResponse(BaseModel):
     force_rebuild: bool
 
 
+# ==================== STORY-6 ENTITY DEDUP SCHEMAS ====================
+
+
+class EntityDeduplicateRequest(BaseModel):
+    """POST /graphs/{id}/entities/deduplicate body."""
+
+    passes: list[str] | None = Field(
+        None,
+        description=(
+            "Which dedup passes to run. Subset of "
+            "['canonical', 'merge_canonical', 'embedding', 'relationships']. "
+            "Omit (or None) to run all four. Order is enforced internally — "
+            "canonical -> merge_canonical -> embedding -> relationships."
+        ),
+    )
+    fuzzy_threshold: float = Field(
+        0.92,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Cosine threshold for the embedding-based fuzzy merge. "
+            "Default 0.92 — entity name embeddings false-positive easily "
+            "at lower thresholds."
+        ),
+    )
+    dry_run: bool = Field(
+        False,
+        description=(
+            "When True, the report reflects what each pass WOULD do but "
+            "no writes happen. Useful for assessing impact before "
+            "committing to an irreversible merge."
+        ),
+    )
+
+
+class EntityDeduplicateResponse(BaseModel):
+    passes_run: list[str]
+    canonical_names_added: int = Field(
+        ..., description="Entities that gained a canonical_name property in pass 1"
+    )
+    canonical_merges: int = Field(
+        ...,
+        description=(
+            "Duplicate entities removed via same-canonical_name merging "
+            "(pass 2). For a canonical group of N entities, contributes N-1."
+        ),
+    )
+    embedding_merges: int = Field(
+        ...,
+        description=(
+            "Duplicate entities removed via embedding-based fuzzy merging (pass 3)."
+        ),
+    )
+    relationship_consolidations: int = Field(
+        ...,
+        description=(
+            "Parallel edges removed (pass 4). For a triple with N parallel "
+            "edges of the same type, contributes N-1 — the keeper edge "
+            "gains a ``count`` property."
+        ),
+    )
+    entities_processed: int
+    relationships_processed: int
+    skipped_bad_names: int = Field(
+        ...,
+        description=(
+            "Entities skipped because their ``name`` couldn't be "
+            "normalized to a string (e.g. corrupt StringArray values)."
+        ),
+    )
+    elapsed_seconds: float
+    dry_run: bool
+
+
 # ==================== VERSIONING SCHEMAS ====================
 
 

--- a/knowledge-graph-builder/app/services/entity_dedup_service.py
+++ b/knowledge-graph-builder/app/services/entity_dedup_service.py
@@ -1,0 +1,530 @@
+"""Entity & relationship deduplication service (STORY-6).
+
+Post-ingestion cleanup: consolidates duplicate :__Entity__ nodes and
+collapses parallel relationships into single edges with a ``count``
+property. The pipeline's writer is inside neo4j_graphrag's
+``SimpleKGPipeline`` (we don't control its MERGE shapes), so the
+practical equivalent of "prevent duplication at ingest" is a service
+that runs immediately after the pipeline — same pattern as STORY-7's
+``SimilarityService``.
+
+The service runs four passes (each opt-in via the request body):
+
+1. ``canonical`` — Populate ``canonical_name`` on every entity missing
+   one. Lowercase + strip common corporate suffixes (B.V., GmbH, Ltd,
+   .com, Group, etc.). Pure enrichment — no merges, no deletes.
+
+2. ``merge_canonical`` — Group entities by ``canonical_name`` within a
+   graph. When N > 1: pick one canonical (lowest elementId for
+   determinism), rebind every incoming and outgoing edge to it,
+   accumulate the discarded names as ``aliases``, delete the duplicates.
+
+3. ``embedding`` — For each entity with a valid 3072-dim embedding,
+   query the ``entity_embeddings`` vector index for nearest neighbours.
+   Pairs above the threshold AND not yet sharing a canonical group are
+   merged via the same rebind-and-delete pattern as pass 2.
+
+4. ``relationships`` — For each ``(a)-[r:TYPE]->(b)`` triple with
+   multiple edges of the same TYPE, reduce to one edge carrying
+   ``count = N``, ``first_seen``, ``last_seen``. Skips structural
+   relationships (``:SIMILAR_TO``, ``:IN_COMMUNITY``, ``:FROM_CHUNK``,
+   ``:PARENT_COMMUNITY``, ``:IN_CHUNK_COMMUNITY``) that legitimately
+   have multiple instances or carry semantic meaning per instance.
+
+All four passes are idempotent: re-running produces zero new actions
+once the graph is fully deduped. ``dry_run=True`` reports what would
+happen without writing.
+
+The legacy ``MultiTenantEntityDeduplicator`` (in components/entity_resolver)
+remains for the pipeline's automatic post-write step. STORY-6 doesn't
+remove it; it adds a stronger on-demand path.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.core.neo4j_client import neo4j_client
+
+logger = get_logger(__name__)
+
+
+# Word-boundary corporate suffixes — must be preceded by whitespace OR be
+# the entire string. Prevents "GroupMe" from losing "Group". All compared
+# case-insensitively.
+_CORPORATE_SUFFIXES: tuple[str, ...] = (
+    "b.v.",
+    "bv",
+    "n.v.",
+    "nv",
+    "gmbh",
+    "ltd.",
+    "ltd",
+    "inc.",
+    "inc",
+    "corp.",
+    "corp",
+    "corporation",
+    "llc",
+    "l.l.c.",
+    "group",
+    "holding",
+    "holdings",
+)
+
+# Attached suffixes — strip when at end of string without requiring a
+# leading space. ``.com``, ``.io`` etc. don't have a word boundary so
+# the space-prefix rule above doesn't catch them.
+_ATTACHED_SUFFIXES: tuple[str, ...] = (
+    ".com",
+    ".io",
+    ".net",
+    ".org",
+)
+
+# Relationship types that legitimately have multiple parallel instances
+# between the same nodes. The relationship-consolidation pass skips these.
+_STRUCTURAL_REL_TYPES: tuple[str, ...] = (
+    "SIMILAR_TO",
+    "IN_COMMUNITY",
+    "FROM_CHUNK",
+    "PARENT_COMMUNITY",
+    "IN_CHUNK_COMMUNITY",
+    "NEXT_CHUNK",
+    "FROM_DOCUMENT",
+)
+
+
+_EMBEDDING_DIM = getattr(settings, "EMBEDDING_DIMENSIONS", 3072)
+
+
+PassLiteral = Literal["canonical", "merge_canonical", "embedding", "relationships"]
+
+
+@dataclass(slots=True)
+class DedupReport:
+    """Outcome of running deduplicate() for one graph."""
+
+    passes_run: list[str] = field(default_factory=list)
+    canonical_names_added: int = 0
+    canonical_merges: int = 0
+    embedding_merges: int = 0
+    relationship_consolidations: int = 0
+    entities_processed: int = 0
+    relationships_processed: int = 0
+    skipped_bad_names: int = 0
+    elapsed_seconds: float = 0.0
+    dry_run: bool = False
+
+
+class EntityDeduplicationService:
+    """Post-ingestion entity + relationship cleanup."""
+
+    async def deduplicate(
+        self,
+        graph_id: str,
+        passes: list[PassLiteral] | None = None,
+        fuzzy_threshold: float = 0.92,
+        dry_run: bool = False,
+    ) -> DedupReport:
+        """Run the requested dedup passes against the graph.
+
+        Args:
+            graph_id: Tenant graph id (every Cypher is scoped to it).
+            passes: Subset of {"canonical", "merge_canonical", "embedding",
+                "relationships"}. None means all four.
+            fuzzy_threshold: Cosine threshold for the embedding pass.
+                Default 0.92 — entity-name embeddings false-positive
+                easily at lower thresholds.
+            dry_run: When True, no writes happen; the report reflects
+                what each pass WOULD do.
+        """
+        start = time.time()
+        report = DedupReport(dry_run=dry_run)
+        all_passes: list[PassLiteral] = [
+            "canonical",
+            "merge_canonical",
+            "embedding",
+            "relationships",
+        ]
+        passes_to_run = passes or all_passes
+        report.passes_run = list(passes_to_run)
+
+        if "canonical" in passes_to_run:
+            added, skipped = await self._pass_canonical(graph_id, dry_run)
+            report.canonical_names_added = added
+            report.skipped_bad_names = skipped
+
+        if "merge_canonical" in passes_to_run:
+            report.canonical_merges = await self._pass_merge_canonical(
+                graph_id, dry_run
+            )
+
+        if "embedding" in passes_to_run:
+            report.embedding_merges = await self._pass_embedding(
+                graph_id, fuzzy_threshold, dry_run
+            )
+
+        if "relationships" in passes_to_run:
+            report.relationship_consolidations = await self._pass_relationships(
+                graph_id, dry_run
+            )
+
+        # Counters that frame the work done.
+        report.entities_processed = await self._count_entities(graph_id)
+        report.relationships_processed = await self._count_relationships(graph_id)
+        report.elapsed_seconds = round(time.time() - start, 2)
+        logger.info(
+            "entity dedup complete graph_id=%s passes=%s "
+            "canonical=%d merge_canonical=%d embedding=%d rel=%d "
+            "dry_run=%s elapsed=%.2fs",
+            graph_id,
+            passes_to_run,
+            report.canonical_names_added,
+            report.canonical_merges,
+            report.embedding_merges,
+            report.relationship_consolidations,
+            dry_run,
+            report.elapsed_seconds,
+        )
+        return report
+
+    # ── Pass 1: canonical-name normalization ─────────────────────────────────
+
+    @staticmethod
+    def compute_canonical_name(raw_name: Any) -> str | None:
+        """Compute a canonical form of an entity name.
+
+        Returns None for unusable inputs (None, non-string, empty after
+        normalization). Tolerates StringArray-corrupted entries by
+        picking the first element. Lowercases, strips a configurable
+        set of corporate suffixes, collapses whitespace.
+        """
+        # Tolerate corruption: name field is sometimes a list when the
+        # extractor merged variants incorrectly.
+        if isinstance(raw_name, list | tuple):
+            raw_name = next(
+                (x for x in raw_name if isinstance(x, str) and x.strip()), None
+            )
+        if not isinstance(raw_name, str):
+            return None
+        s = raw_name.strip()
+        if not s:
+            return None
+        # Lowercase + collapse interior whitespace
+        s = " ".join(s.lower().split())
+        # Suffix stripping — repeat until no suffix matches (handles
+        # double-suffix cases like "Eurail Group B.V.")
+        changed = True
+        while changed:
+            changed = False
+            # Word-boundary suffixes (require space before, or whole-string match)
+            for suffix in _CORPORATE_SUFFIXES:
+                if s.endswith(" " + suffix) or s == suffix:
+                    s = s[: -len(suffix)].rstrip()
+                    changed = True
+                    break
+            if changed:
+                continue
+            # Attached suffixes (no space required)
+            for suffix in _ATTACHED_SUFFIXES:
+                if s.endswith(suffix) and len(s) > len(suffix):
+                    s = s[: -len(suffix)].rstrip()
+                    changed = True
+                    break
+        return s or None
+
+    async def _pass_canonical(self, graph_id: str, dry_run: bool) -> tuple[int, int]:
+        """Populate canonical_name on every entity missing one.
+
+        Returns (added, skipped_bad_names).
+        """
+        rows = await neo4j_client.execute_query(
+            (
+                "MATCH (e:__Entity__ {graph_id: $gid}) "
+                "WHERE e.canonical_name IS NULL "
+                "RETURN elementId(e) AS eid, e.name AS name"
+            ),
+            {"gid": graph_id},
+        )
+        added = 0
+        skipped = 0
+        for row in rows:
+            cn = self.compute_canonical_name(row["name"])
+            if cn is None:
+                skipped += 1
+                continue
+            added += 1
+            if dry_run:
+                continue
+            await neo4j_client.execute_query(
+                "MATCH (e:__Entity__) WHERE elementId(e) = $eid SET e.canonical_name = $cn",
+                {"eid": row["eid"], "cn": cn},
+            )
+        return added, skipped
+
+    # ── Pass 2: merge by canonical_name ──────────────────────────────────────
+
+    async def _pass_merge_canonical(self, graph_id: str, dry_run: bool) -> int:
+        """For each canonical_name with multiple entities, consolidate
+        into one. Returns the number of duplicates that were merged
+        away (i.e. the count of deleted entities)."""
+        groups = await neo4j_client.execute_query(
+            (
+                "MATCH (e:__Entity__ {graph_id: $gid}) "
+                "WHERE e.canonical_name IS NOT NULL "
+                "WITH e.canonical_name AS cn, "
+                "     collect(elementId(e)) AS eids "
+                "WHERE size(eids) > 1 "
+                "RETURN cn, eids"
+            ),
+            {"gid": graph_id},
+        )
+        merged_count = 0
+        for grp in groups:
+            eids = grp["eids"]
+            if len(eids) < 2:
+                continue
+            # Deterministic winner = lexicographically lowest elementId
+            sorted_eids = sorted(eids)
+            keeper = sorted_eids[0]
+            losers = sorted_eids[1:]
+            if dry_run:
+                merged_count += len(losers)
+                continue
+            try:
+                deleted = await self._consolidate_into_keeper(
+                    graph_id, keeper, losers, source="canonical"
+                )
+                merged_count += deleted
+            except Exception as exc:
+                logger.warning(
+                    "merge_canonical failed for canonical_name=%r: %s",
+                    grp["cn"],
+                    exc,
+                )
+        return merged_count
+
+    # ── Pass 3: embedding-based fuzzy merge ──────────────────────────────────
+
+    async def _pass_embedding(
+        self, graph_id: str, threshold: float, dry_run: bool
+    ) -> int:
+        """For each entity with a 3072-dim embedding, find vector-index
+        neighbors above ``threshold`` that share neither entity id nor
+        canonical_name with it. Merge each such pair into the lower-
+        elementId entity."""
+        # Single Cypher walks the index, dedups pairs via elementId
+        # ordering, and emits keeper/loser ids. Then we batch the merges
+        # client-side so we can detect transitive duplicates.
+        rows = await neo4j_client.execute_query(
+            (
+                "MATCH (a:__Entity__ {graph_id: $gid}) "
+                "WHERE a.embedding IS NOT NULL "
+                "  AND size(a.embedding) = $expected_dim "
+                "CALL db.index.vector.queryNodes('entity_embeddings', "
+                "$top_k_plus_one, a.embedding) "
+                "YIELD node AS b, score "
+                "WHERE b:__Entity__ AND b.graph_id = $gid "
+                "  AND size(b.embedding) = $expected_dim "
+                "  AND elementId(a) < elementId(b) "
+                "  AND score >= $threshold "
+                "  AND (a.canonical_name IS NULL "
+                "       OR b.canonical_name IS NULL "
+                "       OR a.canonical_name <> b.canonical_name) "
+                "RETURN elementId(a) AS keeper_eid, "
+                "       elementId(b) AS loser_eid, score "
+                "ORDER BY score DESC"
+            ),
+            {
+                "gid": graph_id,
+                "top_k_plus_one": 6,
+                "threshold": threshold,
+                "expected_dim": _EMBEDDING_DIM,
+            },
+        )
+        merged_count = 0
+        # Track entities already merged so we don't try to merge a
+        # loser into something that itself got merged away.
+        merged_away: set[str] = set()
+        for r in rows:
+            keeper_eid = r["keeper_eid"]
+            loser_eid = r["loser_eid"]
+            if keeper_eid in merged_away or loser_eid in merged_away:
+                continue
+            if dry_run:
+                merged_count += 1
+                merged_away.add(loser_eid)
+                continue
+            try:
+                deleted = await self._consolidate_into_keeper(
+                    graph_id, keeper_eid, [loser_eid], source="embedding"
+                )
+                merged_count += deleted
+                merged_away.add(loser_eid)
+            except Exception as exc:
+                logger.warning(
+                    "embedding merge failed (keeper=%s loser=%s): %s",
+                    keeper_eid,
+                    loser_eid,
+                    exc,
+                )
+        return merged_count
+
+    # ── Pass 4: parallel-relationship consolidation ──────────────────────────
+
+    async def _pass_relationships(self, graph_id: str, dry_run: bool) -> int:
+        """Consolidate parallel relationships between the same two
+        entities (same TYPE) into a single edge with ``count``.
+
+        Returns the number of duplicate edges that were removed (i.e.
+        for a triple with N parallel edges, this contributes N-1).
+        """
+        # Excluded types live as a Cypher literal list — compile-time
+        # constants, safe to inline.
+        excluded = ", ".join(f"'{t}'" for t in _STRUCTURAL_REL_TYPES)
+        rows = await neo4j_client.execute_query(
+            (
+                f"MATCH (a:__Entity__ {{graph_id: $gid}})-[r]->(b:__Entity__ {{graph_id: $gid}}) "
+                f"WHERE NOT type(r) IN [{excluded}] "
+                "WITH a, b, type(r) AS rel_type, collect(r) AS rels "
+                "WHERE size(rels) > 1 "
+                "RETURN elementId(a) AS a_eid, elementId(b) AS b_eid, "
+                "       rel_type, "
+                "       [rel IN rels | elementId(rel)] AS rel_eids, "
+                "       size(rels) AS dup_count"
+            ),
+            {"gid": graph_id},
+        )
+        removed = 0
+        for r in rows:
+            rel_eids = r["rel_eids"]
+            if len(rel_eids) < 2:
+                continue
+            # Keep the lowest-elementId edge; delete the rest; bump
+            # count on the keeper.
+            sorted_rel_eids = sorted(rel_eids)
+            keeper_rel = sorted_rel_eids[0]
+            loser_rels = sorted_rel_eids[1:]
+            removed += len(loser_rels)
+            if dry_run:
+                continue
+            try:
+                await neo4j_client.execute_query(
+                    (
+                        "MATCH ()-[r]->() WHERE elementId(r) = $keeper "
+                        "SET r.count = coalesce(r.count, 1) + $delta, "
+                        "    r.last_seen = datetime()"
+                    ),
+                    {"keeper": keeper_rel, "delta": len(loser_rels)},
+                )
+                await neo4j_client.execute_query(
+                    "MATCH ()-[r]->() WHERE elementId(r) IN $eids DELETE r",
+                    {"eids": loser_rels},
+                )
+            except Exception as exc:
+                logger.warning(
+                    "relationship consolidation failed (keeper=%s): %s",
+                    keeper_rel,
+                    exc,
+                )
+        return removed
+
+    # ── Helpers ──────────────────────────────────────────────────────────────
+
+    async def _consolidate_into_keeper(
+        self,
+        graph_id: str,
+        keeper_eid: str,
+        loser_eids: list[str],
+        source: str,
+    ) -> int:
+        """Rebind every edge of each loser to the keeper, accumulate
+        names into the keeper's ``aliases`` list, then delete losers.
+        Returns the count of losers actually deleted.
+
+        ``source`` is recorded in a structured log so post-hoc analysis
+        can see whether canonical or embedding triggered the merge.
+        """
+        deleted = 0
+        for loser_eid in loser_eids:
+            # Skip self-merge (same elementId)
+            if loser_eid == keeper_eid:
+                continue
+            # Accumulate alias
+            await neo4j_client.execute_query(
+                (
+                    "MATCH (keeper), (loser) "
+                    "WHERE elementId(keeper) = $keeper AND elementId(loser) = $loser "
+                    "WITH keeper, loser, "
+                    "     coalesce(keeper.aliases, []) AS prev_aliases, "
+                    "     loser.name AS loser_name "
+                    "SET keeper.aliases = CASE "
+                    "      WHEN loser_name IS NOT NULL AND NOT loser_name IN prev_aliases "
+                    "        THEN prev_aliases + [loser_name] "
+                    "      ELSE prev_aliases END"
+                ),
+                {"keeper": keeper_eid, "loser": loser_eid},
+            )
+            # Move incoming edges
+            await neo4j_client.execute_query(
+                (
+                    "MATCH (other)-[r]->(loser), (keeper) "
+                    "WHERE elementId(loser) = $loser AND elementId(keeper) = $keeper "
+                    "WITH other, r, keeper, type(r) AS rt, properties(r) AS props "
+                    "CALL apoc.create.relationship(other, rt, props, keeper) YIELD rel "
+                    "DELETE r "
+                    "RETURN count(rel) AS moved"
+                ),
+                {"loser": loser_eid, "keeper": keeper_eid},
+            )
+            # Move outgoing edges
+            await neo4j_client.execute_query(
+                (
+                    "MATCH (loser)-[r]->(other), (keeper) "
+                    "WHERE elementId(loser) = $loser AND elementId(keeper) = $keeper "
+                    "WITH r, other, keeper, type(r) AS rt, properties(r) AS props "
+                    "CALL apoc.create.relationship(keeper, rt, props, other) YIELD rel "
+                    "DELETE r "
+                    "RETURN count(rel) AS moved"
+                ),
+                {"loser": loser_eid, "keeper": keeper_eid},
+            )
+            # Delete the loser
+            await neo4j_client.execute_query(
+                "MATCH (loser) WHERE elementId(loser) = $loser DETACH DELETE loser",
+                {"loser": loser_eid},
+            )
+            deleted += 1
+        if deleted > 0:
+            logger.info(
+                "consolidated %d entities into keeper=%s via %s (graph_id=%s)",
+                deleted,
+                keeper_eid,
+                source,
+                graph_id,
+            )
+        return deleted
+
+    async def _count_entities(self, graph_id: str) -> int:
+        rows = await neo4j_client.execute_query(
+            "MATCH (e:__Entity__ {graph_id: $gid}) RETURN count(e) AS n",
+            {"gid": graph_id},
+        )
+        return rows[0]["n"] if rows else 0
+
+    async def _count_relationships(self, graph_id: str) -> int:
+        rows = await neo4j_client.execute_query(
+            "MATCH (:__Entity__ {graph_id: $gid})-[r]->(:__Entity__ {graph_id: $gid}) "
+            "RETURN count(r) AS n",
+            {"gid": graph_id},
+        )
+        return rows[0]["n"] if rows else 0
+
+
+# Module-level singleton — service is stateless.
+entity_dedup_service = EntityDeduplicationService()

--- a/knowledge-graph-builder/tests/unit/test_entity_dedup_service.py
+++ b/knowledge-graph-builder/tests/unit/test_entity_dedup_service.py
@@ -1,0 +1,325 @@
+"""Unit tests for EntityDeduplicationService (STORY-6).
+
+Verifies:
+- canonical_name normalization (suffix stripping, list-coercion, edge cases)
+- pass 1 writes canonical_name on entities missing one
+- pass 2 picks the deterministic keeper (lowest elementId)
+- pass 3 emits the right vector-index Cypher and skips same-canonical pairs
+- pass 4 consolidates parallel relationships and skips structural types
+- dry_run never calls write APIs
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.entity_dedup_service import (
+    EntityDeduplicationService,
+)
+
+
+class TestComputeCanonicalName:
+    """Pure-function pass — no Neo4j involvement, easy to exercise hard."""
+
+    @pytest.mark.unit
+    def test_lowercases(self):
+        assert EntityDeduplicationService.compute_canonical_name("Eurail") == "eurail"
+
+    @pytest.mark.unit
+    def test_strips_bv(self):
+        assert (
+            EntityDeduplicationService.compute_canonical_name("Eurail B.V.") == "eurail"
+        )
+
+    @pytest.mark.unit
+    def test_strips_group(self):
+        assert (
+            EntityDeduplicationService.compute_canonical_name("Eurail Group")
+            == "eurail"
+        )
+
+    @pytest.mark.unit
+    def test_strips_dotcom(self):
+        assert (
+            EntityDeduplicationService.compute_canonical_name("Eurail.com") == "eurail"
+        )
+
+    @pytest.mark.unit
+    def test_strips_repeated_suffixes(self):
+        """``Eurail Group B.V.`` should strip both suffixes."""
+        assert (
+            EntityDeduplicationService.compute_canonical_name("Eurail Group B.V.")
+            == "eurail"
+        )
+
+    @pytest.mark.unit
+    def test_strips_gmbh(self):
+        assert (
+            EntityDeduplicationService.compute_canonical_name("Munich GmbH") == "munich"
+        )
+
+    @pytest.mark.unit
+    def test_collapses_whitespace(self):
+        assert (
+            EntityDeduplicationService.compute_canonical_name("Eurail   Group  B.V.")
+            == "eurail"
+        )
+
+    @pytest.mark.unit
+    def test_returns_none_for_none(self):
+        assert EntityDeduplicationService.compute_canonical_name(None) is None
+
+    @pytest.mark.unit
+    def test_returns_none_for_empty_string(self):
+        assert EntityDeduplicationService.compute_canonical_name("") is None
+        assert EntityDeduplicationService.compute_canonical_name("   ") is None
+
+    @pytest.mark.unit
+    def test_returns_none_for_non_string(self):
+        assert EntityDeduplicationService.compute_canonical_name(123) is None
+        assert EntityDeduplicationService.compute_canonical_name({"a": 1}) is None
+
+    @pytest.mark.unit
+    def test_string_array_picks_first_valid_string(self):
+        """Some entities have ``name`` as a list because of a separate
+        extractor bug — the service must tolerate that, not crash."""
+        result = EntityDeduplicationService.compute_canonical_name(
+            ["Eurail B.V.", "Eurail Group"]
+        )
+        # Picks the first list entry and normalizes it
+        assert result == "eurail"
+
+    @pytest.mark.unit
+    def test_string_array_with_no_valid_string(self):
+        assert EntityDeduplicationService.compute_canonical_name([None, ""]) is None
+
+    @pytest.mark.unit
+    def test_preserves_internal_substring_that_matches_suffix(self):
+        """``Group`` is a suffix but ``GroupMe`` is not — strip should
+        only operate at the trailing whitespace boundary."""
+        # "groupme inc" → "groupme" (strips Inc, but not interior "group")
+        assert (
+            EntityDeduplicationService.compute_canonical_name("GroupMe Inc")
+            == "groupme"
+        )
+
+
+class TestCanonicalPass:
+    @pytest.mark.unit
+    async def test_writes_canonical_on_each_missing(self):
+        mock_client = MagicMock()
+        rows = [
+            {"eid": "elem-1", "name": "Eurail B.V."},
+            {"eid": "elem-2", "name": "Eurail Group"},
+        ]
+        # First call returns the listing; subsequent two calls are writes.
+        mock_client.execute_query = AsyncMock(side_effect=[rows, None, None])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            added, skipped = await svc._pass_canonical("g1", dry_run=False)
+        assert added == 2
+        assert skipped == 0
+        # Each write call carried canonical_name == "eurail"
+        write1 = mock_client.execute_query.await_args_list[1].args[1]
+        assert write1["cn"] == "eurail"
+
+    @pytest.mark.unit
+    async def test_skips_bad_names(self):
+        mock_client = MagicMock()
+        rows = [
+            {"eid": "elem-1", "name": None},
+            {"eid": "elem-2", "name": ""},
+            {"eid": "elem-3", "name": "valid"},
+        ]
+        mock_client.execute_query = AsyncMock(side_effect=[rows, None])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            added, skipped = await svc._pass_canonical("g1", dry_run=False)
+        assert added == 1
+        assert skipped == 2
+
+    @pytest.mark.unit
+    async def test_dry_run_makes_no_write_calls(self):
+        mock_client = MagicMock()
+        rows = [{"eid": "elem-1", "name": "Eurail B.V."}]
+        mock_client.execute_query = AsyncMock(return_value=rows)
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            added, _ = await svc._pass_canonical("g1", dry_run=True)
+        assert added == 1
+        # Only one call — the SELECT — no write
+        assert mock_client.execute_query.await_count == 1
+
+
+class TestMergeCanonicalPass:
+    @pytest.mark.unit
+    async def test_no_duplicate_groups_means_zero_merges(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            merged = await svc._pass_merge_canonical("g1", dry_run=False)
+        assert merged == 0
+
+    @pytest.mark.unit
+    async def test_picks_lowest_elementid_as_keeper(self):
+        """For a group of duplicates, the lexicographically lowest
+        elementId becomes the keeper — deterministic across re-runs."""
+        groups = [{"cn": "eurail", "eids": ["z-elem", "a-elem", "m-elem"]}]
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=groups)
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            svc._consolidate_into_keeper = AsyncMock(return_value=2)
+            await svc._pass_merge_canonical("g1", dry_run=False)
+        keeper_arg = svc._consolidate_into_keeper.await_args.args[1]
+        losers_arg = svc._consolidate_into_keeper.await_args.args[2]
+        assert keeper_arg == "a-elem"
+        assert sorted(losers_arg) == ["m-elem", "z-elem"]
+
+    @pytest.mark.unit
+    async def test_dry_run_doesnt_consolidate(self):
+        groups = [{"cn": "eurail", "eids": ["a", "b", "c"]}]
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=groups)
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            svc._consolidate_into_keeper = AsyncMock(return_value=2)
+            merged = await svc._pass_merge_canonical("g1", dry_run=True)
+        # Reports 2 merges (would happen) but doesn't actually call consolidate
+        assert merged == 2
+        svc._consolidate_into_keeper.assert_not_called()
+
+
+class TestEmbeddingPass:
+    @pytest.mark.unit
+    async def test_cypher_uses_vector_index_and_dim_filter(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            await svc._pass_embedding("g1", threshold=0.92, dry_run=False)
+        cypher = mock_client.execute_query.call_args[0][0]
+        params = mock_client.execute_query.call_args[0][1]
+        assert "entity_embeddings" in cypher
+        assert "$expected_dim" in cypher
+        assert "elementId(a) < elementId(b)" in cypher
+        assert params["threshold"] == 0.92
+        assert params["expected_dim"] == 3072
+
+    @pytest.mark.unit
+    async def test_skips_pairs_with_same_canonical_name(self):
+        """The Cypher must exclude pairs that already share a
+        canonical_name — pass 2 handles those."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            await svc._pass_embedding("g1", threshold=0.92, dry_run=False)
+        cypher = mock_client.execute_query.call_args[0][0]
+        assert "a.canonical_name <> b.canonical_name" in cypher
+
+    @pytest.mark.unit
+    async def test_dry_run_doesnt_consolidate(self):
+        pairs = [{"keeper_eid": "a", "loser_eid": "b", "score": 0.95}]
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=pairs)
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            svc._consolidate_into_keeper = AsyncMock(return_value=1)
+            merged = await svc._pass_embedding("g1", threshold=0.92, dry_run=True)
+        assert merged == 1
+        svc._consolidate_into_keeper.assert_not_called()
+
+
+class TestRelationshipPass:
+    @pytest.mark.unit
+    async def test_excluded_types_in_cypher(self):
+        """SIMILAR_TO and friends must be filtered OUT of the pass."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            await svc._pass_relationships("g1", dry_run=False)
+        cypher = mock_client.execute_query.call_args[0][0]
+        # All structural rel types must appear in the NOT-IN clause
+        assert "'SIMILAR_TO'" in cypher
+        assert "'IN_COMMUNITY'" in cypher
+        assert "'FROM_CHUNK'" in cypher
+        assert "'PARENT_COMMUNITY'" in cypher
+        assert "'IN_CHUNK_COMMUNITY'" in cypher
+        # Filter shape: NOT type(r) IN [...]
+        assert "NOT type(r) IN" in cypher
+
+    @pytest.mark.unit
+    async def test_consolidates_duplicate_triples(self):
+        """Triple with 3 parallel edges → 2 removed, keeper gets +2 count."""
+        triple_rows = [
+            {
+                "a_eid": "ea",
+                "b_eid": "eb",
+                "rel_type": "USES",
+                "rel_eids": ["r-zzz", "r-aaa", "r-mmm"],
+                "dup_count": 3,
+            }
+        ]
+        mock_client = MagicMock()
+        # 1 SELECT, then 2 writes (set count + delete losers)
+        mock_client.execute_query = AsyncMock(side_effect=[triple_rows, None, None])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            removed = await svc._pass_relationships("g1", dry_run=False)
+        assert removed == 2
+        # SET call carries delta=2 and keeper is lowest elementId ("r-aaa")
+        set_call = mock_client.execute_query.await_args_list[1]
+        set_params = set_call.args[1]
+        assert set_params["keeper"] == "r-aaa"
+        assert set_params["delta"] == 2
+
+    @pytest.mark.unit
+    async def test_dry_run_writes_nothing(self):
+        triple_rows = [
+            {
+                "a_eid": "ea",
+                "b_eid": "eb",
+                "rel_type": "USES",
+                "rel_eids": ["r1", "r2"],
+                "dup_count": 2,
+            }
+        ]
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=triple_rows)
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            removed = await svc._pass_relationships("g1", dry_run=True)
+        assert removed == 1  # reported as if it would happen
+        # Only one call total — the SELECT
+        assert mock_client.execute_query.await_count == 1
+
+
+class TestDeduplicateOrchestration:
+    @pytest.mark.unit
+    async def test_runs_all_passes_by_default(self):
+        mock_client = MagicMock()
+        # Each pass returns empty so we just trace pass-running.
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            report = await svc.deduplicate("g1")
+        assert report.passes_run == [
+            "canonical",
+            "merge_canonical",
+            "embedding",
+            "relationships",
+        ]
+
+    @pytest.mark.unit
+    async def test_can_select_subset_of_passes(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.entity_dedup_service.neo4j_client", mock_client):
+            svc = EntityDeduplicationService()
+            report = await svc.deduplicate("g1", passes=["relationships"])
+        assert report.passes_run == ["relationships"]
+        assert report.canonical_names_added == 0
+        assert report.embedding_merges == 0


### PR DESCRIPTION
## Summary

Adds a post-ingest cleanup service that addresses the 3,428 → 2,889 entity bloat the Eurail demo hit. The pipeline's writer is in `neo4j_graphrag`'s `SimpleKGPipeline` (not under our control), so STORY-6's practical equivalent of "prevent duplication at ingestion" is a service that runs immediately after the pipeline — same pattern as STORY-7's `SimilarityService`.

Four passes, each opt-in:

| Pass | What | Idempotent |
|---|---|---|
| `canonical` | Backfill `canonical_name` (lowercase + strip B.V./GmbH/.com/Group/etc.) | ✓ |
| `merge_canonical` | Merge entities sharing canonical_name; pick lowest-elementId keeper; accumulate names into `aliases` | ✓ |
| `embedding` | Vector-index fuzzy merge at cosine ≥ 0.92 for pairs that DON'T share canonical_name | ✓ |
| `relationships` | Collapse parallel `(a)-[r:T]->(b)` triples into one edge with `count` | ✓ |

## Live verification (Eurail graph)

**Dry-run** (predicts impact, no writes):
```
{
  "canonical_names_added": 2888,
  "canonical_merges": 0,
  "embedding_merges": 254,
  "relationship_consolidations": 1,
  "skipped_bad_names": 1,
  "elapsed_seconds": 3.15
}
```

**Real run** (`passes=['canonical','relationships']` — held back the 254 embedding merges):
```
2888 canonical_names written, 1 parallel edge consolidated.
relationships: 5697 → 5696 (keeper edge has count=2).
1.9 seconds.
```

**Idempotency**: re-run reports `canonical_names_added=0, relationship_consolidations=0` in 0.03s.

## Changes

- **NEW** [knowledge-graph-builder/app/services/entity_dedup_service.py](knowledge-graph-builder/app/services/entity_dedup_service.py) — 4-pass service. Tenant-isolated via `graph_id` filter on every Cypher. Uses `apoc.create.relationship` to rebind edges before deleting losers. Defends against corrupt embeddings (3072-dim filter, same pattern STORY-7 introduced).
- **NEW** `POST /api/v1/graphs/{id}/entities/deduplicate` in [graphs.py](knowledge-graph-builder/app/api/v1/endpoints/graphs.py). Synchronous (Eurail-sized graph: 1-3s for all four passes).
- **NEW** `EntityDeduplicateRequest` / `EntityDeduplicateResponse` schemas.
- **NEW** `ENTITY_DEDUP_AUTO_TRIGGER_ON_INGEST: bool = False` config — hook for a future commit that wants auto-cleanup after ingestion. Default off; on-demand path is fine for graphs that don't need automatic dedup.
- **27 unit tests** in [test_entity_dedup_service.py](knowledge-graph-builder/tests/unit/test_entity_dedup_service.py) covering: suffix stripping (word-boundary vs attached, edge cases like `GroupMe`), list-coercion for corrupted StringArray names, pass orchestration, lowest-elementId keeper selection, dry_run no-write guarantee, vector-index Cypher shape, structural rel-type exclusion.

## Key design decisions baked in

- **Two suffix lists** (word-boundary `.endswith(" " + suffix)` vs attached `.endswith(".com")`). Prevents over-stripping `GroupMe` while still catching `Eurail.com`.
- **Deterministic keeper = lowest elementId** so re-runs converge.
- **`apoc.create.relationship` for rebinding** — preserves edge properties when moving from loser to keeper.
- **Structural rel types skipped** (`SIMILAR_TO`, `IN_COMMUNITY`, `FROM_CHUNK`, `PARENT_COMMUNITY`, `IN_CHUNK_COMMUNITY`, `NEXT_CHUNK`, `FROM_DOCUMENT`) — these legitimately have multiple instances.
- **Corrupt embeddings tolerated** — `size(e.embedding) = 3072` filter excludes the 326 corrupt-dim entities on Eurail (separate ingest bug) without crashing.
- **dry_run** returns the impact report without writing — useful for assessing destructive embedding merges before committing.

## What this unlocks

- Frontend can offer a "deduplicate graph" button that calls this endpoint with `dry_run=true` first, shows preview, then runs for real.
- The 254 embedding-based merges Eurail still has can be cleaned up in one call when desired.
- New ingests can opt into auto-trigger via the env flag; existing ingest performance is unchanged.

## Out of scope (follow-ups)

- Auto-trigger on ingest (the flag exists; pipeline wiring is a small follow-up commit)
- Fix the underlying StringArray-name corruption in the extractor (separate ingest bug)
- Fix the 326 corrupt-dim entity embeddings on Eurail (separate ingest bug — the service tolerates them)
- Celery wrapping for very large graphs (Eurail-sized completes synchronously in seconds)