### PR TITLE
fix(mcp): register memory.context and memory.forget tools (ORA-324)

### DIFF
--- a/knowledge-graph-builder/app/mcp/registry.py
+++ b/knowledge-graph-builder/app/mcp/registry.py
@@ -73,6 +73,7 @@ from app.schemas.graph_schemas import (
 )
 from app.schemas.memory import (
     ConsolidateResponse,
+    MemoryContext,
     MemoryCreate,
     MemoryCreateResponse,
     MemorySearchResponse,
@@ -393,6 +394,41 @@ REGISTRY: tuple[CapabilitySpec, ...] = (
         description="Consolidate a graph's memory store (merge and prune).",
         path_params=("graph_id",),
         result_model=ConsolidateResponse,
+    ),
+    CapabilitySpec(
+        name="memory.context",
+        io_class=IOClass.PLAIN,
+        method="GET",
+        path="/api/v1/graphs/{graph_id}/memories/context",
+        description=(
+            "Assemble an agent context window from a graph's memory store. "
+            "Returns a context_block string ready to inject into an LLM prompt, "
+            "with memory provenance and a token estimate. Call this at the start "
+            "of each conversation turn when prior knowledge may be relevant."
+        ),
+        path_params=("graph_id",),
+        query_params=(
+            "query",
+            "agent_id",
+            "session_id",
+            "scope",
+            "max_tokens",
+            "include_types",
+        ),
+        result_model=MemoryContext,
+    ),
+    CapabilitySpec(
+        name="memory.forget",
+        io_class=IOClass.PLAIN,
+        method="DELETE",
+        path="/api/v1/graphs/{graph_id}/memories/{memory_id}",
+        description=(
+            "Forget (delete) a stored memory. Soft delete by default "
+            "(sets valid_to=now, preserving history); pass hard=true to "
+            "permanently remove the node from the graph."
+        ),
+        path_params=("graph_id", "memory_id"),
+        query_params=("hard",),
     ),
     # === connector.* — data-source connections ==============================
     CapabilitySpec(


### PR DESCRIPTION
## Summary

- Adds `memory.context` (`GET /graphs/{id}/memories/context`) to the MCP registry — the #1 agent-start tool that assembles a ready-to-inject context window from the memory store. Was absent from the curated set despite the REST endpoint existing since ORA-75.
- Adds `memory.forget` (`DELETE /graphs/{id}/memories/{id}`) — soft-deletes a memory by default (`valid_to=now`), hard-deletes with `?hard=true`. Needed for agent memory hygiene via MCP.
- Adds `MemoryContext` to the `app.schemas.memory` import so the projection can publish a typed result schema for `memory.context`.

Both REST endpoints already exist; this was purely a registry omission (root cause: endpoints implemented in ORA-75 but not added to the curated registry during ADR-024 curation).

## Test plan

- [ ] Import check: `from app.mcp.registry import REGISTRY` succeeds with no errors
- [ ] `memory.context` and `memory.forget` appear in MCP `tools/list` after server restart
- [ ] A `memory.context` call returns `context_block`, `memories_used`, `token_estimate`, `retrieval_ms`
- [ ] A `memory.forget` call returns 204 (projection surfaces success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)