### PR TITLE
fix(test): ORA-319 — clear stale app.main module cache in test_main_app_has_limiter_attached

### DIFF
--- a/knowledge-graph-builder/tests/unit/test_rate_limiting.py
+++ b/knowledge-graph-builder/tests/unit/test_rate_limiting.py
@@ -199,6 +199,13 @@ def test_webhook_endpoint_has_rate_limit_decorator():
 @pytest.mark.unit
 def test_main_app_has_limiter_attached():
     """The production FastAPI app has limiter attached to app.state."""
+    import sys
+
+    # Force a fresh import so a contaminated cached module (left by tests that stub
+    # app.core.rate_limiter in sys.modules, e.g. test_lifespan_sync_driver) does not
+    # cause this assertion to see a MagicMock instead of the real Limiter.
+    sys.modules.pop("app.main", None)
+
     # We patch all heavy startup side-effects so we can import the app module cleanly.
     with (
         patch("app.core.neo4j_client.neo4j_client.connect", new=AsyncMock()),


### PR DESCRIPTION
## Summary

- **Root cause**: `test_lifespan_calls_connect_sync` stubs `app.core.rate_limiter` in `sys.modules` (with `limiter=MagicMock()`) and freshly imports `app.main`. If `app.main` was not already in `sys.modules` when that test ran, `monkeypatch.delitem` becomes a no-op restore, leaving the contaminated `app.main` module (with `app.state.limiter=MagicMock`) in `sys.modules` for later tests.
- **Fix**: Added `sys.modules.pop("app.main", None)` at the start of `test_main_app_has_limiter_attached` so the subsequent `from app.main import app` always triggers a fresh import using the real (restored) `app.core.rate_limiter`.
- **Single file changed**: `knowledge-graph-builder/tests/unit/test_rate_limiting.py` (+7 lines)

## Test plan

- [x] `test_main_app_has_limiter_attached` passes in isolation
- [x] `test_main_app_has_limiter_attached` passes after `test_lifespan_sync_driver.py::test_lifespan_calls_connect_sync`
- [x] Full unit suite (1258 tests) passes: `pytest tests/unit/ -m unit`
- [ ] CI green on remote develop after merge

Closes #ORA-319

🤖 Generated with [Claude Code](https://claude.com/claude-code)