### PR TITLE
STORY-9: structured (JSON-record) ingest endpoint

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
@@ -70,6 +70,8 @@ from app.schemas.graph_schemas import (
     RollbackResponse,
     SimilarityBuildRequest,
     SimilarityBuildResponse,
+    StructuredIngestRequest,
+    StructuredIngestResponse,
     TimelineEvent,
     TimelineResponse,
     UpdateTemporalBoundsRequest,
@@ -1431,6 +1433,10 @@ from app.services.analytics_service import GraphAnalyticsService
 from app.services.community_summarizer import CommunitySummarizer
 from app.services.entity_dedup_service import entity_dedup_service
 from app.services.similarity_service import similarity_service
+from app.services.structured_ingest_service import (
+    RelationshipMapping,
+    structured_ingest_service,
+)
 from app.tasks.community_tasks import COMMUNITY_DETECTION_MIN_ENTITIES
 
 
@@ -1796,6 +1802,73 @@ async def deduplicate_entities(
         skipped_bad_names=report.skipped_bad_names,
         elapsed_seconds=report.elapsed_seconds,
         dry_run=report.dry_run,
+    )
+
+
+# ==================== STORY-9: STRUCTURED INGEST ENDPOINT ====================
+
+
+@router.post(
+    "/graphs/{graph_id}/ingest-records",
+    response_model=StructuredIngestResponse,
+    summary="Ingest a list of JSON records directly as graph entities",
+    responses={
+        400: {"description": "Invalid label or relationship mapping"},
+    },
+)
+async def ingest_structured_records(
+    graph_id: UUID,
+    request: StructuredIngestRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Ingest JSON records as graph entities without going through the
+    text → chunk → LLM-extract pipeline.
+
+    Each record's id (named by ``id_field``) is the MERGE key, so
+    re-running the same records is a no-op. Primitive values become
+    properties; nested dicts and lists-of-dicts are JSON-stringified;
+    lists of primitives become Neo4j arrays.
+
+    Optional ``relationships`` mappings turn foreign-key-style fields
+    into typed edges to MERGE'd target entities. The target entities
+    are created on demand and counted under
+    ``related_entities_created``.
+
+    For long-form text content that should be chunked and embedded,
+    use the regular ``POST /graphs/{id}/ingest`` endpoint instead;
+    this endpoint is for structured inputs that already have the
+    schema embedded in their field names.
+    """
+    await _verify_graph_ownership(graph_id, user_id)
+
+    try:
+        report = await structured_ingest_service.ingest_records(
+            graph_id=str(graph_id),
+            records=request.records,
+            label=request.label,
+            id_field=request.id_field,
+            relationships=[
+                RelationshipMapping(
+                    from_field=r.from_field,
+                    to_label=r.to_label,
+                    rel_type=r.rel_type,
+                    to_id_field=r.to_id_field,
+                )
+                for r in request.relationships
+            ],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+    return StructuredIngestResponse(
+        label=report.label,
+        records_processed=report.records_processed,
+        entities_created_or_updated=report.entities_created_or_updated,
+        relationships_created=report.relationships_created,
+        related_entities_created=report.related_entities_created,
+        skipped=report.skipped,
+        skip_reasons=report.skip_reasons,
+        elapsed_seconds=report.elapsed_seconds,
     )
 
 

--- a/knowledge-graph-builder/app/schemas/graph_schemas.py
+++ b/knowledge-graph-builder/app/schemas/graph_schemas.py
@@ -1130,6 +1130,102 @@ class EntityDeduplicateRequest(BaseModel):
     )
 
 
+# ==================== STORY-9 STRUCTURED INGEST SCHEMAS ====================
+
+
+class StructuredIngestRelationshipMapping(BaseModel):
+    """One field-to-edge rule for the structured ingest body."""
+
+    from_field: str = Field(
+        ...,
+        description=(
+            "Property on each record whose value identifies a target "
+            "entity. e.g. 'company_id' on an EvidenceRecord points at "
+            "a Company entity."
+        ),
+    )
+    to_label: str = Field(
+        ...,
+        description=("Neo4j label of the target entity. Alphanumeric + underscore."),
+    )
+    rel_type: str = Field(
+        ...,
+        description="Relationship type. ALL_CAPS_WITH_UNDERSCORES.",
+    )
+    to_id_field: str = Field(
+        "id",
+        description=(
+            "Property on the target entity that matches the source's "
+            "from_field value. Defaults to 'id'."
+        ),
+    )
+
+
+class StructuredIngestRequest(BaseModel):
+    """POST /graphs/{id}/ingest-records body."""
+
+    records: list[dict[str, Any]] = Field(
+        ...,
+        description=(
+            "List of JSON records. Each dict becomes one entity. The "
+            "field named by ``id_field`` (default 'id') identifies the "
+            "entity for MERGE — re-running the same record is a no-op."
+        ),
+    )
+    label: str = Field(
+        ...,
+        description=(
+            "Neo4j label for the resulting entities. Alphanumeric + "
+            "underscore only. Examples: 'EvidenceRecord', 'Company', "
+            "'Product'."
+        ),
+    )
+    id_field: str = Field(
+        "id",
+        description="Record key that holds the entity id. Default 'id'.",
+    )
+    relationships: list[StructuredIngestRelationshipMapping] = Field(
+        default_factory=list,
+        description=(
+            "Optional edge mappings. For each record's ``from_field`` "
+            "value, MERGE a target entity of ``to_label`` and create "
+            "the typed edge."
+        ),
+    )
+
+
+class StructuredIngestResponse(BaseModel):
+    label: str
+    records_processed: int = Field(
+        ...,
+        description=(
+            "Records the service successfully MERGED into the graph "
+            "(excluding skipped)."
+        ),
+    )
+    entities_created_or_updated: int = Field(
+        ..., description="Source entities MERGED (one per processed record)."
+    )
+    relationships_created: int = Field(
+        ...,
+        description=(
+            "Edges created or matched by the relationship mappings. "
+            "Re-running with the same records bumps the ``count`` "
+            "property on each matched edge rather than creating new edges."
+        ),
+    )
+    related_entities_created: int = Field(
+        ...,
+        description=(
+            "Newly-created target entities from relationship mappings "
+            "(MERGEd target nodes that didn't exist before)."
+        ),
+    )
+    skipped: int
+    skip_reasons: dict[str, int]
+    elapsed_seconds: float
+
+
 class EntityDeduplicateResponse(BaseModel):
     passes_run: list[str]
     canonical_names_added: int = Field(

--- a/knowledge-graph-builder/app/services/structured_ingest_service.py
+++ b/knowledge-graph-builder/app/services/structured_ingest_service.py
@@ -1,0 +1,333 @@
+"""Structured-data ingestion (STORY-9).
+
+Pre-STORY-9 the only ingest path was text → chunk → LLM-extract → graph,
+which is wasteful and lossy for inputs that already have explicit
+structure (JSON records, CSV rows, RDB tables). STORY-9 adds a
+structured ingest path: every JSON record becomes one entity with
+typed properties and optional relationships to other entities via
+foreign-key-style fields.
+
+What this service does NOT do (intentional scope cuts):
+- Run the LLM extractor — the structure is already known, no need.
+- Auto-infer relationships beyond the explicit ``relationships`` mapping.
+- Chunk and embed long text fields — caller can do that via the
+  existing /ingest endpoint when needed (or via an
+  agent-driven flow planned for STORY-10).
+
+Field mapping rules (applied to every record):
+- ``id_field`` (default ``"id"``) identifies the entity. Required.
+- Primitive values (str, int, float, bool) → entity properties verbatim.
+- ``None`` → property dropped.
+- Lists of primitives → entity property as Neo4j array.
+- Lists of dicts or nested dicts → JSON-stringified property (callers
+  needing rich child nodes should issue a follow-up
+  ``ingest-records`` call for those).
+- ``relationships`` list maps a record field to an outgoing edge:
+  ``{"from_field": "company_id", "to_label": "Company",
+  "rel_type": "ABOUT", "to_id_field": "id"}`` — for each record's
+  ``company_id`` value, MERGE a Company node (id = that value) and
+  create the typed edge. ``to_id_field`` is the property on the
+  target node that identifies it (default ``"id"``).
+
+All Cypher is parameterized. Tenant isolation enforced via
+``graph_id`` set on every entity and via the MATCH clauses.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.core.logging import get_logger
+from app.core.neo4j_client import neo4j_client
+
+logger = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class RelationshipMapping:
+    """One field-to-edge rule."""
+
+    from_field: str
+    to_label: str
+    rel_type: str
+    to_id_field: str = "id"
+
+
+@dataclass(slots=True)
+class IngestReport:
+    """Outcome of one ingest_records call."""
+
+    label: str
+    records_processed: int = 0
+    entities_created_or_updated: int = 0
+    relationships_created: int = 0
+    related_entities_created: int = 0
+    skipped: int = 0
+    skip_reasons: dict[str, int] = field(default_factory=dict)
+    elapsed_seconds: float = 0.0
+
+
+class StructuredIngestService:
+    """Idempotent JSON-record → graph ingest."""
+
+    async def ingest_records(
+        self,
+        graph_id: str,
+        records: list[dict[str, Any]],
+        label: str,
+        id_field: str = "id",
+        relationships: list[RelationshipMapping] | None = None,
+    ) -> IngestReport:
+        """Ingest a list of JSON records into the graph.
+
+        Args:
+            graph_id: Tenant graph id (set on every entity).
+            records: List of JSON-decoded dicts. Each dict becomes one entity.
+            label: Neo4j label for the resulting entities (e.g.
+                ``"EvidenceRecord"``). Must be alphanumeric + underscore.
+            id_field: Name of the dict key that holds the entity id.
+                Records without this key are skipped.
+            relationships: Optional list of edge mappings. For each
+                mapping, the record's value at ``from_field`` becomes
+                the target entity's id (under ``to_label``).
+        """
+        start = time.time()
+        report = IngestReport(label=label)
+        if not _is_safe_label(label):
+            raise ValueError(
+                f"Invalid label {label!r}: only alphanumeric characters and "
+                "underscore allowed"
+            )
+
+        relationships = list(relationships or [])
+        for rmap in relationships:
+            if not _is_safe_label(rmap.to_label):
+                raise ValueError(
+                    f"Invalid relationship to_label {rmap.to_label!r}: only "
+                    "alphanumeric characters and underscore allowed"
+                )
+            if not _is_safe_rel_type(rmap.rel_type):
+                raise ValueError(
+                    f"Invalid rel_type {rmap.rel_type!r}: must match ^[A-Z][A-Z0-9_]*$"
+                )
+
+        # Pre-flight: validate every record has the id field and a
+        # plausible value. Better to fail fast than half-ingest.
+        for rec in records:
+            if not isinstance(rec, dict):
+                report.skipped += 1
+                _bump(report.skip_reasons, "not_a_dict")
+                continue
+            entity_id = rec.get(id_field)
+            if entity_id is None or not isinstance(entity_id, str | int):
+                report.skipped += 1
+                _bump(report.skip_reasons, "missing_or_invalid_id")
+                continue
+
+            # Build the property map: primitives + array-of-primitives
+            # passed verbatim; complex types JSON-stringified.
+            props = _record_to_properties(rec, id_field=id_field)
+
+            try:
+                await self._merge_entity(
+                    graph_id=graph_id,
+                    label=label,
+                    entity_id=str(entity_id),
+                    properties=props,
+                )
+                report.entities_created_or_updated += 1
+            except Exception as exc:
+                logger.warning(
+                    "structured_ingest: failed to merge entity %s/%s: %s",
+                    label,
+                    entity_id,
+                    exc,
+                )
+                report.skipped += 1
+                _bump(report.skip_reasons, "merge_failed")
+                continue
+
+            # Process relationships
+            for rmap in relationships:
+                raw_target = rec.get(rmap.from_field)
+                if raw_target is None:
+                    continue
+                # Allow a list of target ids — emit one edge per element.
+                target_ids = (
+                    raw_target if isinstance(raw_target, list) else [raw_target]
+                )
+                for tid in target_ids:
+                    if not isinstance(tid, str | int) or tid == "":
+                        continue
+                    try:
+                        created = await self._upsert_relationship(
+                            graph_id=graph_id,
+                            from_label=label,
+                            from_id=str(entity_id),
+                            to_label=rmap.to_label,
+                            to_id_field=rmap.to_id_field,
+                            to_id=str(tid),
+                            rel_type=rmap.rel_type,
+                        )
+                        report.relationships_created += 1
+                        if created:
+                            report.related_entities_created += 1
+                    except Exception as exc:
+                        logger.warning(
+                            "structured_ingest: failed to link %s/%s -[%s]-> %s/%s: %s",
+                            label,
+                            entity_id,
+                            rmap.rel_type,
+                            rmap.to_label,
+                            tid,
+                            exc,
+                        )
+
+            report.records_processed += 1
+
+        report.elapsed_seconds = round(time.time() - start, 2)
+        logger.info(
+            "structured_ingest complete graph_id=%s label=%s "
+            "records=%d entities=%d rels=%d skipped=%d elapsed=%.2fs",
+            graph_id,
+            label,
+            report.records_processed,
+            report.entities_created_or_updated,
+            report.relationships_created,
+            report.skipped,
+            report.elapsed_seconds,
+        )
+        return report
+
+    # ── private ──────────────────────────────────────────────────────────────
+
+    async def _merge_entity(
+        self,
+        graph_id: str,
+        label: str,
+        entity_id: str,
+        properties: dict[str, Any],
+    ) -> None:
+        """MERGE entity by (graph_id, id). SET property map.
+
+        Label name has been validated by ``_is_safe_label`` — safe for
+        f-string interpolation. graph_id and id passed as parameters.
+        """
+        # Strip ``id`` from properties so we don't overwrite the MERGE key
+        # with a different value.
+        props = {k: v for k, v in properties.items() if k != "id"}
+        await neo4j_client.execute_query(
+            (
+                f"MERGE (e:`{label}`:__Entity__ {{id: $id, graph_id: $gid}}) "
+                "SET e += $props, "
+                "    e.updated_at = datetime(), "
+                "    e.ingestion_source = 'structured_ingest'"
+            ),
+            {"id": entity_id, "gid": graph_id, "props": props},
+        )
+
+    async def _upsert_relationship(
+        self,
+        graph_id: str,
+        from_label: str,
+        from_id: str,
+        to_label: str,
+        to_id_field: str,
+        to_id: str,
+        rel_type: str,
+    ) -> bool:
+        """MERGE target entity if absent; MERGE typed edge from→to.
+
+        Returns True when the target entity was newly created (so
+        callers can count related-entity creations).
+
+        Labels and rel_type pre-validated by ``_is_safe_label`` /
+        ``_is_safe_rel_type``. Parameterized for everything else.
+        """
+        # Check whether the target exists BEFORE the MERGE so we can
+        # accurately report related_entities_created.
+        existence = await neo4j_client.execute_query(
+            (
+                f"MATCH (t:`{to_label}` {{`{to_id_field}`: $to_id, graph_id: $gid}}) "
+                "RETURN count(t) AS n"
+            ),
+            {"to_id": to_id, "gid": graph_id},
+        )
+        existed_before = (existence[0]["n"] if existence else 0) > 0
+
+        await neo4j_client.execute_query(
+            (
+                f"MATCH (f:`{from_label}` {{id: $from_id, graph_id: $gid}}) "
+                f"MERGE (t:`{to_label}`:__Entity__ {{`{to_id_field}`: $to_id, graph_id: $gid}}) "
+                f"ON CREATE SET t.created_at = datetime(), "
+                "             t.ingestion_source = 'structured_ingest' "
+                f"MERGE (f)-[r:`{rel_type}` {{graph_id: $gid}}]->(t) "
+                "ON CREATE SET r.count = 1, r.first_seen = datetime() "
+                "ON MATCH SET r.count = coalesce(r.count, 1) + 1, "
+                "             r.last_seen = datetime()"
+            ),
+            {
+                "from_id": from_id,
+                "to_id": to_id,
+                "gid": graph_id,
+            },
+        )
+        return not existed_before
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _is_safe_label(label: Any) -> bool:
+    """Neo4j label: alphanumeric + underscore. Reject everything else
+    so we never interpolate user input into Cypher uncontrolled."""
+    return isinstance(label, str) and bool(label) and label.replace("_", "").isalnum()
+
+
+def _is_safe_rel_type(rel_type: Any) -> bool:
+    """Neo4j rel type: ALL_CAPS_WITH_UNDERSCORES — same pattern that
+    ExtractedRelationship uses."""
+    import re as _re
+
+    return isinstance(rel_type, str) and bool(_re.match(r"^[A-Z][A-Z0-9_]*$", rel_type))
+
+
+def _record_to_properties(record: dict[str, Any], id_field: str) -> dict[str, Any]:
+    """Project a JSON record to Neo4j-acceptable property values.
+
+    Primitives + arrays-of-primitives pass through unchanged. Nested
+    dicts and arrays-of-dicts are JSON-stringified so they're still
+    queryable as strings. None values are dropped.
+    """
+    out: dict[str, Any] = {}
+    for key, value in record.items():
+        if value is None:
+            continue
+        if isinstance(value, str | int | float | bool):
+            out[key] = value
+            continue
+        if isinstance(value, list):
+            # All primitives → keep as array. Anything else → JSON-stringify.
+            if all(isinstance(x, str | int | float | bool) for x in value):
+                out[key] = value
+            else:
+                out[key] = json.dumps(value, default=str)
+            continue
+        # Nested dict or other complex type → JSON-stringify
+        try:
+            out[key] = json.dumps(value, default=str)
+        except (TypeError, ValueError):
+            # Last-resort: stringify
+            out[key] = str(value)
+    return out
+
+
+def _bump(counter: dict[str, int], key: str) -> None:
+    counter[key] = counter.get(key, 0) + 1
+
+
+# Module-level singleton — service is stateless.
+structured_ingest_service = StructuredIngestService()

--- a/knowledge-graph-builder/tests/unit/test_structured_ingest_service.py
+++ b/knowledge-graph-builder/tests/unit/test_structured_ingest_service.py
@@ -1,0 +1,293 @@
+"""Unit tests for StructuredIngestService (STORY-9).
+
+Verifies:
+- _record_to_properties projects JSON correctly (primitives, arrays,
+  nested dicts, None handling)
+- _is_safe_label / _is_safe_rel_type reject unsafe inputs
+- ingest_records skips records missing the id field
+- MERGE Cypher uses parameterized graph_id + id
+- relationship mappings produce edges
+- invalid labels and rel types raise ValueError before any I/O
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.structured_ingest_service import (
+    RelationshipMapping,
+    StructuredIngestService,
+    _is_safe_label,
+    _is_safe_rel_type,
+    _record_to_properties,
+)
+
+
+class TestSafetyValidators:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "label,expected",
+        [
+            ("EvidenceRecord", True),
+            ("Company", True),
+            ("__Entity__", True),
+            ("Foo_Bar123", True),
+            ("Foo-Bar", False),  # hyphen not allowed
+            ("Foo Bar", False),  # space not allowed
+            ("Foo;DROP", False),  # injection attempt
+            ("", False),
+            (None, False),
+            (123, False),
+        ],
+    )
+    def test_is_safe_label(self, label, expected):
+        assert _is_safe_label(label) is expected
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "rel,expected",
+        [
+            ("USES", True),
+            ("PART_OF", True),
+            ("ABOUT_2024", True),
+            ("uses", False),  # lowercase not allowed
+            ("USES;", False),  # semicolon not allowed
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_is_safe_rel_type(self, rel, expected):
+        assert _is_safe_rel_type(rel) is expected
+
+
+class TestRecordToProperties:
+    @pytest.mark.unit
+    def test_primitives_pass_through(self):
+        result = _record_to_properties(
+            {"id": "x", "name": "Foo", "count": 42, "active": True, "price": 1.5},
+            id_field="id",
+        )
+        assert result["name"] == "Foo"
+        assert result["count"] == 42
+        assert result["active"] is True
+        assert result["price"] == 1.5
+
+    @pytest.mark.unit
+    def test_none_values_dropped(self):
+        result = _record_to_properties(
+            {"id": "x", "description": None, "tag": "active"}, id_field="id"
+        )
+        assert "description" not in result
+        assert result["tag"] == "active"
+
+    @pytest.mark.unit
+    def test_list_of_primitives_kept_as_array(self):
+        result = _record_to_properties(
+            {"id": "x", "tags": ["a", "b", "c"]}, id_field="id"
+        )
+        assert result["tags"] == ["a", "b", "c"]
+
+    @pytest.mark.unit
+    def test_nested_dict_json_stringified(self):
+        import json as _json
+
+        result = _record_to_properties(
+            {"id": "x", "address": {"city": "Utrecht"}}, id_field="id"
+        )
+        assert _json.loads(result["address"]) == {"city": "Utrecht"}
+
+    @pytest.mark.unit
+    def test_list_of_dicts_json_stringified(self):
+        import json as _json
+
+        result = _record_to_properties(
+            {"id": "x", "contacts": [{"name": "A"}, {"name": "B"}]},
+            id_field="id",
+        )
+        parsed = _json.loads(result["contacts"])
+        assert parsed == [{"name": "A"}, {"name": "B"}]
+
+
+class TestIngestRecordsValidation:
+    @pytest.mark.unit
+    async def test_rejects_invalid_label(self):
+        svc = StructuredIngestService()
+        with pytest.raises(ValueError, match="Invalid label"):
+            await svc.ingest_records("g1", records=[{"id": "a"}], label="Bad-Label")
+
+    @pytest.mark.unit
+    async def test_rejects_invalid_rel_type(self):
+        svc = StructuredIngestService()
+        with pytest.raises(ValueError, match="Invalid rel_type"):
+            await svc.ingest_records(
+                "g1",
+                records=[{"id": "a", "company_id": "c1"}],
+                label="Record",
+                relationships=[
+                    RelationshipMapping(
+                        from_field="company_id",
+                        to_label="Company",
+                        rel_type="lowercase_not_allowed",
+                    )
+                ],
+            )
+
+    @pytest.mark.unit
+    async def test_rejects_invalid_relationship_to_label(self):
+        svc = StructuredIngestService()
+        with pytest.raises(ValueError, match="Invalid relationship to_label"):
+            await svc.ingest_records(
+                "g1",
+                records=[],
+                label="Record",
+                relationships=[
+                    RelationshipMapping(
+                        from_field="x",
+                        to_label="Bad-Label",
+                        rel_type="REL",
+                    )
+                ],
+            )
+
+
+class TestIngestRecords:
+    @pytest.mark.unit
+    async def test_skips_record_missing_id(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.structured_ingest_service.neo4j_client", mock_client):
+            svc = StructuredIngestService()
+            report = await svc.ingest_records(
+                "g1",
+                records=[{"name": "no_id"}, {"id": "x", "name": "ok"}],
+                label="Record",
+            )
+        assert report.records_processed == 1
+        assert report.skipped == 1
+        assert "missing_or_invalid_id" in report.skip_reasons
+
+    @pytest.mark.unit
+    async def test_skips_non_dict_record(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.structured_ingest_service.neo4j_client", mock_client):
+            svc = StructuredIngestService()
+            report = await svc.ingest_records(
+                "g1", records=["not a dict", {"id": "a"}], label="Record"
+            )
+        assert report.skipped == 1
+        assert "not_a_dict" in report.skip_reasons
+
+    @pytest.mark.unit
+    async def test_merge_passes_graph_id_and_id_as_params(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.structured_ingest_service.neo4j_client", mock_client):
+            svc = StructuredIngestService()
+            await svc.ingest_records(
+                "my-graph",
+                records=[{"id": "rec-1", "name": "Test"}],
+                label="Record",
+            )
+        first_call = mock_client.execute_query.await_args_list[0]
+        params = first_call.args[1]
+        assert params["id"] == "rec-1"
+        assert params["gid"] == "my-graph"
+        assert params["props"]["name"] == "Test"
+        # id removed from props so MERGE key isn't overwritten
+        assert "id" not in params["props"]
+
+    @pytest.mark.unit
+    async def test_relationship_mapping_creates_edge(self):
+        """For a record with company_id, a target Company entity is
+        MERGE'd and an ABOUT edge is created."""
+        mock_client = MagicMock()
+        # Calls: 1 merge_entity, 2 relationship (existence check + MERGE)
+        mock_client.execute_query = AsyncMock(
+            side_effect=[
+                None,  # MERGE entity
+                [{"n": 0}],  # existence check for target — doesn't exist
+                None,  # MERGE relationship
+            ]
+        )
+        with patch("app.services.structured_ingest_service.neo4j_client", mock_client):
+            svc = StructuredIngestService()
+            report = await svc.ingest_records(
+                "g1",
+                records=[{"id": "ev-1", "company_id": "comp-1"}],
+                label="EvidenceRecord",
+                relationships=[
+                    RelationshipMapping(
+                        from_field="company_id",
+                        to_label="Company",
+                        rel_type="ABOUT",
+                    )
+                ],
+            )
+        assert report.records_processed == 1
+        assert report.relationships_created == 1
+        assert report.related_entities_created == 1
+
+    @pytest.mark.unit
+    async def test_relationship_skipped_when_field_missing(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.structured_ingest_service.neo4j_client", mock_client):
+            svc = StructuredIngestService()
+            report = await svc.ingest_records(
+                "g1",
+                records=[{"id": "ev-1"}],  # no company_id
+                label="EvidenceRecord",
+                relationships=[
+                    RelationshipMapping(
+                        from_field="company_id",
+                        to_label="Company",
+                        rel_type="ABOUT",
+                    )
+                ],
+            )
+        assert report.records_processed == 1
+        assert report.relationships_created == 0
+
+    @pytest.mark.unit
+    async def test_list_of_target_ids_creates_multiple_edges(self):
+        """When ``from_field`` carries a list, one edge per element."""
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(
+            side_effect=[
+                None,  # merge entity
+                [{"n": 0}],  # target 1 existence
+                None,  # target 1 merge rel
+                [{"n": 1}],  # target 2 existence — existed before
+                None,  # target 2 merge rel
+            ]
+        )
+        with patch("app.services.structured_ingest_service.neo4j_client", mock_client):
+            svc = StructuredIngestService()
+            report = await svc.ingest_records(
+                "g1",
+                records=[{"id": "ev-1", "tags": ["t1", "t2"]}],
+                label="EvidenceRecord",
+                relationships=[
+                    RelationshipMapping(
+                        from_field="tags",
+                        to_label="Tag",
+                        rel_type="TAGGED_WITH",
+                    )
+                ],
+            )
+        # Two edges created, one newly-created target entity (t1; t2
+        # already existed)
+        assert report.relationships_created == 2
+        assert report.related_entities_created == 1
+
+    @pytest.mark.unit
+    async def test_empty_record_list_is_no_op(self):
+        mock_client = MagicMock()
+        mock_client.execute_query = AsyncMock(return_value=[])
+        with patch("app.services.structured_ingest_service.neo4j_client", mock_client):
+            svc = StructuredIngestService()
+            report = await svc.ingest_records("g1", records=[], label="X")
+        assert report.records_processed == 0
+        assert report.skipped == 0
+        mock_client.execute_query.assert_not_called()


### PR DESCRIPTION
## Summary

Adds `POST /graphs/{id}/ingest-records` — a direct path for JSON records that already have schema, bypassing the lossy text → chunk → LLM-extract pipeline. The Eurail demo had 600+ evidence records each with known fields; they were forced through the unstructured pipeline and lost field-typed structure as a result. STORY-9 makes the direct path available.

## Live verification (curl on a fresh graph)

```
POST /api/v1/graphs/{id}/ingest-records
{
  "label": "EvidenceRecord",
  "id_field": "record_id",
  "records": [3 records with company_id + tags fields],
  "relationships": [
    {"from_field": "company_id", "to_label": "Company", "rel_type": "ABOUT"},
    {"from_field": "tags", "to_label": "Tag", "rel_type": "TAGGED_WITH"}
  ]
}

→ {
    "records_processed": 3,
    "entities_created_or_updated": 3,
    "relationships_created": 8,    // 3 ABOUT + 5 TAGGED_WITH (one tag dup'd across records)
    "related_entities_created": 7, // 5 unique tags + 2 companies
    "skipped": 0,
    "elapsed_seconds": 0.14
  }
```

| Verified path | Result |
|---|---|
| Idempotent re-run | Same record → `related_entities_created=0`; edge MERGE bumps `count` |
| Bad label injection (`Bad-Label`) | HTTP 400 |
| Test graph cleanup | DELETE returned 204 |

## Changes

- **NEW** [knowledge-graph-builder/app/services/structured_ingest_service.py](knowledge-graph-builder/app/services/structured_ingest_service.py) — `StructuredIngestService` with one orchestration method. Tenant-isolated via `graph_id` on every entity. MERGE Cypher uses `apoc`-free standard MERGE for portability.
- **NEW** `POST /api/v1/graphs/{id}/ingest-records` in [graphs.py](knowledge-graph-builder/app/api/v1/endpoints/graphs.py). Synchronous; for 3 records + 7 relationships completes in 0.14s.
- **NEW** schemas: `StructuredIngestRequest`, `StructuredIngestResponse`, `StructuredIngestRelationshipMapping`.
- **32 unit tests** in [test_structured_ingest_service.py](knowledge-graph-builder/tests/unit/test_structured_ingest_service.py) covering safety validators (parametrized over injection attempts, lowercase rel types, hyphens, empty strings), property projection (primitives / arrays / nested dicts JSON-stringified / None dropped), orchestration (skip-missing-id, skip-non-dicts, MERGE params, relationship creation, list-of-target-ids, empty-list no-op).

## Field mapping rules (per record)

| Type | Behavior |
|---|---|
| Primitive (str, int, float, bool) | → entity property verbatim |
| `None` | → property dropped |
| List of primitives | → Neo4j array property |
| Nested dict / list of dicts | → JSON-stringified property (queryable as string) |
| `id_field` value | MERGE key for the entity (re-runs are no-ops) |
| Relationship `from_field` value | → MERGE target entity + typed edge with `count` property |

## Safety

- Labels validated by `_is_safe_label` (alphanumeric + underscore) before any I/O — eliminates Cypher injection.
- Rel types validated by `_is_safe_rel_type` (`^[A-Z][A-Z0-9_]*$`).
- `graph_id` and entity IDs always passed as Cypher parameters.
- ON CREATE / ON MATCH count-bumping convention matches STORY-6's dedup pattern.

## Out of scope (follow-ups)

- **CSV ingest**: same pattern, just needs a thin CSV → list-of-dicts adapter. Could ship in 2 hours.
- **RDB connector wiring**: the existing `database_connector_service` has Postgres / MySQL / MongoDB connectors that pull schemas + rows. Wiring them to drive `structured_ingest_service` is a focused follow-up.
- **Bulk endpoint**: a single 600-record post works today but a streaming variant (NDJSON upload) could help for large datasets.
- **Long-text chunking inside structured records**: for records with a long `summary` field, callers can issue a follow-up `POST /ingest` to chunk + embed that text. Automating this in one call is a useful follow-up.