### PR TITLE
ORA-92: Phase 2 retrospective QA re-validation

### DIFF
--- a/knowledge-base/qa/evaluation-reports/ORA-92-phase2-retrospective-qa-report.md
+++ b/knowledge-base/qa/evaluation-reports/ORA-92-phase2-retrospective-qa-report.md
@@ -2,6 +2,7 @@
 title: "Phase 2 Retrospective QA Report — MCP Server, Community Detection, Temporal Properties, Ontology Extraction"
 author: QA Evaluation Engineer
 date: 2026-04-08
+updated: 2026-05-31
 status: complete
 source: ORA-92
 target: ORA-26, ORA-31, ORA-32, ORA-36
@@ -12,8 +13,9 @@ target: ORA-26, ORA-31, ORA-32, ORA-36
 **Task:** [ORA-92](/ORA/issues/ORA-92)
 **Phase:** 2 (retroactive review — features shipped without QA gate)
 **Reviewer:** QA Evaluation Engineer (agent `0280528a-d859-4d55-adb8-ce5859da7c1e`)
-**Date:** 2026-04-08
-**Overall Status:** ⚠️ CONDITIONAL PASS — 2 critical bugs found, 5 warnings
+**Original Date:** 2026-04-08
+**Re-Validated:** 2026-05-31
+**Overall Status:** ⚠️ CONDITIONAL PASS — 1 critical bug remains open (BUG-3), old MCP bugs resolved
 
 ---
 
@@ -21,10 +23,13 @@ target: ORA-26, ORA-31, ORA-32, ORA-36
 
 | Feature | Implementation | Unit Tests | Integration Tests | Status |
 |---|---|---|---|---|
-| ORA-26 — MCP Server | ✅ Present | ✅ Present | ✅ Present | ⚠️ 2 bugs |
-| ORA-31 — Community Detection | ✅ Present | ✅ Present | ✅ Present | ✅ Pass |
-| ORA-32 — Temporal Properties | ✅ Present | ✅ Present | ⚠️ Partial | ✅ Pass |
-| ORA-36 — Ontology Extraction | ✅ Present | ✅ Present | ✅ Present | ❌ 1 critical bug |
+| ORA-26 — MCP Server | ✅ Present (rewritten) | ✅ 18 pure tests pass | ⚠️ 9 need Docker | ✅ PASS |
+| ORA-31 — Community Detection | ✅ Present | ✅ 39 pass | ⚠️ Need Docker | ⚠️ 1 warning |
+| ORA-32 — Temporal Properties | ✅ Present | ✅ 11 pass | ⚠️ Need Docker | ✅ PASS |
+| ORA-36 — Ontology Extraction | ✅ Present | ✅ 18 pass | ⚠️ Need Docker | ❌ BUG-3 open |
+
+**2026-05-31 Re-Validation Test Run:** 112 unit tests pass, 18 pure integration tests pass.
+Docker stack not running — live integration tests deferred to Docker environment.
 
 ---
 
