### PR TITLE
fix(tests): fix test_main_app_has_limiter_attached CI failure (ORA-319)

### DIFF
--- a/knowledge-graph-builder/tests/unit/test_lifespan_sync_driver.py
+++ b/knowledge-graph-builder/tests/unit/test_lifespan_sync_driver.py
@@ -52,8 +52,13 @@ async def test_lifespan_calls_connect_sync(monkeypatch):
         slowapi_errors_stub.RateLimitExceeded = sys.modules["slowapi"].RateLimitExceeded
         monkeypatch.setitem(sys.modules, "slowapi.errors", slowapi_errors_stub)
 
-    # Ensure app.main is re-imported fresh (cleared via monkeypatch for auto-restore).
-    monkeypatch.delitem(sys.modules, "app.main", raising=False)
+    # Ensure app.main is re-imported fresh and cleaned up after the test.
+    # monkeypatch.setitem registers the original state for teardown:
+    #   - if app.main was absent → saves notset → teardown DELETES the freshly-imported module
+    #   - if app.main was present → saves the original module → teardown restores it
+    # This prevents the stub-contaminated module from leaking into subsequent tests.
+    monkeypatch.setitem(sys.modules, "app.main", None)
+    del sys.modules["app.main"]  # clear the None so import gets a fresh module
 
     # Build mock neo4j_client
     mock_client = MagicMock()

--- a/knowledge-graph-builder/tests/unit/test_rate_limiting.py
+++ b/knowledge-graph-builder/tests/unit/test_rate_limiting.py
@@ -199,7 +199,14 @@ def test_webhook_endpoint_has_rate_limit_decorator():
 @pytest.mark.unit
 def test_main_app_has_limiter_attached():
     """The production FastAPI app has limiter attached to app.state."""
-    # We patch all heavy startup side-effects so we can import the app module cleanly.
+    import sys
+
+    # Clear any cached (potentially stub-contaminated) app.main so that the
+    # import below always runs main.py's module-level code fresh, ensuring
+    # app.state.limiter is the real Limiter and not a leftover MagicMock from
+    # another test (e.g. test_lifespan_sync_driver stubs app.core.rate_limiter).
+    sys.modules.pop("app.main", None)
+
     with (
         patch("app.core.neo4j_client.neo4j_client.connect", new=AsyncMock()),
         patch("app.core.database.init_database_schema", new=AsyncMock()),


### PR DESCRIPTION
## Summary
- **Root cause:** `test_lifespan_calls_connect_sync` stubs `app.core.rate_limiter` with a `MagicMock` limiter and imports a fresh `app.main` while stubs are active. The old `monkeypatch.delitem(sys.modules, "app.main", raising=False)` is a no-op when the key is absent — so the contaminated module (with `app.state.limiter = MagicMock`) leaked into `sys.modules` and was seen by later tests.
- **Fix 1 (`test_lifespan_sync_driver.py`):** Replace `monkeypatch.delitem` with `monkeypatch.setitem(sys.modules, "app.main", None) + del`. `setitem` always records the original state: saves `notset` when absent (teardown **deletes** the freshly-imported stub), or saves the original module when present (teardown **restores** it). The stub-contaminated module no longer leaks.
- **Fix 2 (`test_rate_limiting.py`):** Add `sys.modules.pop("app.main", None)` before the import in `test_main_app_has_limiter_attached` as a defensive guard — ensures a clean re-import regardless of prior test ordering.

## Test plan
- [x] `test_lifespan_calls_connect_sync` passes
- [x] `test_main_app_has_limiter_attached` passes (no more MagicMock assertion failure)
- [x] All 13 tests in `test_rate_limiting.py` pass
- [x] Full unit suite: 1289 passed, 0 failures, 0 regressions
- [x] lint + format clean (black, isort, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)