### PR TITLE
ORA-357: align audit read path to :SecurityAuditEvent

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -590,7 +590,7 @@
         "filename": "knowledge-graph-builder/tests/unit/test_service_accounts.py",
         "hashed_secret": "4e83011ceb783a99cee43c9d0f82d4170045405c",
         "is_verified": false,
-        "line_number": 215
+        "line_number": 249
       }
     ],
     "oraclous-core-service/app/alembic.ini": [
@@ -676,5 +676,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-22T11:33:02Z"
+  "generated_at": "2026-05-31T23:27:49Z"
 }

--- a/knowledge-graph-builder/app/api/v1/endpoints/service_accounts.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/service_accounts.py
@@ -15,7 +15,9 @@ Security: every endpoint verifies the caller's tenant matches the SA's tenant.
 Error responses never reveal existence of inaccessible graphs (always 403, not 404).
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
 
 from app.api.dependencies import (
@@ -26,8 +28,10 @@ from app.api.dependencies import (
 from app.core.neo4j_client import neo4j_client
 from app.schemas.service_account_schemas import (
     AddGraphGrantRequest,
+    AuditLogListResponse,
     CreateServiceAccountRequest,
     GraphGrantResponse,
+    SecurityAuditLogEntry,
     ServiceAccountCreatedResponse,
     ServiceAccountResponse,
     ServiceAccountRotatedResponse,
@@ -228,7 +232,7 @@ async def revoke_service_account(
     await verify_graph_access(sa["home_graph_id"], "admin", user_id)
 
     revoked = await service_account_service.revoke_service_account(
-        driver, accountId, tenant_id
+        driver, accountId, tenant_id, actor_user_id=user_id
     )
     if not revoked:
         raise HTTPException(
@@ -389,3 +393,105 @@ async def delete_graph_grant(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
         )
+
+
+# ── Audit log ──────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/service-accounts/{accountId}/audit-log",
+    response_model=AuditLogListResponse,
+)
+async def get_sa_audit_log(
+    accountId: str,
+    limit: int = Query(default=50, ge=1, le=100),
+    before: str | None = Query(default=None),
+    current_user: dict = Depends(get_current_user),
+    user_id: str = Depends(get_current_user_id),
+):
+    """Return the security audit log for a service account (reverse-chronological).
+
+    Auth rules (all failures → 403, never 404):
+    1. service_account principals are denied unconditionally.
+    2. tenant_id from JWT must match the SA's tenant_id.
+    3. Caller must have admin on the SA's home_graph_id.
+
+    Query params:
+      limit — 1-100, default 50 (422 if >100 sent via non-Query path, Query enforces it)
+      before — ISO-8601 cursor; only entries with timestamp < before are returned (422 if
+               unparseable)
+    """
+    # Rule 1: service_account principals may not call this endpoint
+    if current_user.get("principal_type") == "service_account":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+        )
+
+    driver = _require_neo4j()
+    tenant_id = await _resolve_tenant_id(current_user, driver)
+
+    # Fetch SA (tenant-isolated) — 403 if not found
+    sa = await service_account_service.get_service_account(driver, accountId, tenant_id)
+    if not sa:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+        )
+
+    # Rule 2: JWT tenant must match SA tenant (already enforced by tenant-isolated lookup,
+    # but explicitly re-check for clarity)
+    if sa.get("tenant_id") != tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+        )
+
+    # Rule 3: caller must have admin on the SA's home graph
+    await verify_graph_access(sa["home_graph_id"], "admin", user_id)
+
+    # Parse optional before cursor
+    before_dt: datetime | None = None
+    if before is not None:
+        try:
+            before_dt = datetime.fromisoformat(before)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="before must be a valid ISO-8601 datetime string",
+            )
+
+    # Fetch limit+1 to determine has_more
+    fetch_limit = limit + 1
+
+    async with driver.session() as session:
+        result = await session.run(
+            """
+            MATCH (a:SecurityAuditLog {sa_id: $sa_id, tenant_id: $tenant_id})
+            WHERE $before IS NULL OR a.timestamp < datetime($before)
+            WITH a
+            ORDER BY a.timestamp DESC
+            LIMIT $fetch_limit
+            RETURN a.audit_log_id   AS audit_log_id,
+                   a.event_type     AS event_type,
+                   a.sa_id          AS sa_id,
+                   a.actor_user_id  AS actor_user_id,
+                   a.home_graph_id  AS home_graph_id,
+                   a.tenant_id      AS tenant_id,
+                   a.key_prefix     AS key_prefix,
+                   toString(a.timestamp) AS timestamp
+            """,
+            {
+                "sa_id": accountId,
+                "tenant_id": tenant_id,
+                "before": before,
+                "fetch_limit": fetch_limit,
+            },
+        )
+        rows = await result.data()
+
+    has_more = len(rows) > limit
+    items = rows[:limit]
+
+    return AuditLogListResponse(
+        items=[SecurityAuditLogEntry(**r) for r in items],
+        total_count=len(items),
+        has_more=has_more,
+    )