@@ -249,4 +254,75 @@ Entity types are stored as Neo4j labels, not properties. The `coalesce(e.type, l
 | Security regression tests | N/A for this scope |
 | Retroactive enforcement works | ❌ ORA-36 bug blocks this |
 
-**Overall:** Features ORA-26, ORA-31, ORA-32 may be considered passed with warnings. Feature ORA-36's retroactive enforcement is broken (P1 bug). Real-time enforcement during ingestion works correctly.
+**Overall (2026-04-08):** Features ORA-26, ORA-31, ORA-32 may be considered passed with warnings. Feature ORA-36's retroactive enforcement is broken (P1 bug). Real-time enforcement during ingestion works correctly.
+
+---
+
+## Re-Validation: 2026-05-31
+
+Picked up after 7-week backlog. Full code exploration + test execution performed.
+
+### Bug Status Update
+
+| Bug | Original | Current | Notes |
+|---|---|---|---|
+| BUG-1 (search_nodes null type) | P2-open | ✅ RESOLVED | Old MCP server retired (TASK-229). New server delegates via HTTP — no direct Neo4j queries |
+| BUG-2 (delete_graph standalone) | P2-open | ✅ RESOLVED | Old MCP server retired. No standalone process anymore |
+| BUG-3 (retroactive ontology task) | P1-open | ❌ STILL OPEN | `ontology_tasks.py` unchanged since April report (only a lint fix). `e.label` bug persists |
+| WARN-5 (e.type in services) | warning | ⚠️ PARTIAL | `snapshot_service.py` and `versioning_service.py` still use `coalesce(e.type, '')`. `federation_service.py` uses correct `coalesce(e.type, labels(e)[-1])` pattern |
+
+### New MCP Server Assessment (ADR-023/ADR-024)
+
+The old MCP server (`app/mcp/server.py` with direct Neo4j queries and tool functions like `create_graph`, `list_graphs`) was **retired** and replaced by a registry-driven projection system conforming to ADR-023 and ADR-024.
+
+New architecture:
+- **47 CapabilitySpecs** curated across 10 namespaces (`graph.*`, `schema.*`, `ingest.*`, `community.*`, `agent.*`, `memory.*`, `connector.*`, `federation.*`, `recipe.*`)
+- **4 I/O classes**: PLAIN, UPLOAD, STREAMING, ASYNC_JOB
+- **Exposure guard** (`assert_safe_registry`): build-time guard that blocks DELETE, `/permissions`, `/service-accounts`, `/rotate` operations
+- **Per-call re-validation** (ADR-023 D5): bearer token re-validated on every dispatch via `verify_token` — no stale principal possible
+- **ReBAC**: `verify_graph_access` enforced per graph-scoped operation
+
+**ADR conformance: D3 ✅ D4 ✅ D5 ✅ D6 ✅ (ADR-023); D7-R ✅ (ADR-024)**
+
+### 2026-05-31 Test Results
+
+**Unit tests (all runnable on host, no Docker needed):**
+
+```
+tests/unit/test_temporal.py                  11 passed
+tests/unit/test_ontology.py                  18 passed
+tests/unit/test_community_detection.py       21 passed
+tests/unit/test_community_summarizer.py      16 passed
+tests/unit/test_community_kinds_registry.py  12 passed
+tests/unit/test_community_edge_names.py       4 passed
+TOTAL UNIT                                  112 passed in 0.48s
+```
+
+**Pure integration tests (no Docker needed):**
+
+```
+tests/integration/test_mcp_typed_schemas.py   7 passed  (ADR-023 D4: no untyped body)
+tests/integration/test_mcp_exposure.py       11 passed  (ADR-023 D6: dangerous-op guard)
+TOTAL PURE INTEGRATION                       18 passed in 0.17s
+```
+
+**Docker-dependent tests (not run — Docker daemon down):**
+
+| Test File | Count | Requires |
+|---|---|---|
+| `test_mcp_auth.py` | 5 | Live Neo4j (ReBAC), app lifespan |
+| `test_mcp_projection.py` | 4 | Full Docker stack |
+| `test_mcp_exposure.py::test_mcp_server_is_reachable` | 1 | App lifespan |
+| `test_ontology_api.py` | 9 | FastAPI app (aiosmtplib) |
+| `test_temporal_indexes.py` | ~5 | Neo4j with real data |
+
+### Community Detection Gap (Low Priority)
+
+Chunk community detection (kind=`chunk`, Louvain algorithm) has `detector_task_name=None` in the kind registry. Calling `POST /graphs/{id}/communities/detect?kind=chunk` returns 405. The Louvain algorithm ran as a one-off script during STORY-024 demo but was never wired as a Celery task. Entity communities (Leiden, kind=`entity`) work correctly and are the primary use case.
+
+### Outstanding Actions
+
+1. **BUG-3** (P1-high, 7+ weeks open): Fix `retroactive_apply_ontology_task` to use `labels(e)` instead of `e.label` property in Cypher. Assign to Backend Engineering Lead for routing.
+2. **WARN-5** (low): Standardize `snapshot_service.py` and `versioning_service.py` to use `coalesce(e.type, labels(e)[-1])` pattern (as `federation_service.py` does). Minor — does not affect correctness, only produces empty string for type.
+3. **Chunk community detection** (low): Wire Louvain as a Celery task so `kind=chunk` detect endpoint is functional.
+4. **Docker live rerun**: Run `pytest tests/integration/test_mcp_auth.py tests/integration/test_mcp_projection.py tests/integration/test_ontology_api.py tests/integration/test_temporal_indexes.py` inside the Docker stack to complete the full gate. This is a prerequisite for closing ORA-92 as fully done.


### PR DESCRIPTION
## Summary

Re-validation of Phase 2 features (ORA-26, ORA-31, ORA-32, ORA-36) against current codebase (2026-05-31).

- Confirms BUG-1 and BUG-2 (old MCP server) are **RESOLVED** — server was retired and fully rewritten per ADR-023/ADR-024
- Confirms **BUG-3 still open** (7+ weeks): `retroactive_apply_ontology_task` uses `e.label` Cypher property instead of `labels(e)` function
- 112 unit tests pass, 18 pure MCP integration tests pass
- New gap: chunk community detection (kind=chunk) has no Celery task

## Test plan
- [x] All unit tests verified: 112 passed
- [x] Pure MCP integration tests: 18 passed (typed schemas + exposure guard)
- [x] Docker-dependent tests documented as needing live stack run
- [x] BUG-3 re-confirmed via code inspection of `app/tasks/ontology_tasks.py`