### PR TITLE
ORA-302: Migrate GraphNodeService to AsyncDriver

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
@@ -144,8 +144,7 @@ async def create_graph(
     """
 
     try:
-        # Use GraphNodeService with Neo4j sync driver for Neo4j operations
-        if not neo4j_client.sync_driver:
+        if not neo4j_client.async_driver:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Neo4j connection not available",
@@ -166,7 +165,7 @@ async def create_graph(
                 db, driver, user_id
             )
 
-        graph_service = GraphNodeService(neo4j_client.sync_driver)
+        graph_service = GraphNodeService(neo4j_client.async_driver)
 
         # Generate unique graph_id
         from uuid import uuid4
@@ -174,7 +173,7 @@ async def create_graph(
         graph_id = str(uuid4())
 
         # Create graph in Neo4j
-        graph_result = graph_service.create_graph(
+        graph_result = await graph_service.create_graph(
             graph_id=graph_id,
             user_id=user_id,
             name=graph_data.name,
@@ -259,14 +258,14 @@ async def list_graphs(user_id: str = Depends(get_current_user_id)):
     """
 
     try:
-        if not neo4j_client.sync_driver:
+        if not neo4j_client.async_driver:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Neo4j connection not available",
             )
 
-        graph_service = GraphNodeService(neo4j_client.sync_driver)
-        graphs = graph_service.list_user_graphs(user_id)
+        graph_service = GraphNodeService(neo4j_client.async_driver)
+        graphs = await graph_service.list_user_graphs(user_id)
 
         # Convert to GraphResponse format
         graph_responses = []
@@ -317,14 +316,14 @@ async def get_graph(graph_id: UUID, user_id: str = Depends(get_current_user_id))
     await verify_graph_access(str(graph_id), "read", user_id)
 
     try:
-        if not neo4j_client.sync_driver:
+        if not neo4j_client.async_driver:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Neo4j connection not available",
             )
 
-        graph_service = GraphNodeService(neo4j_client.sync_driver)
-        graph = graph_service.get_graph(str(graph_id))
+        graph_service = GraphNodeService(neo4j_client.async_driver)
+        graph = await graph_service.get_graph(str(graph_id))
 
         if not graph:
             raise HTTPException(
@@ -379,22 +378,22 @@ async def update_graph(
     await verify_graph_access(str(graph_id), "write", user_id)
 
     try:
-        if not neo4j_client.sync_driver:
+        if not neo4j_client.async_driver:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Neo4j connection not available",
             )
 
-        graph_service = GraphNodeService(neo4j_client.sync_driver)
+        graph_service = GraphNodeService(neo4j_client.async_driver)
 
-        existing_graph = graph_service.get_graph(str(graph_id))
+        existing_graph = await graph_service.get_graph(str(graph_id))
         if not existing_graph:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Graph not found"
             )
 
         # Update graph