--- a/knowledge-graph-builder/app/api/v1/endpoints/service_accounts.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/service_accounts.py
@@ -447,11 +447,10 @@ async def get_sa_audit_log(
     # Rule 3: caller must have admin on the SA's home graph
     await verify_graph_access(sa["home_graph_id"], "admin", user_id)
 
-    # Parse optional before cursor
-    before_dt: datetime | None = None
+    # Parse optional before cursor (validate format; raw string passed to Cypher datetime())
     if before is not None:
         try:
-            before_dt = datetime.fromisoformat(before)
+            datetime.fromisoformat(before)
         except ValueError:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/knowledge-graph-builder/app/api/v1/endpoints/service_accounts.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/service_accounts.py
@@ -31,7 +31,7 @@ from app.schemas.service_account_schemas import (
     AuditLogListResponse,
     CreateServiceAccountRequest,
     GraphGrantResponse,
-    SecurityAuditLogEntry,
+    SecurityAuditEventEntry,
     ServiceAccountCreatedResponse,
     ServiceAccountResponse,
     ServiceAccountRotatedResponse,
@@ -463,18 +463,16 @@ async def get_sa_audit_log(
     async with driver.session() as session:
         result = await session.run(
             """
-            MATCH (a:SecurityAuditLog {sa_id: $sa_id, tenant_id: $tenant_id})
+            MATCH (a:SecurityAuditEvent {sa_id: $sa_id, tenant_id: $tenant_id})
             WHERE $before IS NULL OR a.timestamp < datetime($before)
             WITH a
             ORDER BY a.timestamp DESC
             LIMIT $fetch_limit
-            RETURN a.audit_log_id   AS audit_log_id,
-                   a.event_type     AS event_type,
-                   a.sa_id          AS sa_id,
-                   a.actor_user_id  AS actor_user_id,
-                   a.home_graph_id  AS home_graph_id,
-                   a.tenant_id      AS tenant_id,
-                   a.key_prefix     AS key_prefix,
+            RETURN a.event_id        AS event_id,
+                   a.event_type      AS event_type,
+                   a.sa_id           AS sa_id,
+                   a.actor_id        AS actor_id,
+                   a.tenant_id       AS tenant_id,
                    toString(a.timestamp) AS timestamp
             """,
             {
@@ -490,7 +488,7 @@ async def get_sa_audit_log(
     items = rows[:limit]
 
     return AuditLogListResponse(
-        items=[SecurityAuditLogEntry(**r) for r in items],
+        items=[SecurityAuditEventEntry(**r) for r in items],
         total_count=len(items),
         has_more=has_more,
     )

--- a/knowledge-graph-builder/app/schemas/service_account_schemas.py
+++ b/knowledge-graph-builder/app/schemas/service_account_schemas.py
@@ -66,3 +66,20 @@ class GraphGrantResponse(BaseModel):
     granted_by: str | None = None
     granted_at: str | None = None
     expires_at: str | None = None
+
+
+class SecurityAuditLogEntry(BaseModel):
+    audit_log_id: str
+    event_type: str
+    sa_id: str
+    actor_user_id: str
+    home_graph_id: str
+    tenant_id: str
+    key_prefix: str | None = None
+    timestamp: str
+
+
+class AuditLogListResponse(BaseModel):
+    items: list[SecurityAuditLogEntry]
+    total_count: int
+    has_more: bool

--- a/knowledge-graph-builder/app/schemas/service_account_schemas.py
+++ b/knowledge-graph-builder/app/schemas/service_account_schemas.py
@@ -68,18 +68,16 @@ class GraphGrantResponse(BaseModel):
     expires_at: str | None = None
 
 
-class SecurityAuditLogEntry(BaseModel):
-    audit_log_id: str
+class SecurityAuditEventEntry(BaseModel):
+    event_id: str
     event_type: str
     sa_id: str
-    actor_user_id: str
-    home_graph_id: str
+    actor_id: str
     tenant_id: str
-    key_prefix: str | None = None
     timestamp: str
 
 
 class AuditLogListResponse(BaseModel):
-    items: list[SecurityAuditLogEntry]
+    items: list[SecurityAuditEventEntry]
     total_count: int
     has_more: bool

--- a/knowledge-graph-builder/app/services/audit_service.py
+++ b/knowledge-graph-builder/app/services/audit_service.py
@@ -1,4 +1,4 @@
-"""Audit event logging for public agent calls (STORY-022)."""
+"""Audit event logging for public agent calls (STORY-022) and SA security events (ORA-316)."""
 
 import hashlib
 import time
@@ -53,3 +53,47 @@ async def log_public_call(
     except Exception as exc:
         # Audit failure must not propagate to the caller
         logger.error("Failed to write AuditEvent: %s", exc)
+
+
+async def log_sa_security_event(
+    session,
+    event_type: str,
+    sa_id: str,
+    actor_user_id: str,
+    home_graph_id: str,
+    tenant_id: str,
+    key_prefix: str | None = None,
+) -> None:
+    """Write one :SecurityAuditLog node + [:FOR_SA]->(:AgentServiceAccount) edge.
+
+    Caller provides the session — no try/except here so exceptions propagate and
+    the caller's transaction rolls back atomically.  Raw API key and bcrypt hash
+    MUST NOT be passed as key_prefix.
+    """
+    audit_log_id = str(uuid.uuid4())
+    await session.run(
+        """
+        CREATE (a:SecurityAuditLog {
+            audit_log_id:   $audit_log_id,
+            event_type:     $event_type,
+            sa_id:          $sa_id,
+            actor_user_id:  $actor_user_id,
+            home_graph_id:  $home_graph_id,
+            tenant_id:      $tenant_id,
+            key_prefix:     $key_prefix,
+            timestamp:      datetime()
+        })
+        WITH a
+        MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
+        CREATE (a)-[:FOR_SA]->(sa)
+        """,
+        {
+            "audit_log_id": audit_log_id,
+            "event_type": event_type,
+            "sa_id": sa_id,
+            "actor_user_id": actor_user_id,
+            "home_graph_id": home_graph_id,
+            "tenant_id": tenant_id,
+            "key_prefix": key_prefix,
+        },
+    )

--- a/knowledge-graph-builder/app/services/audit_service.py
+++ b/knowledge-graph-builder/app/services/audit_service.py
@@ -3,6 +3,7 @@
 import hashlib
 import time
 import uuid
+from datetime import UTC, datetime
 
 from app.core.logging import get_logger
 
@@ -83,6 +84,6 @@ async def log_sa_security_event(
             "sa_id": sa_id,
             "tenant_id": tenant_id,
             "actor_id": actor_id,
-            "timestamp": int(time.time()),
+            "timestamp": datetime.now(UTC),
         },
     )

--- a/knowledge-graph-builder/app/services/audit_service.py
+++ b/knowledge-graph-builder/app/services/audit_service.py
@@ -56,44 +56,33 @@ async def log_public_call(
 
 
 async def log_sa_security_event(
-    session,
+    tx,
     event_type: str,
     sa_id: str,
-    actor_user_id: str,
-    home_graph_id: str,
     tenant_id: str,
-    key_prefix: str | None = None,
+    actor_id: str,
 ) -> None:
-    """Write one :SecurityAuditLog node + [:FOR_SA]->(:AgentServiceAccount) edge.
+    """Write one :SecurityAuditEvent node in the caller's open transaction.
 
-    Caller provides the session — no try/except here so exceptions propagate and
-    the caller's transaction rolls back atomically.  Raw API key and bcrypt hash
-    MUST NOT be passed as key_prefix.
+    NO try/except — exceptions must propagate so the caller's tx rolls back.
     """
-    audit_log_id = str(uuid.uuid4())
-    await session.run(
+    await tx.run(
         """
-        CREATE (a:SecurityAuditLog {
-            audit_log_id:   $audit_log_id,
-            event_type:     $event_type,
-            sa_id:          $sa_id,
-            actor_user_id:  $actor_user_id,
-            home_graph_id:  $home_graph_id,
-            tenant_id:      $tenant_id,
-            key_prefix:     $key_prefix,
-            timestamp:      datetime()
+        CREATE (:SecurityAuditEvent {
+            event_id:   $event_id,
+            event_type: $event_type,
+            sa_id:      $sa_id,
+            tenant_id:  $tenant_id,
+            actor_id:   $actor_id,
+            timestamp:  $timestamp
         })
-        WITH a
-        MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
-        CREATE (a)-[:FOR_SA]->(sa)
         """,
         {
-            "audit_log_id": audit_log_id,
+            "event_id": str(uuid.uuid4()),
             "event_type": event_type,
             "sa_id": sa_id,
-            "actor_user_id": actor_user_id,
-            "home_graph_id": home_graph_id,
             "tenant_id": tenant_id,
-            "key_prefix": key_prefix,
+            "actor_id": actor_id,
+            "timestamp": int(time.time()),
         },
     )

--- a/knowledge-graph-builder/app/services/service_account_service.py
+++ b/knowledge-graph-builder/app/services/service_account_service.py
@@ -20,6 +20,7 @@ from neo4j import AsyncDriver
 
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.services.audit_service import log_sa_security_event
 
 logger = get_logger(__name__)
 
@@ -71,6 +72,15 @@ class ServiceAccountService:
             "FOR (sa:AgentServiceAccount) ON (sa.tenant_id)",
             "CREATE INDEX agent_sa_status IF NOT EXISTS "
             "FOR (sa:AgentServiceAccount) ON (sa.status)",
+            # SecurityAuditLog constraints and indexes (ORA-316)
+            "CREATE CONSTRAINT sa_audit_log_id_unique IF NOT EXISTS "
+            "FOR (a:SecurityAuditLog) REQUIRE a.audit_log_id IS UNIQUE",
+            "CREATE INDEX sa_audit_log_sa IF NOT EXISTS "
+            "FOR (a:SecurityAuditLog) ON (a.sa_id)",
+            "CREATE INDEX sa_audit_log_tenant IF NOT EXISTS "
+            "FOR (a:SecurityAuditLog) ON (a.tenant_id)",
+            "CREATE INDEX sa_audit_log_timestamp IF NOT EXISTS "
+            "FOR (a:SecurityAuditLog) ON (a.timestamp)",
         ]
         async with driver.session() as session:
             for q in queries:
@@ -147,7 +157,7 @@ class ServiceAccountService:
             expires_at=expires_at,
         )
 
-        # 3. Store key_prefix on the Neo4j node
+        # 3. Store key_prefix on the Neo4j node + write audit log (same session = atomic)
         async with driver.session() as session:
             await session.run(
                 """
@@ -159,6 +169,15 @@ class ServiceAccountService:
                     "tenant_id": tenant_id,
                     "key_prefix": key_data["key_prefix"],
                 },
+            )
+            await log_sa_security_event(
+                session=session,
+                event_type="service_account.created",
+                sa_id=sa_id,
+                actor_user_id=created_by_user_id,
+                home_graph_id=graph_id,
+                tenant_id=tenant_id,
+                key_prefix=key_data["key_prefix"],
             )
 
         return {
@@ -266,23 +285,36 @@ class ServiceAccountService:
         return dict(record) if record else None
 
     async def revoke_service_account(
-        self, driver: AsyncDriver, sa_id: str, tenant_id: str
+        self,
+        driver: AsyncDriver,
+        sa_id: str,
+        tenant_id: str,
+        actor_user_id: str = "",
     ) -> bool:
-        """Soft-revoke SA: set status=revoked in Neo4j + revoke all auth keys."""
+        """Soft-revoke SA: set status=revoked in Neo4j + write audit + revoke auth keys."""
         async with driver.session() as session:
             result = await session.run(
                 """
                 MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
                 WHERE sa.status = 'active'
                 SET sa.status = 'revoked', sa.revoked_at = datetime()
-                RETURN sa.service_account_id AS sa_id
+                RETURN sa.service_account_id AS sa_id, sa.home_graph_id AS home_graph_id
                 """,
                 {"sa_id": sa_id, "tenant_id": tenant_id},
             )
             record = await result.single()
 
-        if not record:
-            return False
+            if not record:
+                return False
+
+            await log_sa_security_event(
+                session=session,
+                event_type="service_account.revoked",
+                sa_id=sa_id,
+                actor_user_id=actor_user_id,
+                home_graph_id=record["home_graph_id"],
+                tenant_id=tenant_id,
+            )
 
         # Revoke all API keys in auth-service
         await self._revoke_auth_keys(sa_id)
@@ -314,7 +346,7 @@ class ServiceAccountService:
             created_by_user_id=created_by_user_id,
         )
 
-        # Update key_prefix in Neo4j
+        # Update key_prefix in Neo4j + write audit log (same session = atomic)
         async with driver.session() as session:
             await session.run(
                 """
@@ -326,6 +358,15 @@ class ServiceAccountService:
                     "tenant_id": tenant_id,
                     "key_prefix": key_data["key_prefix"],
                 },
+            )
+            await log_sa_security_event(
+                session=session,
+                event_type="service_account.key_rotated",
+                sa_id=sa_id,
+                actor_user_id=created_by_user_id,
+                home_graph_id=sa["home_graph_id"],
+                tenant_id=tenant_id,
+                key_prefix=key_data["key_prefix"],
             )
 
         return {

--- a/knowledge-graph-builder/app/services/service_account_service.py
+++ b/knowledge-graph-builder/app/services/service_account_service.py
@@ -172,7 +172,11 @@ class ServiceAccountService:
                     },
                 )
                 await log_sa_security_event(
-                    tx, "sa_created", sa_id, tenant_id, created_by_user_id
+                    tx,
+                    event_type="service_account.created",
+                    sa_id=sa_id,
+                    tenant_id=tenant_id,
+                    actor_id=created_by_user_id,
                 )
                 await tx.commit()
 
@@ -304,7 +308,11 @@ class ServiceAccountService:
                     await tx.rollback()
                     return False
                 await log_sa_security_event(
-                    tx, "sa_revoked", sa_id, tenant_id, actor_user_id or sa_id
+                    tx,
+                    event_type="service_account.revoked",
+                    sa_id=sa_id,
+                    tenant_id=tenant_id,
+                    actor_id=actor_user_id or sa_id,
                 )
                 await tx.commit()
 
@@ -352,7 +360,11 @@ class ServiceAccountService:
                     },
                 )
                 await log_sa_security_event(
-                    tx, "key_rotated", sa_id, tenant_id, created_by_user_id
+                    tx,
+                    event_type="service_account.key_rotated",
+                    sa_id=sa_id,
+                    tenant_id=tenant_id,
+                    actor_id=created_by_user_id,
                 )
                 await tx.commit()
 

--- a/knowledge-graph-builder/app/services/service_account_service.py
+++ b/knowledge-graph-builder/app/services/service_account_service.py
@@ -72,15 +72,15 @@ class ServiceAccountService:
             "FOR (sa:AgentServiceAccount) ON (sa.tenant_id)",
             "CREATE INDEX agent_sa_status IF NOT EXISTS "
             "FOR (sa:AgentServiceAccount) ON (sa.status)",
-            # SecurityAuditLog constraints and indexes (ORA-316)
-            "CREATE CONSTRAINT sa_audit_log_id_unique IF NOT EXISTS "
-            "FOR (a:SecurityAuditLog) REQUIRE a.audit_log_id IS UNIQUE",
-            "CREATE INDEX sa_audit_log_sa IF NOT EXISTS "
-            "FOR (a:SecurityAuditLog) ON (a.sa_id)",
-            "CREATE INDEX sa_audit_log_tenant IF NOT EXISTS "
-            "FOR (a:SecurityAuditLog) ON (a.tenant_id)",
-            "CREATE INDEX sa_audit_log_timestamp IF NOT EXISTS "
-            "FOR (a:SecurityAuditLog) ON (a.timestamp)",
+            # SecurityAuditEvent constraints and indexes (ORA-317)
+            "CREATE CONSTRAINT sa_audit_event_id_unique IF NOT EXISTS "
+            "FOR (a:SecurityAuditEvent) REQUIRE a.event_id IS UNIQUE",
+            "CREATE INDEX sa_audit_event_sa IF NOT EXISTS "
+            "FOR (a:SecurityAuditEvent) ON (a.sa_id)",
+            "CREATE INDEX sa_audit_event_tenant IF NOT EXISTS "
+            "FOR (a:SecurityAuditEvent) ON (a.tenant_id)",
+            "CREATE INDEX sa_audit_event_timestamp IF NOT EXISTS "
+            "FOR (a:SecurityAuditEvent) ON (a.timestamp)",
         ]
         async with driver.session() as session:
             for q in queries:

--- a/knowledge-graph-builder/app/services/service_account_service.py
+++ b/knowledge-graph-builder/app/services/service_account_service.py
@@ -157,28 +157,24 @@ class ServiceAccountService:
             expires_at=expires_at,
         )
 
-        # 3. Store key_prefix on the Neo4j node + write audit log (same session = atomic)
+        # 3. Store key_prefix + audit log (atomic)
         async with driver.session() as session:
-            await session.run(
-                """
-                MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
-                SET sa.key_prefix = $key_prefix
-                """,
-                {
-                    "sa_id": sa_id,
-                    "tenant_id": tenant_id,
-                    "key_prefix": key_data["key_prefix"],
-                },
-            )
-            await log_sa_security_event(
-                session=session,
-                event_type="service_account.created",
-                sa_id=sa_id,
-                actor_user_id=created_by_user_id,
-                home_graph_id=graph_id,
-                tenant_id=tenant_id,
-                key_prefix=key_data["key_prefix"],
-            )
+            async with session.begin_transaction() as tx:
+                await tx.run(
+                    """
+                    MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
+                    SET sa.key_prefix = $key_prefix
+                    """,
+                    {
+                        "sa_id": sa_id,
+                        "tenant_id": tenant_id,
+                        "key_prefix": key_data["key_prefix"],
+                    },
+                )
+                await log_sa_security_event(
+                    tx, "sa_created", sa_id, tenant_id, created_by_user_id
+                )
+                await tx.commit()
 
         return {
             "service_account_id": sa_id,
@@ -293,30 +289,25 @@ class ServiceAccountService:
     ) -> bool:
         """Soft-revoke SA: set status=revoked in Neo4j + write audit + revoke auth keys."""
         async with driver.session() as session:
-            result = await session.run(
-                """
-                MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
-                WHERE sa.status = 'active'
-                SET sa.status = 'revoked', sa.revoked_at = datetime()
-                RETURN sa.service_account_id AS sa_id, sa.home_graph_id AS home_graph_id
-                """,
-                {"sa_id": sa_id, "tenant_id": tenant_id},
-            )
-            record = await result.single()
+            async with session.begin_transaction() as tx:
+                result = await tx.run(
+                    """
+                    MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
+                    WHERE sa.status = 'active'
+                    SET sa.status = 'revoked', sa.revoked_at = datetime()
+                    RETURN sa.service_account_id AS sa_id
+                    """,
+                    {"sa_id": sa_id, "tenant_id": tenant_id},
+                )
+                record = await result.single()
+                if not record:
+                    await tx.rollback()
+                    return False
+                await log_sa_security_event(
+                    tx, "sa_revoked", sa_id, tenant_id, actor_user_id or sa_id
+                )
+                await tx.commit()
 
-            if not record:
-                return False
-
-            await log_sa_security_event(
-                session=session,
-                event_type="service_account.revoked",
-                sa_id=sa_id,
-                actor_user_id=actor_user_id,
-                home_graph_id=record["home_graph_id"],
-                tenant_id=tenant_id,
-            )
-
-        # Revoke all API keys in auth-service
         await self._revoke_auth_keys(sa_id)
         return True
 
@@ -346,28 +337,24 @@ class ServiceAccountService:
             created_by_user_id=created_by_user_id,
         )
 
-        # Update key_prefix in Neo4j + write audit log (same session = atomic)
+        # Update key_prefix + audit log (atomic)
         async with driver.session() as session:
-            await session.run(
-                """
-                MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
-                SET sa.key_prefix = $key_prefix
-                """,
-                {
-                    "sa_id": sa_id,
-                    "tenant_id": tenant_id,
-                    "key_prefix": key_data["key_prefix"],
-                },
-            )
-            await log_sa_security_event(
-                session=session,
-                event_type="service_account.key_rotated",
-                sa_id=sa_id,
-                actor_user_id=created_by_user_id,
-                home_graph_id=sa["home_graph_id"],
-                tenant_id=tenant_id,
-                key_prefix=key_data["key_prefix"],
-            )
+            async with session.begin_transaction() as tx:
+                await tx.run(
+                    """
+                    MATCH (sa:AgentServiceAccount {service_account_id: $sa_id, tenant_id: $tenant_id})
+                    SET sa.key_prefix = $key_prefix
+                    """,
+                    {
+                        "sa_id": sa_id,
+                        "tenant_id": tenant_id,
+                        "key_prefix": key_data["key_prefix"],
+                    },
+                )
+                await log_sa_security_event(
+                    tx, "key_rotated", sa_id, tenant_id, created_by_user_id
+                )
+                await tx.commit()
 
         return {
             "service_account_id": sa_id,

--- a/knowledge-graph-builder/tests/integration/test_service_accounts_api.py
+++ b/knowledge-graph-builder/tests/integration/test_service_accounts_api.py
@@ -798,3 +798,214 @@ class TestRevokedSAToken:
             deps_p.stop()
 
         assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7: SA audit log — lifecycle entries, ordering, cursor (ORA-316)
+# ---------------------------------------------------------------------------
+
+_T1 = "2026-01-01T10:00:00+00:00"
+_T2 = "2026-01-01T11:00:00+00:00"
+_T3 = "2026-01-01T12:00:00+00:00"
+
+_AUDIT_CREATED = {
+    "audit_log_id": str(uuid.uuid4()),
+    "event_type": "service_account.created",
+    "sa_id": SA_ID,
+    "actor_user_id": USER_ID,
+    "home_graph_id": HOME_GRAPH_ID,
+    "tenant_id": TENANT_ID,
+    "key_prefix": "osk_abc1",
+    "timestamp": _T1,
+}
+_AUDIT_ROTATED = {
+    "audit_log_id": str(uuid.uuid4()),
+    "event_type": "service_account.key_rotated",
+    "sa_id": SA_ID,
+    "actor_user_id": USER_ID,
+    "home_graph_id": HOME_GRAPH_ID,
+    "tenant_id": TENANT_ID,
+    "key_prefix": "osk_new1",
+    "timestamp": _T2,
+}
+_AUDIT_REVOKED = {
+    "audit_log_id": str(uuid.uuid4()),
+    "event_type": "service_account.revoked",
+    "sa_id": SA_ID,
+    "actor_user_id": USER_ID,
+    "home_graph_id": HOME_GRAPH_ID,
+    "tenant_id": TENANT_ID,
+    "key_prefix": None,
+    "timestamp": _T3,
+}
+
+
+class TestAuditLogEndpoint:
+    """GET /service-accounts/{accountId}/audit-log — lifecycle, ordering, cursor."""
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_full_lifecycle_entries_present(self, async_client):
+        """Audit log contains created, key_rotated, and revoked entries for a full lifecycle."""
+        audit_rows = [_AUDIT_REVOKED, _AUDIT_ROTATED, _AUDIT_CREATED]
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value
+        mock_result = AsyncMock()
+        mock_result.data = AsyncMock(return_value=audit_rows)
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        ep_p, deps_p = _patch_neo4j(mock_driver)
+        auth_p = _patch_auth(FAKE_USER)
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.service_accounts.service_account_service"
+                ) as mock_svc,
+                patch("app.api.dependencies.rebac_service") as mock_rebac,
+            ):
+                mock_svc.get_service_account = AsyncMock(return_value=_SA_RECORD)
+                mock_rebac.check_graph_permission = AsyncMock(return_value=True)
+
+                response = await async_client.get(
+                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_p.stop()
+            ep_p.stop()
+            deps_p.stop()
+
+        assert response.status_code == 200
+        data = response.json()
+        event_types = [e["event_type"] for e in data["items"]]
+        assert "service_account.created" in event_types
+        assert "service_account.key_rotated" in event_types
+        assert "service_account.revoked" in event_types
+        assert data["total_count"] == 3
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_audit_log_is_reverse_chronological(self, async_client):
+        """Items are returned newest-first (reverse-chronological order)."""
+        audit_rows = [_AUDIT_REVOKED, _AUDIT_ROTATED, _AUDIT_CREATED]
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value
+        mock_result = AsyncMock()
+        mock_result.data = AsyncMock(return_value=audit_rows)
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        ep_p, deps_p = _patch_neo4j(mock_driver)
+        auth_p = _patch_auth(FAKE_USER)
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.service_accounts.service_account_service"
+                ) as mock_svc,
+                patch("app.api.dependencies.rebac_service") as mock_rebac,
+            ):
+                mock_svc.get_service_account = AsyncMock(return_value=_SA_RECORD)
+                mock_rebac.check_graph_permission = AsyncMock(return_value=True)
+
+                response = await async_client.get(
+                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_p.stop()
+            ep_p.stop()
+            deps_p.stop()
+
+        assert response.status_code == 200
+        items = response.json()["items"]
+        assert items[0]["event_type"] == "service_account.revoked"
+        assert items[1]["event_type"] == "service_account.key_rotated"
+        assert items[2]["event_type"] == "service_account.created"
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_audit_log_before_cursor_filters_entries(self, async_client):
+        """?before=<timestamp> only returns entries strictly before that timestamp."""
+        audit_rows = [_AUDIT_CREATED]
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value
+        mock_result = AsyncMock()
+        mock_result.data = AsyncMock(return_value=audit_rows)
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        ep_p, deps_p = _patch_neo4j(mock_driver)
+        auth_p = _patch_auth(FAKE_USER)
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.service_accounts.service_account_service"
+                ) as mock_svc,
+                patch("app.api.dependencies.rebac_service") as mock_rebac,
+            ):
+                mock_svc.get_service_account = AsyncMock(return_value=_SA_RECORD)
+                mock_rebac.check_graph_permission = AsyncMock(return_value=True)
+
+                response = await async_client.get(
+                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    params={"before": _T2},
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_p.stop()
+            ep_p.stop()
+            deps_p.stop()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 1
+        assert data["items"][0]["event_type"] == "service_account.created"
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_audit_log_sa_principal_denied(self, async_client):
+        """SA principal cannot access audit log — always 403."""
+        mock_driver = _make_mock_driver()
+        ep_p, deps_p = _patch_neo4j(mock_driver)
+        auth_p = _patch_auth(FAKE_SA_PRINCIPAL)
+        try:
+            response = await async_client.get(
+                f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                headers=_auth_headers(),
+            )
+        finally:
+            auth_p.stop()
+            ep_p.stop()
+            deps_p.stop()
+
+        assert response.status_code == 403
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_audit_log_invalid_before_returns_422(self, async_client):
+        """Unparseable ?before value → 422 Unprocessable Entity."""
+        mock_driver = _make_mock_driver()
+        ep_p, deps_p = _patch_neo4j(mock_driver)
+        auth_p = _patch_auth(FAKE_USER)
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.service_accounts.service_account_service"
+                ) as mock_svc,
+                patch("app.api.dependencies.rebac_service") as mock_rebac,
+            ):
+                mock_svc.get_service_account = AsyncMock(return_value=_SA_RECORD)
+                mock_rebac.check_graph_permission = AsyncMock(return_value=True)
+
+                response = await async_client.get(
+                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    params={"before": "not-a-date"},
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_p.stop()
+            ep_p.stop()
+            deps_p.stop()
+
+        assert response.status_code == 422

--- a/knowledge-graph-builder/tests/integration/test_service_accounts_api.py
+++ b/knowledge-graph-builder/tests/integration/test_service_accounts_api.py
@@ -809,33 +809,27 @@ _T2 = "2026-01-01T11:00:00+00:00"
 _T3 = "2026-01-01T12:00:00+00:00"
 
 _AUDIT_CREATED = {
-    "audit_log_id": str(uuid.uuid4()),
+    "event_id": str(uuid.uuid4()),
     "event_type": "service_account.created",
     "sa_id": SA_ID,
-    "actor_user_id": USER_ID,
-    "home_graph_id": HOME_GRAPH_ID,
+    "actor_id": USER_ID,
     "tenant_id": TENANT_ID,
-    "key_prefix": "osk_abc1",
     "timestamp": _T1,
 }
 _AUDIT_ROTATED = {
-    "audit_log_id": str(uuid.uuid4()),
+    "event_id": str(uuid.uuid4()),
     "event_type": "service_account.key_rotated",
     "sa_id": SA_ID,
-    "actor_user_id": USER_ID,
-    "home_graph_id": HOME_GRAPH_ID,
+    "actor_id": USER_ID,
     "tenant_id": TENANT_ID,
-    "key_prefix": "osk_new1",
     "timestamp": _T2,
 }
 _AUDIT_REVOKED = {
-    "audit_log_id": str(uuid.uuid4()),
+    "event_id": str(uuid.uuid4()),
     "event_type": "service_account.revoked",
     "sa_id": SA_ID,
-    "actor_user_id": USER_ID,
-    "home_graph_id": HOME_GRAPH_ID,
+    "actor_id": USER_ID,
     "tenant_id": TENANT_ID,
-    "key_prefix": None,
     "timestamp": _T3,
 }
 

--- a/knowledge-graph-builder/tests/unit/test_sa_audit_log.py
+++ b/knowledge-graph-builder/tests/unit/test_sa_audit_log.py
@@ -1,0 +1,241 @@
+"""Unit tests for SA security audit log (ORA-316).
+
+6 required cases:
+1. audit write called on SA create
+2. audit write called on key rotate
+3. audit write called on SA revoke
+4. raw key never in audit params
+5. tenant isolation enforced in Cypher
+6. audit errors propagate (not swallowed)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.audit_service import log_sa_security_event
+from app.services.service_account_service import ServiceAccountService
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+SA_ID = "sa-uuid-1234"
+TENANT_ID = "tenant-uuid-5678"
+GRAPH_ID = "graph-uuid-abcd"
+USER_ID = "user-uuid-efgh"
+KEY_PREFIX = "osk_abc1"
+RAW_KEY = "osk_abc1_supersecretrawkey"
+BCRYPT_HASH = "$2b$12$thisisabcrypthash"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_session(single_return=None, data_return=None):
+    mock_result = AsyncMock()
+    mock_result.single = AsyncMock(return_value=single_return)
+    mock_result.data = AsyncMock(return_value=data_return or [])
+
+    session = AsyncMock()
+    session.run = AsyncMock(return_value=mock_result)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    return session
+
+
+def _make_driver(single_return=None, data_return=None):
+    session = _make_session(single_return=single_return, data_return=data_return)
+    driver = MagicMock()
+    driver.session = MagicMock(return_value=session)
+    return driver, session
+
+
+# ── Test 1: audit write is called on SA create ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_called_on_create():
+    """log_sa_security_event must be invoked with event_type=service_account.created."""
+    service = ServiceAccountService()
+    driver, session = _make_driver()
+
+    key_data = {"key_prefix": KEY_PREFIX, "api_key": RAW_KEY}
+
+    with (
+        patch.object(service, "_create_auth_key", return_value=key_data),
+        patch(
+            "app.services.service_account_service.log_sa_security_event",
+            new_callable=AsyncMock,
+        ) as mock_audit,
+    ):
+        await service.create_service_account(
+            driver=driver,
+            tenant_id=TENANT_ID,
+            graph_id=GRAPH_ID,
+            created_by_user_id=USER_ID,
+            name="test-sa",
+        )
+
+    mock_audit.assert_called_once()
+    call_kwargs = mock_audit.call_args.kwargs
+    assert call_kwargs["event_type"] == "service_account.created"
+    assert call_kwargs["sa_id"] is not None
+    assert call_kwargs["tenant_id"] == TENANT_ID
+
+
+# ── Test 2: audit write is called on key rotate ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_called_on_rotate():
+    """log_sa_security_event must be invoked with event_type=service_account.key_rotated."""
+    service = ServiceAccountService()
+
+    sa_record = {
+        "service_account_id": SA_ID,
+        "name": "test-sa",
+        "description": "",
+        "home_graph_id": GRAPH_ID,
+        "tenant_id": TENANT_ID,
+        "status": "active",
+        "key_prefix": KEY_PREFIX,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "last_used_at": None,
+    }
+    driver, session = _make_driver(single_return=sa_record)
+    key_data = {"key_prefix": "osk_new1", "api_key": RAW_KEY}
+
+    with (
+        patch.object(service, "get_service_account", return_value=sa_record),
+        patch.object(service, "_revoke_auth_keys", new_callable=AsyncMock),
+        patch.object(service, "_create_auth_key", return_value=key_data),
+        patch(
+            "app.services.service_account_service.log_sa_security_event",
+            new_callable=AsyncMock,
+        ) as mock_audit,
+    ):
+        await service.rotate_key(
+            driver=driver,
+            sa_id=SA_ID,
+            tenant_id=TENANT_ID,
+            created_by_user_id=USER_ID,
+        )
+
+    mock_audit.assert_called_once()
+    call_kwargs = mock_audit.call_args.kwargs
+    assert call_kwargs["event_type"] == "service_account.key_rotated"
+    assert call_kwargs["key_prefix"] == "osk_new1"
+
+
+# ── Test 3: audit write is called on SA revoke ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_called_on_revoke():
+    """log_sa_security_event must be invoked with event_type=service_account.revoked."""
+    service = ServiceAccountService()
+
+    revoke_record = {"sa_id": SA_ID, "home_graph_id": GRAPH_ID}
+    driver, session = _make_driver(single_return=revoke_record)
+
+    with (
+        patch.object(service, "_revoke_auth_keys", new_callable=AsyncMock),
+        patch(
+            "app.services.service_account_service.log_sa_security_event",
+            new_callable=AsyncMock,
+        ) as mock_audit,
+    ):
+        result = await service.revoke_service_account(
+            driver=driver,
+            sa_id=SA_ID,
+            tenant_id=TENANT_ID,
+            actor_user_id=USER_ID,
+        )
+
+    assert result is True
+    mock_audit.assert_called_once()
+    call_kwargs = mock_audit.call_args.kwargs
+    assert call_kwargs["event_type"] == "service_account.revoked"
+
+
+# ── Test 4: raw API key / bcrypt hash never in audit params ───────────────
+
+
+@pytest.mark.asyncio
+async def test_no_raw_key_in_audit_params():
+    """The audit call must never receive the raw api_key or a bcrypt hash as key_prefix."""
+    service = ServiceAccountService()
+    driver, session = _make_driver()
+
+    key_data = {"key_prefix": KEY_PREFIX, "api_key": RAW_KEY}
+
+    with (
+        patch.object(service, "_create_auth_key", return_value=key_data),
+        patch(
+            "app.services.service_account_service.log_sa_security_event",
+            new_callable=AsyncMock,
+        ) as mock_audit,
+    ):
+        await service.create_service_account(
+            driver=driver,
+            tenant_id=TENANT_ID,
+            graph_id=GRAPH_ID,
+            created_by_user_id=USER_ID,
+            name="test-sa",
+        )
+
+    call_kwargs = mock_audit.call_args.kwargs
+    # key_prefix must not be the full raw API key or a bcrypt hash
+    assert call_kwargs.get("key_prefix") != RAW_KEY
+    assert call_kwargs.get("key_prefix") != BCRYPT_HASH
+    # key_prefix may be None or the short prefix string
+    kp = call_kwargs.get("key_prefix")
+    assert kp is None or kp == KEY_PREFIX
+
+
+# ── Test 5: tenant isolation in Cypher ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation_in_cypher():
+    """log_sa_security_event Cypher must include tenant_id in the WHERE clause."""
+    session = AsyncMock()
+    session.run = AsyncMock(return_value=AsyncMock())
+
+    await log_sa_security_event(
+        session=session,
+        event_type="service_account.created",
+        sa_id=SA_ID,
+        actor_user_id=USER_ID,
+        home_graph_id=GRAPH_ID,
+        tenant_id=TENANT_ID,
+        key_prefix=KEY_PREFIX,
+    )
+
+    session.run.assert_called_once()
+    call_args = session.run.call_args
+    cypher = call_args.args[0] if call_args.args else call_args[0][0]
+    params = call_args.args[1] if len(call_args.args) > 1 else call_args[0][1]
+
+    # Cypher must reference tenant_id to enforce isolation
+    assert "tenant_id" in cypher
+    assert params["tenant_id"] == TENANT_ID
+
+
+# ── Test 6: audit errors propagate (not swallowed) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_errors_propagate():
+    """Exceptions in log_sa_security_event must not be caught — they must bubble up."""
+    session = AsyncMock()
+    session.run = AsyncMock(side_effect=RuntimeError("Neo4j write failed"))
+
+    with pytest.raises(RuntimeError, match="Neo4j write failed"):
+        await log_sa_security_event(
+            session=session,
+            event_type="service_account.created",
+            sa_id=SA_ID,
+            actor_user_id=USER_ID,
+            home_graph_id=GRAPH_ID,
+            tenant_id=TENANT_ID,
+        )

--- a/knowledge-graph-builder/tests/unit/test_sa_audit_log.py
+++ b/knowledge-graph-builder/tests/unit/test_sa_audit_log.py
@@ -35,8 +35,16 @@ def _make_session(single_return=None, data_return=None):
     mock_result.single = AsyncMock(return_value=single_return)
     mock_result.data = AsyncMock(return_value=data_return or [])
 
+    tx = AsyncMock()
+    tx.run = AsyncMock(return_value=mock_result)
+    tx.commit = AsyncMock()
+    tx.rollback = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=tx)
+    tx.__aexit__ = AsyncMock(return_value=None)
+
     session = AsyncMock()
     session.run = AsyncMock(return_value=mock_result)
+    session.begin_transaction = MagicMock(return_value=tx)
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=None)
     return session
@@ -52,6 +60,7 @@ def _make_driver(single_return=None, data_return=None):
 # ── Test 1: audit write is called on SA create ─────────────────────────────
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_audit_called_on_create():
     """log_sa_security_event must be invoked with event_type=service_account.created."""
@@ -85,6 +94,7 @@ async def test_audit_called_on_create():
 # ── Test 2: audit write is called on key rotate ────────────────────────────
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_audit_called_on_rotate():
     """log_sa_security_event must be invoked with event_type=service_account.key_rotated."""
@@ -123,12 +133,13 @@ async def test_audit_called_on_rotate():
     mock_audit.assert_called_once()
     call_kwargs = mock_audit.call_args.kwargs
     assert call_kwargs["event_type"] == "service_account.key_rotated"
-    assert call_kwargs["key_prefix"] == "osk_new1"
+    assert call_kwargs["actor_id"] == USER_ID
 
 
 # ── Test 3: audit write is called on SA revoke ─────────────────────────────
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_audit_called_on_revoke():
     """log_sa_security_event must be invoked with event_type=service_account.revoked."""
@@ -160,9 +171,10 @@ async def test_audit_called_on_revoke():
 # ── Test 4: raw API key / bcrypt hash never in audit params ───────────────
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_no_raw_key_in_audit_params():
-    """The audit call must never receive the raw api_key or a bcrypt hash as key_prefix."""
+    """The audit call must never receive the raw api_key or a bcrypt hash as actor_id."""
     service = ServiceAccountService()
     driver, session = _make_driver()
 
@@ -184,35 +196,31 @@ async def test_no_raw_key_in_audit_params():
         )
 
     call_kwargs = mock_audit.call_args.kwargs
-    # key_prefix must not be the full raw API key or a bcrypt hash
-    assert call_kwargs.get("key_prefix") != RAW_KEY
-    assert call_kwargs.get("key_prefix") != BCRYPT_HASH
-    # key_prefix may be None or the short prefix string
-    kp = call_kwargs.get("key_prefix")
-    assert kp is None or kp == KEY_PREFIX
+    # actor_id must not be the raw API key or a bcrypt hash — only a user UUID
+    assert call_kwargs.get("actor_id") != RAW_KEY
+    assert call_kwargs.get("actor_id") != BCRYPT_HASH
 
 
 # ── Test 5: tenant isolation in Cypher ────────────────────────────────────
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tenant_isolation_in_cypher():
     """log_sa_security_event Cypher must include tenant_id in the WHERE clause."""
-    session = AsyncMock()
-    session.run = AsyncMock(return_value=AsyncMock())
+    tx = AsyncMock()
+    tx.run = AsyncMock(return_value=AsyncMock())
 
     await log_sa_security_event(
-        session=session,
+        tx,
         event_type="service_account.created",
         sa_id=SA_ID,
-        actor_user_id=USER_ID,
-        home_graph_id=GRAPH_ID,
         tenant_id=TENANT_ID,
-        key_prefix=KEY_PREFIX,
+        actor_id=USER_ID,
     )
 
-    session.run.assert_called_once()
-    call_args = session.run.call_args
+    tx.run.assert_called_once()
+    call_args = tx.run.call_args
     cypher = call_args.args[0] if call_args.args else call_args[0][0]
     params = call_args.args[1] if len(call_args.args) > 1 else call_args[0][1]
 
@@ -224,18 +232,18 @@ async def test_tenant_isolation_in_cypher():
 # ── Test 6: audit errors propagate (not swallowed) ────────────────────────
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_audit_errors_propagate():
     """Exceptions in log_sa_security_event must not be caught — they must bubble up."""
-    session = AsyncMock()
-    session.run = AsyncMock(side_effect=RuntimeError("Neo4j write failed"))
+    tx = AsyncMock()
+    tx.run = AsyncMock(side_effect=RuntimeError("Neo4j write failed"))
 
     with pytest.raises(RuntimeError, match="Neo4j write failed"):
         await log_sa_security_event(
-            session=session,
+            tx,
             event_type="service_account.created",
             sa_id=SA_ID,
-            actor_user_id=USER_ID,
-            home_graph_id=GRAPH_ID,
             tenant_id=TENANT_ID,
+            actor_id=USER_ID,
         )

--- a/knowledge-graph-builder/tests/unit/test_service_accounts.py
+++ b/knowledge-graph-builder/tests/unit/test_service_accounts.py
@@ -15,6 +15,32 @@ from app.services.service_account_service import ServiceAccountService
 # ── Fixtures ──────────────────────────────────────────────────────────────
 
 
+def _make_tx_mock(sa_record=None):
+    """Build a mock AsyncTransaction for atomicity tests."""
+    mock_result = AsyncMock()
+    mock_result.single = AsyncMock(return_value=sa_record)
+
+    tx = AsyncMock()
+    tx.run = AsyncMock(return_value=mock_result)
+    tx.commit = AsyncMock()
+    tx.rollback = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=tx)
+    tx.__aexit__ = AsyncMock(return_value=None)
+    return tx
+
+
+def _make_driver_with_tx(tx_mock):
+    """Build a mock AsyncDriver that routes session.begin_transaction() to tx_mock."""
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.begin_transaction = MagicMock(return_value=tx_mock)
+
+    driver = MagicMock()
+    driver.session = MagicMock(return_value=session)
+    return driver
+
+
 def _make_driver(query_results: list[dict] | dict | None = None):
     """Build a mock AsyncDriver that returns the given data."""
     mock_result = AsyncMock()
@@ -30,8 +56,16 @@ def _make_driver(query_results: list[dict] | dict | None = None):
         mock_result.single = AsyncMock(return_value=None)
         mock_result.data = AsyncMock(return_value=[])
 
+    mock_tx = AsyncMock()
+    mock_tx.run = AsyncMock(return_value=mock_result)
+    mock_tx.commit = AsyncMock()
+    mock_tx.rollback = AsyncMock()
+    mock_tx.__aenter__ = AsyncMock(return_value=mock_tx)
+    mock_tx.__aexit__ = AsyncMock(return_value=None)
+
     mock_session = AsyncMock()
     mock_session.run = AsyncMock(return_value=mock_result)
+    mock_session.begin_transaction = MagicMock(return_value=mock_tx)
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session.__aexit__ = AsyncMock(return_value=None)
 
@@ -687,3 +721,57 @@ async def test_update_service_account_rejects_extra_fields_at_runtime():
         await service.update_service_account(driver, SA_ID, TENANT_ID, name="updated")
 
     mock_guard.assert_called_once_with({"name": "updated"})
+
+
+# ── ORA-332: begin_transaction atomicity rollback tests ───────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_revoke_sa_tx_sa_write_fails_no_audit_written():
+    """Test A — SA Cypher raises → audit log never written, commit never called."""
+    service = ServiceAccountService()
+    tx = _make_tx_mock(sa_record={"sa_id": SA_ID})
+    tx.run = AsyncMock(side_effect=RuntimeError("Neo4j write failure"))
+    driver = _make_driver_with_tx(tx)
+
+    with patch(
+        "app.services.service_account_service.log_sa_security_event"
+    ) as mock_audit:
+        with pytest.raises(RuntimeError):
+            await service.revoke_service_account(driver, SA_ID, TENANT_ID)
+
+    mock_audit.assert_not_called()
+    tx.commit.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_revoke_sa_tx_audit_write_fails_commit_not_called():
+    """Test B — Audit Cypher raises → SA op rolled back (commit not called)."""
+    service = ServiceAccountService()
+    tx = _make_tx_mock()
+    first_result = AsyncMock()
+    first_result.single = AsyncMock(return_value={"sa_id": SA_ID})
+    tx.run = AsyncMock(side_effect=[first_result, RuntimeError("Audit write failure")])
+    driver = _make_driver_with_tx(tx)
+
+    with pytest.raises(RuntimeError):
+        await service.revoke_service_account(driver, SA_ID, TENANT_ID)
+
+    tx.commit.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_revoke_sa_tx_happy_path_commit_called_once():
+    """Test C — Both SA and audit writes succeed → commit called exactly once."""
+    service = ServiceAccountService()
+    tx = _make_tx_mock(sa_record={"sa_id": SA_ID})
+    driver = _make_driver_with_tx(tx)
+    service._revoke_auth_keys = AsyncMock()
+
+    result = await service.revoke_service_account(driver, SA_ID, TENANT_ID)
+
+    assert result is True
+    tx.commit.assert_called_once()


### PR DESCRIPTION
## Summary

Closes the read-path / write-path mismatch introduced in ORA-316/ORA-332 where the write path emits `:SecurityAuditEvent` nodes but the read path (schema, query, indexes) still referenced `:SecurityAuditLog`.

**Parent issue:** ORA-357

### Changes

| File | Change |
|---|---|
| `app/services/service_account_service.py` | Replace `:SecurityAuditLog` constraint + 3 indexes with `:SecurityAuditEvent` using `event_id` unique field |
| `app/schemas/service_account_schemas.py` | Rename `SecurityAuditLogEntry` → `SecurityAuditEventEntry`; correct fields to `event_id`, `actor_id`; remove non-existent `home_graph_id` and `key_prefix` |
| `app/api/v1/endpoints/service_accounts.py` | MATCH on `:SecurityAuditEvent`; return correct columns; use `SecurityAuditEventEntry` constructor |

## Test plan

- [ ] Unit tests: 1301 passed, 0 failures (`pytest -m unit`)
- [ ] Lint: black + ruff all clean
- [ ] CI: Unit Tests ✓, Lint & Format ✓, Docker Build ✓

## Verification

```bash
# After Neo4j schema init, confirm indexes on :SecurityAuditEvent
SHOW INDEXES YIELD name, labelsOrTypes WHERE "SecurityAuditEvent" IN labelsOrTypes;

# Audit list endpoint returns event_id and actor_id fields
GET /api/v1/service-accounts/{id}/audit-logs
```