### PR TITLE
ORA-120: Scrub MongoDB credentials from ConnectorSyncError error messages

### DIFF
--- a/knowledge-graph-builder/app/services/background_jobs.py
+++ b/knowledge-graph-builder/app/services/background_jobs.py
@@ -3,6 +3,7 @@ Refactored Background Jobs using Pipeline Service
 Clean implementation with Neo4j GraphRAG pipeline and multi-tenant support
 """
 
+import re
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -1523,8 +1524,7 @@ def code_ingest_task(self, job_id: str, user_id: str) -> dict[str, Any]:
     ) -> None:
         with pg_engine.begin() as conn:
             conn.execute(
-                _text(
-                    """
+                _text("""
                     UPDATE ingestion_jobs
                     SET status = :status,
                         progress = :progress,
@@ -1533,8 +1533,7 @@ def code_ingest_task(self, job_id: str, user_id: str) -> dict[str, Any]:
                         completed_at = CASE WHEN :status IN ('completed','failed') THEN NOW() ELSE completed_at END,
                         started_at = CASE WHEN :status = 'running' AND started_at IS NULL THEN NOW() ELSE started_at END
                     WHERE id = :id
-                """
-                ),
+                """),
                 {
                     "id": job_id_str,
                     "status": status,
@@ -1864,12 +1863,20 @@ async def _sync_database_connector_async(
         except Exception as exc:
             logger.error(f"DB connector {connector_id} connect failed: {exc}")
             await _worker_record_sync_error(
-                async_driver, graph_id, connector_id, "connection_failed", str(exc)
+                async_driver,
+                graph_id,
+                connector_id,
+                "connection_failed",
+                _scrub_credentials(str(exc)),
             )
             await _worker_update_sync_status(
-                async_driver, graph_id, connector_id, "failed", error_msg=str(exc)
+                async_driver,
+                graph_id,
+                connector_id,
+                "failed",
+                error_msg=_scrub_credentials(str(exc)),
             )
-            return {"status": "failed", "error": str(exc)}
+            return {"status": "failed", "error": _scrub_credentials(str(exc))}
 
         total_entities = 0
         tables_failed: list = []
@@ -2070,15 +2077,28 @@ async def _sync_database_connector_async(
         except Exception as exc:
             logger.error(f"DB connector sync failed: {exc}", exc_info=True)
             await _worker_record_sync_error(
-                async_driver, graph_id, connector_id, "schema_error", str(exc)
+                async_driver,
+                graph_id,
+                connector_id,
+                "schema_error",
+                _scrub_credentials(str(exc)),
             )
             await _worker_update_sync_status(
-                async_driver, graph_id, connector_id, "failed", error_msg=str(exc)
+                async_driver,
+                graph_id,
+                connector_id,
+                "failed",
+                error_msg=_scrub_credentials(str(exc)),
             )
-            return {"status": "failed", "error": str(exc)}
+            return {"status": "failed", "error": _scrub_credentials(str(exc))}
 
         finally:
             await connector.close()
+
+
+def _scrub_credentials(msg: str) -> str:
+    """Redact embedded credentials from URI-style exception messages before storage."""
+    return re.sub(r"://[^:]+:[^@]+@", "://<redacted>@", msg)  # pragma: allowlist secret
 
 
 async def _worker_update_sync_status(

--- a/knowledge-graph-builder/tests/unit/test_background_jobs.py
+++ b/knowledge-graph-builder/tests/unit/test_background_jobs.py
@@ -386,3 +386,47 @@ class TestProcessIngestionJobStateTransitions:
 
         assert result["status"] == "error"
         assert "Access denied" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _scrub_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestScrubCredentials:
+    @pytest.mark.unit
+    def test_redacts_mongodb_uri_with_credentials(self):
+        from app.services.background_jobs import _scrub_credentials
+
+        result = _scrub_credentials("mongodb://user:s3cr3t@host:27017/db")
+        assert result == "mongodb://<redacted>@host:27017/db"
+
+    @pytest.mark.unit
+    def test_plain_message_passes_through_unchanged(self):
+        from app.services.background_jobs import _scrub_credentials
+
+        msg = "Connection timed out after 30 seconds"
+        assert _scrub_credentials(msg) == msg
+
+    @pytest.mark.unit
+    def test_redacts_postgres_uri(self):
+        from app.services.background_jobs import _scrub_credentials
+
+        result = _scrub_credentials("postgresql://admin:hunter2@db.internal:5432/prod")
+        assert result == "postgresql://<redacted>@db.internal:5432/prod"
+
+    @pytest.mark.unit
+    def test_redacts_multiple_uris_in_one_message(self):
+        from app.services.background_jobs import _scrub_credentials
+
+        msg = "Failed: mongodb://u1:p1@host1/db and mongodb://u2:p2@host2/db"  # pragma: allowlist secret
+        result = _scrub_credentials(msg)
+        assert "p1" not in result
+        assert "p2" not in result
+        assert result.count("<redacted>") == 2
+
+    @pytest.mark.unit
+    def test_empty_string_passes_through(self):
+        from app.services.background_jobs import _scrub_credentials
+
+        assert _scrub_credentials("") == ""


### PR DESCRIPTION
## Summary

- Adds `_scrub_credentials()` helper in `background_jobs.py` that redacts `://user:pass@host` URI patterns from exception messages before they reach Neo4j storage
- Applied at all 6 `str(exc)` call sites in `_sync_database_connector_async`: both the connection failure path (lines ~1864-1872) and the schema error path (lines ~2070-2078)
- 5 new unit tests covering MongoDB URI scrubbing, plain messages, PostgreSQL URIs, multi-URI messages, and empty strings — all pass

## Security Checklist
- [x] No credentials leak into `ConnectorSyncError.error_message` in Neo4j
- [x] All Cypher queries remain parameterized (no change to queries)
- [x] No new endpoints or auth changes — unit-only impact

## Test plan
- [x] `pytest tests/unit/test_background_jobs.py -m unit` — 29 passed
- [x] Black, isort, ruff all pass
- [x] detect-secrets pre-commit hook passes

Closes ORA-299 / fixes ORA-120