-        updated_graph = graph_service.update_graph(
+        updated_graph = await graph_service.update_graph(
             graph_id=str(graph_id),
             user_id=user_id,
             name=graph_update.name,
@@ -464,22 +463,22 @@ async def delete_graph(
     # ReBAC check — admin level required for delete (ORA-39 spec)
     await verify_graph_access(str(graph_id), "admin", user_id)
 
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j connection not available",
         )
 
     try:
-        graph_service = GraphNodeService(neo4j_client.sync_driver)
+        graph_service = GraphNodeService(neo4j_client.async_driver)
 
-        existing_graph = graph_service.get_graph(str(graph_id))
+        existing_graph = await graph_service.get_graph(str(graph_id))
         if not existing_graph:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Graph not found"
             )
 
-        deactivated = graph_service.soft_delete_graph(str(graph_id))
+        deactivated = await graph_service.soft_delete_graph(str(graph_id))
         if not deactivated:
             # Race: get_graph saw the node but soft_delete didn't match.  Treat as 404.
             raise HTTPException(
@@ -581,14 +580,14 @@ async def ingest_data_corrected(
 
     # Verify graph exists in Neo4j (authorized users only reach this point)
     try:
-        if not neo4j_client.sync_driver:
+        if not neo4j_client.async_driver:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Neo4j connection not available",
             )
 
-        graph_service = GraphNodeService(neo4j_client.sync_driver)
-        neo4j_graph = graph_service.get_graph(str(graph_id))
+        graph_service = GraphNodeService(neo4j_client.async_driver)
+        neo4j_graph = await graph_service.get_graph(str(graph_id))
 
         if not neo4j_graph:
             raise HTTPException(
@@ -862,7 +861,7 @@ async def set_graph_instructions(
     # ReBAC check — write level required to set instructions
     await verify_graph_access(str(graph_id), "write", user_id)
 
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -895,7 +894,7 @@ async def get_graph_instructions(
     # ReBAC check — read level required to view instructions
     await verify_graph_access(str(graph_id), "read", user_id)
 
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -936,7 +935,7 @@ async def delete_graph_instructions(
     # ReBAC check — admin level required to delete instructions
     await verify_graph_access(str(graph_id), "admin", user_id)
 
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -976,15 +975,15 @@ async def migrate_graph_properties(
     # ReBAC check — admin level required for property migration
     await verify_graph_access(str(graph_id), "admin", user_id)
 
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
         )
 
-    graph_service = GraphNodeService(neo4j_client.sync_driver)
+    graph_service = GraphNodeService(neo4j_client.async_driver)
     try:
-        result = graph_service.migrate_relationship_properties(str(graph_id))
+        result = await graph_service.migrate_relationship_properties(str(graph_id))
         return result
     except Exception as e:
         logger.error(f"Migration failed for graph {graph_id}: {e}")
@@ -1094,7 +1093,7 @@ async def set_graph_ontology(
     Existing graph data is NOT modified; use the retroactive-apply endpoint for that.
     Invalidates the schema cache.
     """
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -1124,7 +1123,7 @@ async def get_graph_ontology(
 
     Returns `404` if no ontology has been configured. Free-form graphs have no ontology.
     """
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -1162,7 +1161,7 @@ async def patch_graph_ontology(
     Types are matched by name. Adding a type that already exists replaces it.
     Invalidates the schema cache.
     """
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -1195,7 +1194,7 @@ async def delete_graph_ontology(
     Previously extracted entities are NOT removed.
     Invalidates the schema cache.
     """
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -1226,7 +1225,7 @@ async def validate_graph_ontology(
     Returns violation counts and a sample of offending entities. Use this to assess
     the impact before running retroactive-apply.
     """
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",
@@ -1329,7 +1328,7 @@ async def retroactive_apply_ontology(
     - `dry_run=false, >10k entities`: dispatches a Celery background task and returns
       `celery_task_id`. Poll job status separately.
     """
-    if not neo4j_client.sync_driver:
+    if not neo4j_client.async_driver:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Neo4j not available",

--- a/knowledge-graph-builder/app/services/graph_node_service.py
+++ b/knowledge-graph-builder/app/services/graph_node_service.py
@@ -24,19 +24,19 @@ graph as the ReBAC permission anchor. All user-facing queries filter by
 
 from typing import Any
 
-from neo4j import Driver
+from neo4j import AsyncDriver
 from neo4j.exceptions import Neo4jError
 
 
 class GraphNodeService:
     """Service for managing Graph nodes in Neo4j"""
 
-    def __init__(self, driver: Driver):
+    def __init__(self, driver: AsyncDriver):
         """
-        Initialize GraphNodeService with Neo4j driver
+        Initialize GraphNodeService with Neo4j async driver
 
         Args:
-            driver: Neo4j driver instance
+            driver: Neo4j async driver instance
         """
         self.driver = driver
 
@@ -72,7 +72,7 @@ class GraphNodeService:
         "FOR (e:__Entity__) ON (e.name, e.type)",
     ]
 
-    def create_graph(
+    async def create_graph(
         self,
         graph_id: str,
         name: str,
@@ -111,8 +111,8 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(
+            async with self.driver.session() as session:
+                result = await session.run(
                     query,
                     {
                         "graph_id": graph_id,
@@ -123,7 +123,7 @@ class GraphNodeService:
                     },
                 )
 
-                record = result.single()
+                record = await result.single()
                 if not record:
                     raise ValueError("Failed to create Graph node")
 
@@ -131,7 +131,7 @@ class GraphNodeService:
 
                 # TASK-202: wire ownership edges when an org owns the graph.
                 if org_id:
-                    session.run(
+                    await session.run(
                         """
                         MATCH (o:Organization {org_id: $org_id})
                         MATCH (g:Graph:__Platform__ {graph_id: $graph_id})
@@ -139,7 +139,7 @@ class GraphNodeService:
                         """,
                         {"org_id": org_id, "graph_id": graph_id},
                     )
-                    session.run(
+                    await session.run(
                         """
                         MERGE (u:User:__Platform__ {
                             user_id: $user_id, graph_id: "__system__"
@@ -152,7 +152,7 @@ class GraphNodeService:
                     )
 
             # Ensure temporal indexes exist (idempotent — IF NOT EXISTS)
-            self._ensure_temporal_indexes()
+            await self._ensure_temporal_indexes()
 
             return {
                 "graph_id": graph_data["graph_id"],
@@ -174,17 +174,17 @@ class GraphNodeService:
         except Exception as e:
             raise Exception(f"Unexpected error creating graph: {str(e)}") from None
 
-    def _ensure_temporal_indexes(self) -> None:
+    async def _ensure_temporal_indexes(self) -> None:
         """Create temporal indexes if they don't exist. Idempotent."""
-        with self.driver.session() as session:
+        async with self.driver.session() as session:
             for stmt in self._TEMPORAL_INDEX_STATEMENTS:
                 try:
-                    session.run(stmt)
+                    await session.run(stmt)
                 except Exception:
                     # Index creation errors are non-fatal; the graph node was already created
                     pass
 
-    def get_graph(self, graph_id: str) -> dict[str, Any] | None:
+    async def get_graph(self, graph_id: str) -> dict[str, Any] | None:
         """
         Retrieve a Graph node by graph_id.
 
@@ -216,9 +216,9 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(query, {"graph_id": graph_id})
-                record = result.single()
+            async with self.driver.session() as session:
+                result = await session.run(query, {"graph_id": graph_id})
+                record = await result.single()
 
                 if record:
                     data = dict(record["graph"])
@@ -231,7 +231,7 @@ class GraphNodeService:
         except Neo4jError as e:
             raise Exception(f"Failed to retrieve Graph node {graph_id}: {e}") from None
 
-    def list_user_graphs(self, user_id: str) -> list[dict[str, Any]]:
+    async def list_user_graphs(self, user_id: str) -> list[dict[str, Any]]:
         """
         List all Graph nodes for a specific user.
 
@@ -267,11 +267,11 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(query, {"user_id": user_id})
+            async with self.driver.session() as session:
+                result = await session.run(query, {"user_id": user_id})
 
                 graphs: list[dict[str, Any]] = []
-                for record in result:
+                async for record in result:
                     data = dict(record["graph"])
                     data.setdefault("federatable", False)
                     data.setdefault("federation_group", None)
@@ -283,7 +283,7 @@ class GraphNodeService:
         except Neo4jError as e:
             raise Exception(f"Failed to list user graphs: {e}") from None
 
-    def update_graph(
+    async def update_graph(
         self,
         graph_id: str,
         user_id: str,
@@ -370,9 +370,9 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(query, params)
-                record = result.single()
+            async with self.driver.session() as session:
+                result = await session.run(query, params)
+                record = await result.single()
 
                 if record:
                     data = dict(record["graph"])
@@ -385,7 +385,7 @@ class GraphNodeService:
         except Neo4jError as e:
             raise Exception(f"Failed to update graph: {e}") from None
 
-    def list_federatable_graphs(
+    async def list_federatable_graphs(
         self, user_id: str, graph_ids: list[str] | None = None
     ) -> list[dict[str, Any]]:
         """Return graphs owned by user_id that have federatable=true.
@@ -424,14 +424,14 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(query, params)
-                return [dict(record["graph"]) for record in result]
+            async with self.driver.session() as session:
+                result = await session.run(query, params)
+                return [dict(record["graph"]) async for record in result]
 
         except Neo4jError as e:
             raise Exception(f"Failed to list federatable graphs: {e}") from None
 
-    def delete_graph(self, graph_id: str, user_id: str) -> bool:
+    async def delete_graph(self, graph_id: str, user_id: str) -> bool:
         """
         Delete a Graph node and all its relationships.
 
@@ -452,10 +452,12 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(query, {"graph_id": graph_id, "user_id": user_id})
+            async with self.driver.session() as session:
+                result = await session.run(
+                    query, {"graph_id": graph_id, "user_id": user_id}
+                )
 
-                record = result.single()
+                record = await result.single()
                 if record:
                     return record["deleted_count"] > 0
                 return False
@@ -463,7 +465,7 @@ class GraphNodeService:
         except Neo4jError as e:
             raise Exception(f"Failed to delete graph: {e}") from None
 
-    def soft_delete_graph(self, graph_id: str) -> bool:
+    async def soft_delete_graph(self, graph_id: str) -> bool:
         """
         Soft-delete a Graph node by setting status='deactivated' and
         recording a deactivated_at timestamp.
@@ -495,9 +497,9 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(query, {"graph_id": graph_id})
-                record = result.single()
+            async with self.driver.session() as session:
+                result = await session.run(query, {"graph_id": graph_id})
+                record = await result.single()
                 if record:
                     return record["deactivated_count"] > 0
                 return False
@@ -505,7 +507,7 @@ class GraphNodeService:
         except Neo4jError as e:
             raise Exception(f"Failed to soft-delete graph: {e}") from None
 
-    def migrate_relationship_properties(self, graph_id: str) -> dict[str, Any]:
+    async def migrate_relationship_properties(self, graph_id: str) -> dict[str, Any]:
         """
         Run 3-phase migration to move contextual properties from entity nodes
         to their corresponding relationships, per the ORA-4 spec.
@@ -568,24 +570,32 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
+            async with self.driver.session() as session:
                 # Phase 1a: transfer job_title to WORKS_FOR.position
-                r1a = session.run(phase1_job_title, {"graph_id": graph_id}).single()
+                r1a = await (
+                    await session.run(phase1_job_title, {"graph_id": graph_id})
+                ).single()
                 transferred_job_title = r1a["transferred"] if r1a else 0
 
                 # Phase 1b: transfer proficiency to HAS_SKILL.proficiency
-                r1b = session.run(phase1_proficiency, {"graph_id": graph_id}).single()
+                r1b = await (
+                    await session.run(phase1_proficiency, {"graph_id": graph_id})
+                ).single()
                 transferred_proficiency = r1b["transferred"] if r1b else 0
 
                 # Phase 2: detect orphans
-                orphan_records = session.run(phase2_orphans, {"graph_id": graph_id})
+                orphan_result = await session.run(
+                    phase2_orphans, {"graph_id": graph_id}
+                )
                 orphans = [
                     {"entity_id": r["entity_id"], "name": r["name"], "type": r["type"]}
-                    for r in orphan_records
+                    async for r in orphan_result
                 ]
 
                 # Phase 3: cleanup all banned props
-                r3 = session.run(phase3_cleanup, {"graph_id": graph_id}).single()
+                r3 = await (
+                    await session.run(phase3_cleanup, {"graph_id": graph_id})
+                ).single()
                 cleaned = r3["cleaned"] if r3 else 0
 
             return {
@@ -601,7 +611,7 @@ class GraphNodeService:
         except Neo4jError as e:
             raise Exception(f"Migration failed for graph {graph_id}: {e}") from None
 
-    def graph_exists(self, graph_id: str, user_id: str) -> bool:
+    async def graph_exists(self, graph_id: str, user_id: str) -> bool:
         """
         Check if a Graph node exists for the given user.
 
@@ -621,10 +631,12 @@ class GraphNodeService:
             if not self.driver:
                 raise ValueError("Neo4j driver not initialized")
 
-            with self.driver.session() as session:
-                result = session.run(query, {"graph_id": graph_id, "user_id": user_id})
+            async with self.driver.session() as session:
+                result = await session.run(
+                    query, {"graph_id": graph_id, "user_id": user_id}
+                )
 
-                record = result.single()
+                record = await result.single()
                 if record:
                     return record["exists"]
                 return False

--- a/knowledge-graph-builder/tests/unit/test_graph_node_service.py
+++ b/knowledge-graph-builder/tests/unit/test_graph_node_service.py
@@ -2,10 +2,10 @@
 Unit tests for GraphNodeService.
 
 Tests CRUD operations and multi-tenant isolation (user_id + graph_id scoping)
-against a mocked Neo4j sync driver.
+against a mocked Neo4j async driver.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from neo4j.exceptions import Neo4jError
@@ -17,26 +17,32 @@ from app.services.graph_node_service import GraphNodeService
 # ---------------------------------------------------------------------------
 
 
-def _make_driver(single_return=None, all_records=None):
-    """Build a mock Neo4j sync driver whose session().run() returns controllable data."""
+def _make_async_driver(single_return=None, all_records=None):
+    """Build a mock Neo4j async driver whose session().run() returns controllable data."""
     mock_record = MagicMock()
     mock_record.__getitem__ = MagicMock(
         side_effect=lambda key: single_return.get(key) if single_return else None
     )
 
-    mock_result = MagicMock()
-    mock_result.single.return_value = mock_record if single_return is not None else None
-    mock_result.__iter__ = MagicMock(
-        return_value=iter([_wrap_record(r) for r in (all_records or [])])
+    mock_result = AsyncMock()
+    mock_result.single = AsyncMock(
+        return_value=mock_record if single_return is not None else None
     )
 
-    mock_session = MagicMock()
-    mock_session.run.return_value = mock_result
-    mock_session.__enter__ = MagicMock(return_value=mock_session)
-    mock_session.__exit__ = MagicMock(return_value=False)
+    # Async iteration support
+    async def _aiter(self):
+        for r in all_records or []:
+            yield r
+
+    mock_result.__aiter__ = _aiter
+
+    mock_session = AsyncMock()
+    mock_session.run = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
 
     mock_driver = MagicMock()
-    mock_driver.session.return_value = mock_session
+    mock_driver.session = MagicMock(return_value=mock_session)
 
     return mock_driver, mock_session, mock_result, mock_record
 
@@ -68,8 +74,9 @@ def _graph_node_data():
 
 class TestCreateGraph:
     @pytest.mark.unit
-    def test_create_graph_success(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_create_graph_success(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
 
         real_graph_data = {
             "graph_id": "g-123",
@@ -91,10 +98,14 @@ class TestCreateGraph:
         mock_record.__getitem__ = MagicMock(
             side_effect=lambda k: real_graph_data if k == "g" else None
         )
-        mock_result.single.return_value = mock_record
+        mock_result.single = AsyncMock(return_value=mock_record)
 
         svc = GraphNodeService(mock_driver)
-        result = svc.create_graph("g-123", "My Graph", "user-1", "A test graph")
+        # Patch _ensure_temporal_indexes to avoid extra session calls
+        with patch.object(svc, "_ensure_temporal_indexes", new=AsyncMock()):
+            result = await svc.create_graph(
+                "g-123", "My Graph", "user-1", "A test graph"
+            )
 
         assert result["graph_id"] == "g-123"
         assert result["name"] == "My Graph"
@@ -103,36 +114,40 @@ class TestCreateGraph:
         assert result["node_count"] == 0
 
     @pytest.mark.unit
-    def test_create_graph_raises_when_driver_none(self):
+    @pytest.mark.asyncio
+    async def test_create_graph_raises_when_driver_none(self):
         svc = GraphNodeService(None)
         with pytest.raises(Exception, match="Unexpected error creating graph"):
-            svc.create_graph("g-1", "name", "user-1")
+            await svc.create_graph("g-1", "name", "user-1")
 
     @pytest.mark.unit
-    def test_create_graph_raises_on_no_record(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_create_graph_raises_on_no_record(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Unexpected error creating graph"):
-            svc.create_graph("g-1", "name", "user-1")
+            await svc.create_graph("g-1", "name", "user-1")
 
     @pytest.mark.unit
-    def test_create_graph_wraps_neo4j_error(self):
+    @pytest.mark.asyncio
+    async def test_create_graph_wraps_neo4j_error(self):
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        mock_session.run.side_effect = Neo4jError("DB error")
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(side_effect=Neo4jError("DB error"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Failed to create graph"):
-            svc.create_graph("g-1", "name", "user-1")
+            await svc.create_graph("g-1", "name", "user-1")
 
     @pytest.mark.unit
-    def test_create_graph_passes_graph_id_in_query_params(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_create_graph_passes_graph_id_in_query_params(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         real_data = {
             "graph_id": "g-123",
             "name": "N",
@@ -149,10 +164,11 @@ class TestCreateGraph:
         )
 
         svc = GraphNodeService(mock_driver)
-        try:
-            svc.create_graph("g-123", "N", "u")
-        except Exception:
-            pass  # May fail on dict() — we just need to check params
+        with patch.object(svc, "_ensure_temporal_indexes", new=AsyncMock()):
+            try:
+                await svc.create_graph("g-123", "N", "u")
+            except Exception:
+                pass  # May fail on dict() — we just need to check params
 
         call_args = mock_session.run.call_args
         params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
@@ -167,46 +183,50 @@ class TestCreateGraph:
 
 class TestGetGraph:
     @pytest.mark.unit
-    def test_get_graph_returns_none_when_not_found(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_get_graph_returns_none_when_not_found(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        result = svc.get_graph("nonexistent")
+        result = await svc.get_graph("nonexistent")
         assert result is None
 
     @pytest.mark.unit
-    def test_get_graph_passes_graph_id_to_query(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_get_graph_passes_graph_id_to_query(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(
             side_effect=lambda k: {"graph_id": "g-1"} if k == "graph" else None
         )
 
         svc = GraphNodeService(mock_driver)
-        svc.get_graph("g-1")
+        await svc.get_graph("g-1")
 
         call_args = mock_session.run.call_args
         params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
         assert params.get("graph_id") == "g-1"
 
     @pytest.mark.unit
-    def test_get_graph_wraps_neo4j_error(self):
+    @pytest.mark.asyncio
+    async def test_get_graph_wraps_neo4j_error(self):
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        mock_session.run.side_effect = Neo4jError("Query failed")
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(side_effect=Neo4jError("Query failed"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Failed to retrieve Graph node"):
-            svc.get_graph("g-1")
+            await svc.get_graph("g-1")
 
     @pytest.mark.unit
-    def test_get_graph_raises_when_driver_none(self):
+    @pytest.mark.asyncio
+    async def test_get_graph_raises_when_driver_none(self):
         svc = GraphNodeService(None)
         with pytest.raises(Exception):  # noqa: B017
-            svc.get_graph("g-1")
+            await svc.get_graph("g-1")
 
 
 # ---------------------------------------------------------------------------
@@ -216,59 +236,60 @@ class TestGetGraph:
 
 class TestListUserGraphs:
     @pytest.mark.unit
-    def test_list_user_graphs_returns_empty_list_when_none(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver(all_records=[])
-        mock_result.__iter__ = MagicMock(return_value=iter([]))
+    @pytest.mark.asyncio
+    async def test_list_user_graphs_returns_empty_list_when_none(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver(all_records=[])
 
         svc = GraphNodeService(mock_driver)
-        result = svc.list_user_graphs("user-1")
+        result = await svc.list_user_graphs("user-1")
         assert result == []
 
     @pytest.mark.unit
-    def test_list_user_graphs_passes_user_id_to_query(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.__iter__ = MagicMock(return_value=iter([]))
+    @pytest.mark.asyncio
+    async def test_list_user_graphs_passes_user_id_to_query(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver(all_records=[])
 
         svc = GraphNodeService(mock_driver)
-        svc.list_user_graphs("user-abc")
+        await svc.list_user_graphs("user-abc")
 
         call_args = mock_session.run.call_args
         params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
         assert params.get("user_id") == "user-abc"
 
     @pytest.mark.unit
-    def test_list_user_graphs_scopes_to_user(self):
+    @pytest.mark.asyncio
+    async def test_list_user_graphs_scopes_to_user(self):
         """The query must always filter by user_id — never return other users' graphs."""
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_driver, mock_session, mock_result, _ = _make_async_driver(all_records=[])
 
         svc = GraphNodeService(mock_driver)
-        svc.list_user_graphs("user-1")
+        await svc.list_user_graphs("user-1")
 
         run_call_query = mock_session.run.call_args[0][0]
         assert "user_id" in run_call_query
 
     @pytest.mark.unit
-    def test_list_user_graphs_wraps_neo4j_error(self):
+    @pytest.mark.asyncio
+    async def test_list_user_graphs_wraps_neo4j_error(self):
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        mock_session.run.side_effect = Neo4jError("List failed")
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(side_effect=Neo4jError("List failed"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Failed to list user graphs"):
-            svc.list_user_graphs("user-1")
+            await svc.list_user_graphs("user-1")
 
     @pytest.mark.unit
-    def test_list_user_graphs_excludes_deactivated_graphs(self):
+    @pytest.mark.asyncio
+    async def test_list_user_graphs_excludes_deactivated_graphs(self):
         """Soft-deleted graphs (status='deactivated') must be filtered out (TASK-050)."""
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_driver, mock_session, mock_result, _ = _make_async_driver(all_records=[])
 
         svc = GraphNodeService(mock_driver)
-        svc.list_user_graphs("user-1")
+        await svc.list_user_graphs("user-1")
 
         query = mock_session.run.call_args[0][0]
         assert "deactivated" in query
@@ -281,36 +302,39 @@ class TestListUserGraphs:
 
 class TestDeleteGraph:
     @pytest.mark.unit
-    def test_delete_graph_returns_true_when_deleted(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_delete_graph_returns_true_when_deleted(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(
             side_effect=lambda k: 1 if k == "deleted_count" else None
         )
-        mock_result.single.return_value = mock_record
+        mock_result.single = AsyncMock(return_value=mock_record)
 
         svc = GraphNodeService(mock_driver)
-        result = svc.delete_graph("g-1", "user-1")
+        result = await svc.delete_graph("g-1", "user-1")
         assert result is True
 
     @pytest.mark.unit
-    def test_delete_graph_returns_false_when_not_found(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_delete_graph_returns_false_when_not_found(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(
             side_effect=lambda k: 0 if k == "deleted_count" else None
         )
 
         svc = GraphNodeService(mock_driver)
-        result = svc.delete_graph("g-none", "user-1")
+        result = await svc.delete_graph("g-none", "user-1")
         assert result is False
 
     @pytest.mark.unit
-    def test_delete_graph_requires_user_id_in_query(self):
+    @pytest.mark.asyncio
+    async def test_delete_graph_requires_user_id_in_query(self):
         """Delete query must include user_id for tenant isolation."""
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(side_effect=lambda k: 0)
 
         svc = GraphNodeService(mock_driver)
-        svc.delete_graph("g-1", "user-1")
+        await svc.delete_graph("g-1", "user-1")
 
         call_args = mock_session.run.call_args
         params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
@@ -318,17 +342,18 @@ class TestDeleteGraph:
         assert params.get("graph_id") == "g-1"
 
     @pytest.mark.unit
-    def test_delete_graph_wraps_neo4j_error(self):
+    @pytest.mark.asyncio
+    async def test_delete_graph_wraps_neo4j_error(self):
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        mock_session.run.side_effect = Neo4jError("Delete failed")
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(side_effect=Neo4jError("Delete failed"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Failed to delete graph"):
-            svc.delete_graph("g-1", "user-1")
+            await svc.delete_graph("g-1", "user-1")
 
 
 # ---------------------------------------------------------------------------
@@ -338,35 +363,38 @@ class TestDeleteGraph:
 
 class TestSoftDeleteGraph:
     @pytest.mark.unit
-    def test_soft_delete_returns_true_when_node_matched(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_soft_delete_returns_true_when_node_matched(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(
             side_effect=lambda k: 1 if k == "deactivated_count" else None
         )
-        mock_result.single.return_value = mock_record
+        mock_result.single = AsyncMock(return_value=mock_record)
 
         svc = GraphNodeService(mock_driver)
-        assert svc.soft_delete_graph("g-1") is True
+        assert await svc.soft_delete_graph("g-1") is True
 
     @pytest.mark.unit
-    def test_soft_delete_returns_false_when_no_node(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_soft_delete_returns_false_when_no_node(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(
             side_effect=lambda k: 0 if k == "deactivated_count" else None
         )
-        mock_result.single.return_value = mock_record
+        mock_result.single = AsyncMock(return_value=mock_record)
 
         svc = GraphNodeService(mock_driver)
-        assert svc.soft_delete_graph("g-missing") is False
+        assert await svc.soft_delete_graph("g-missing") is False
 
     @pytest.mark.unit
-    def test_soft_delete_query_sets_deactivated_at_and_status(self):
+    @pytest.mark.asyncio
+    async def test_soft_delete_query_sets_deactivated_at_and_status(self):
         """The Cypher must SET status='deactivated' and a deactivated_at timestamp."""
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(side_effect=lambda k: 1)
 
         svc = GraphNodeService(mock_driver)
-        svc.soft_delete_graph("g-1")
+        await svc.soft_delete_graph("g-1")
 
         call_args = mock_session.run.call_args
         query = call_args[0][0]
@@ -376,37 +404,40 @@ class TestSoftDeleteGraph:
         assert "DETACH DELETE" not in query
 
     @pytest.mark.unit
-    def test_soft_delete_passes_graph_id_param(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_soft_delete_passes_graph_id_param(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(side_effect=lambda k: 1)
 
         svc = GraphNodeService(mock_driver)
-        svc.soft_delete_graph("g-99")
+        await svc.soft_delete_graph("g-99")
 
         call_args = mock_session.run.call_args
         params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
         assert params.get("graph_id") == "g-99"
 
     @pytest.mark.unit
-    def test_soft_delete_returns_false_when_no_record(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_soft_delete_returns_false_when_no_record(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        assert svc.soft_delete_graph("g-1") is False
+        assert await svc.soft_delete_graph("g-1") is False
 
     @pytest.mark.unit
-    def test_soft_delete_wraps_neo4j_error(self):
+    @pytest.mark.asyncio
+    async def test_soft_delete_wraps_neo4j_error(self):
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        mock_session.run.side_effect = Neo4jError("Boom")
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(side_effect=Neo4jError("Boom"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Failed to soft-delete graph"):
-            svc.soft_delete_graph("g-1")
+            await svc.soft_delete_graph("g-1")
 
 
 # ---------------------------------------------------------------------------
@@ -416,32 +447,35 @@ class TestSoftDeleteGraph:
 
 class TestGraphExists:
     @pytest.mark.unit
-    def test_graph_exists_returns_true(self):
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+    @pytest.mark.asyncio
+    async def test_graph_exists_returns_true(self):
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(
             side_effect=lambda k: True if k == "exists" else None
         )
-        mock_result.single.return_value = mock_record
+        mock_result.single = AsyncMock(return_value=mock_record)
 
         svc = GraphNodeService(mock_driver)
-        assert svc.graph_exists("g-1", "user-1") is True
+        assert await svc.graph_exists("g-1", "user-1") is True
 
     @pytest.mark.unit
-    def test_graph_exists_returns_false_when_no_record(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_graph_exists_returns_false_when_no_record(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        assert svc.graph_exists("g-none", "user-1") is False
+        assert await svc.graph_exists("g-none", "user-1") is False
 
     @pytest.mark.unit
-    def test_graph_exists_requires_both_graph_and_user_ids(self):
+    @pytest.mark.asyncio
+    async def test_graph_exists_requires_both_graph_and_user_ids(self):
         """Existence check must scope by BOTH graph_id AND user_id."""
-        mock_driver, mock_session, mock_result, mock_record = _make_driver()
+        mock_driver, mock_session, mock_result, mock_record = _make_async_driver()
         mock_record.__getitem__ = MagicMock(side_effect=lambda k: False)
 
         svc = GraphNodeService(mock_driver)
-        svc.graph_exists("g-1", "user-1")
+        await svc.graph_exists("g-1", "user-1")
 
         call_args = mock_session.run.call_args
         query = call_args[0][0]
@@ -459,21 +493,23 @@ class TestGraphExists:
 
 class TestUpdateGraph:
     @pytest.mark.unit
-    def test_update_graph_returns_none_when_not_found(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_update_graph_returns_none_when_not_found(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        result = svc.update_graph("g-none", "user-1", name="New Name")
+        result = await svc.update_graph("g-none", "user-1", name="New Name")
         assert result is None
 
     @pytest.mark.unit
-    def test_update_graph_passes_user_id_for_tenant_isolation(self):
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_update_graph_passes_user_id_for_tenant_isolation(self):
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        svc.update_graph("g-1", "user-1", name="New Name")
+        await svc.update_graph("g-1", "user-1", name="New Name")
 
         call_args = mock_session.run.call_args
         params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
@@ -481,28 +517,30 @@ class TestUpdateGraph:
         assert params.get("graph_id") == "g-1"
 
     @pytest.mark.unit
-    def test_update_graph_wraps_neo4j_error(self):
+    @pytest.mark.asyncio
+    async def test_update_graph_wraps_neo4j_error(self):
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        mock_session.run.side_effect = Neo4jError("Update failed")
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(side_effect=Neo4jError("Update failed"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Failed to update graph"):
-            svc.update_graph("g-1", "user-1", name="New Name")
+            await svc.update_graph("g-1", "user-1", name="New Name")
 
     @pytest.mark.unit
-    def test_update_graph_federatable_syncs_shadow_node(self):
+    @pytest.mark.asyncio
+    async def test_update_graph_federatable_syncs_shadow_node(self):
         """When federatable is updated, the Cypher must MERGE the shadow node and
         SET shadow.federatable so that federation_service reads the correct flag.
         """
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None  # return value doesn't matter here
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        svc.update_graph("g-1", "user-1", federatable=True)
+        await svc.update_graph("g-1", "user-1", federatable=True)
 
         call_args = mock_session.run.call_args
         query: str = call_args[0][0] if call_args[0] else ""
@@ -521,17 +559,14 @@ class TestUpdateGraph:
         assert params.get("graph_id") == "g-1"
 
     @pytest.mark.unit
-    def test_update_graph_shadow_merge_bootstrap_path(self):
-        """Bootstrap path: when no shadow node exists, MERGE must create it.
-
-        Verified by asserting MERGE (not OPTIONAL MATCH) appears in the query,
-        meaning a missing shadow node will be created rather than silently skipped.
-        """
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_update_graph_shadow_merge_bootstrap_path(self):
+        """Bootstrap path: when no shadow node exists, MERGE must create it."""
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        svc.update_graph("g-new", "user-1", federatable=True)
+        await svc.update_graph("g-new", "user-1", federatable=True)
 
         call_args = mock_session.run.call_args
         query: str = call_args[0][0] if call_args[0] else ""
@@ -548,39 +583,34 @@ class TestUpdateGraph:
         assert params.get("federatable") is True
 
     @pytest.mark.unit
-    def test_update_graph_shadow_merge_update_path_preserves_other_props(self):
-        """Update path: shadow MERGE must only SET federatable — not overwrite other props.
-
-        Verified by asserting the SET clause targets shadow.federatable specifically
-        and does not use SET shadow = {…} (which would wipe owner_user_id, graph_name, etc.).
-        """
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_update_graph_shadow_merge_update_path_preserves_other_props(self):
+        """Update path: shadow MERGE must only SET federatable — not overwrite other props."""
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        svc.update_graph("g-existing", "user-1", federatable=False)
+        await svc.update_graph("g-existing", "user-1", federatable=False)
 
         call_args = mock_session.run.call_args
         query: str = call_args[0][0] if call_args[0] else ""
         params: dict = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]
 
         assert "shadow.federatable" in query, "Must SET shadow.federatable specifically"
-        # Ensure we're not doing a destructive SET shadow = {...} that wipes all properties
         assert "SET shadow = " not in query, (
             "Must not overwrite all shadow node properties"
         )
         assert params.get("federatable") is False
 
     @pytest.mark.unit
-    def test_update_graph_no_shadow_sync_when_federatable_not_provided(self):
-        """When federatable is not in the update payload, the shadow node must NOT
-        be touched (avoids unnecessary writes and respects separation of concerns).
-        """
-        mock_driver, mock_session, mock_result, _ = _make_driver()
-        mock_result.single.return_value = None
+    @pytest.mark.asyncio
+    async def test_update_graph_no_shadow_sync_when_federatable_not_provided(self):
+        """When federatable is not in the update payload, the shadow node must NOT be touched."""
+        mock_driver, mock_session, mock_result, _ = _make_async_driver()
+        mock_result.single = AsyncMock(return_value=None)
 
         svc = GraphNodeService(mock_driver)
-        svc.update_graph("g-1", "user-1", name="Renamed")
+        await svc.update_graph("g-1", "user-1", name="Renamed")
 
         call_args = mock_session.run.call_args
         query: str = call_args[0][0] if call_args[0] else ""
@@ -606,7 +636,7 @@ class TestMigrateRelationshipProperties:
         cleaned: int = 0,
     ):
         """
-        Build a mock driver whose session.run() returns different results
+        Build a mock async driver whose session.run() returns different results
         for each of the 4 sequential queries (phase1a, phase1b, phase2, phase3).
         """
         orphan_records = orphan_records or []
@@ -614,14 +644,25 @@ class TestMigrateRelationshipProperties:
         def _single_result(value: dict):
             rec = MagicMock()
             rec.__getitem__ = MagicMock(side_effect=lambda k: value.get(k))
-            result = MagicMock()
-            result.single.return_value = rec
+            result = AsyncMock()
+            result.single = AsyncMock(return_value=rec)
+
+            async def _aiter(self):
+                return
+                yield  # make it an async generator
+
+            result.__aiter__ = _aiter
             return result
 
         def _iter_result(records):
-            result = MagicMock()
-            result.single.return_value = None
-            result.__iter__ = MagicMock(return_value=iter(records))
+            result = AsyncMock()
+            result.single = AsyncMock(return_value=None)
+
+            async def _aiter(self):
+                for r in records:
+                    yield r
+
+            result.__aiter__ = _aiter
             return result
 
         def _make_orphan_record(entity_id, name, entity_type, props):
@@ -644,41 +685,44 @@ class TestMigrateRelationshipProperties:
         ]
         call_count = [0]
 
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        def run_side_effect(query, params=None, **kwargs):
+        async def run_side_effect(query, params=None, **kwargs):
             idx = call_count[0]
             call_count[0] += 1
-            return call_results[idx] if idx < len(call_results) else MagicMock()
+            return call_results[idx] if idx < len(call_results) else AsyncMock()
 
-        mock_session.run.side_effect = run_side_effect
+        mock_session.run = AsyncMock(side_effect=run_side_effect)
 
         mock_driver = MagicMock()
-        mock_driver.session.return_value = mock_session
+        mock_driver.session = MagicMock(return_value=mock_session)
         return mock_driver
 
     @pytest.mark.unit
-    def test_returns_graph_id_in_result(self):
+    @pytest.mark.asyncio
+    async def test_returns_graph_id_in_result(self):
         driver = self._make_migration_driver()
         svc = GraphNodeService(driver)
-        result = svc.migrate_relationship_properties("g-abc")
+        result = await svc.migrate_relationship_properties("g-abc")
         assert result["graph_id"] == "g-abc"
 
     @pytest.mark.unit
-    def test_transferred_counts_are_correct(self):
+    @pytest.mark.asyncio
+    async def test_transferred_counts_are_correct(self):
         driver = self._make_migration_driver(
             transferred_job_title=5, transferred_proficiency=3
         )
         svc = GraphNodeService(driver)
-        result = svc.migrate_relationship_properties("g-1")
+        result = await svc.migrate_relationship_properties("g-1")
         assert result["transferred_job_title"] == 5
         assert result["transferred_proficiency"] == 3
         assert result["transferred_total"] == 8
 
     @pytest.mark.unit
-    def test_orphans_detected_count(self):
+    @pytest.mark.asyncio
+    async def test_orphans_detected_count(self):
         orphans = [
             {
                 "entity_id": "e-1",
@@ -695,11 +739,12 @@ class TestMigrateRelationshipProperties:
         ]
         driver = self._make_migration_driver(orphan_records=orphans)
         svc = GraphNodeService(driver)
-        result = svc.migrate_relationship_properties("g-1")
+        result = await svc.migrate_relationship_properties("g-1")
         assert result["orphans_detected"] == 2
 
     @pytest.mark.unit
-    def test_zero_violations_clean_graph(self):
+    @pytest.mark.asyncio
+    async def test_zero_violations_clean_graph(self):
         driver = self._make_migration_driver(
             transferred_job_title=0,
             transferred_proficiency=0,
@@ -707,26 +752,28 @@ class TestMigrateRelationshipProperties:
             cleaned=0,
         )
         svc = GraphNodeService(driver)
-        result = svc.migrate_relationship_properties("g-clean")
+        result = await svc.migrate_relationship_properties("g-clean")
         assert result["transferred_total"] == 0
         assert result["orphans_detected"] == 0
         assert result["nodes_cleaned"] == 0
 
     @pytest.mark.unit
-    def test_nodes_cleaned_count(self):
+    @pytest.mark.asyncio
+    async def test_nodes_cleaned_count(self):
         driver = self._make_migration_driver(cleaned=7)
         svc = GraphNodeService(driver)
-        result = svc.migrate_relationship_properties("g-1")
+        result = await svc.migrate_relationship_properties("g-1")
         assert result["nodes_cleaned"] == 7
 
     @pytest.mark.unit
-    def test_graph_id_passed_to_all_queries(self):
+    @pytest.mark.asyncio
+    async def test_graph_id_passed_to_all_queries(self):
         """graph_id must appear in every query parameter — multi-tenancy enforcement."""
         driver = self._make_migration_driver()
         svc = GraphNodeService(driver)
-        svc.migrate_relationship_properties("target-graph")
+        await svc.migrate_relationship_properties("target-graph")
 
-        session = driver.session.return_value.__enter__.return_value
+        session = driver.session.return_value.__aenter__.return_value
         for call in session.run.call_args_list:
             params = call[0][1] if len(call[0]) > 1 else call[1].get("parameters", {})
             assert params.get("graph_id") == "target-graph", (
@@ -734,19 +781,18 @@ class TestMigrateRelationshipProperties:
             )
 
     @pytest.mark.unit
-    def test_wraps_neo4j_error(self):
+    @pytest.mark.asyncio
+    async def test_wraps_neo4j_error(self):
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        from neo4j.exceptions import Neo4jError
-
-        mock_session.run.side_effect = Neo4jError("write failed")
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(side_effect=Neo4jError("write failed"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
         with pytest.raises(Exception, match="Migration failed"):
-            svc.migrate_relationship_properties("g-1")
+            await svc.migrate_relationship_properties("g-1")
 
 
 # ---------------------------------------------------------------------------
@@ -784,16 +830,18 @@ class TestTemporalIndexStatements:
             )
 
     @pytest.mark.unit
-    def test_ensure_temporal_indexes_calls_session_run_for_each_statement(self):
+    @pytest.mark.asyncio
+    async def test_ensure_temporal_indexes_calls_session_run_for_each_statement(self):
         """_ensure_temporal_indexes must run every statement in _TEMPORAL_INDEX_STATEMENTS."""
         mock_driver = MagicMock()
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-        mock_driver.session.return_value = mock_session
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(return_value=AsyncMock())
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session)
 
         svc = GraphNodeService(mock_driver)
-        svc._ensure_temporal_indexes()
+        await svc._ensure_temporal_indexes()
 
         assert mock_session.run.call_count == len(
             GraphNodeService._TEMPORAL_INDEX_STATEMENTS

--- a/knowledge-graph-builder/tests/unit/test_rate_limiting.py
+++ b/knowledge-graph-builder/tests/unit/test_rate_limiting.py
@@ -199,6 +199,13 @@ def test_webhook_endpoint_has_rate_limit_decorator():
 @pytest.mark.unit
 def test_main_app_has_limiter_attached():
     """The production FastAPI app has limiter attached to app.state."""
+    import sys
+
+    # Force a fresh import so a contaminated cached module (left by tests that stub
+    # app.core.rate_limiter in sys.modules, e.g. test_lifespan_sync_driver) does not
+    # cause this assertion to see a MagicMock instead of the real Limiter.
+    sys.modules.pop("app.main", None)
+
     # We patch all heavy startup side-effects so we can import the app module cleanly.
     with (
         patch("app.core.neo4j_client.neo4j_client.connect", new=AsyncMock()),


### PR DESCRIPTION
## Summary

- Migrates `GraphNodeService` from sync `Driver` to `AsyncDriver` (Architecture Rule 5)
- Updates all `graphs.py` endpoint call sites to `async_driver` + `await`
- Converts unit tests to `async def` with `AsyncMock` and `pytest.mark.asyncio`
- Includes pre-existing test isolation fix for `test_main_app_has_limiter_attached` (needed for CI green on `origin/develop` base)

## Files Changed (4)

| File | Change |
|---|---|
| `knowledge-graph-builder/app/services/graph_node_service.py` | AsyncDriver migration (ORA-302) |
| `knowledge-graph-builder/app/api/v1/endpoints/graphs.py` | async_driver call sites (ORA-302) |
| `knowledge-graph-builder/tests/unit/test_graph_node_service.py` | Async test conversion (ORA-302) |
| `knowledge-graph-builder/tests/unit/test_rate_limiting.py` | Pre-existing test isolation bug fix — module cache contamination |

## Notes

This is a clean replacement for PR #89, which had 79 files changed due to being built on top of unmerged TASK-229/230/232/234/235/237 commits. This PR branches directly from `origin/develop` (HEAD `c6ebe9b`) and contains only the 3 ORA-302 commits plus one pre-existing test fix (`3baab82`) required because `test_main_app_has_limiter_attached` fails on the clean `origin/develop` base due to stale module-cache contamination from the prior test.

Closes/replaces: #89
ORA task: ORA-302