### PR TITLE
feat(analytics): get_entity_neighborhood() — N-hop subgraph query (ORA-358)

### DIFF
--- a/knowledge-graph-builder/app/services/analytics_service.py
+++ b/knowledge-graph-builder/app/services/analytics_service.py
@@ -17,6 +17,9 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
+from neo4j import AsyncDriver
+from neo4j.spatial import Point
+from neo4j.time import Date, DateTime, Duration, Time
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
@@ -2039,3 +2042,212 @@ class GraphAnalyticsService:
 
 # Create global instance
 analytics_service = GraphAnalyticsService()
+
+
+# ==================== NEIGHBORHOOD SUBGRAPH (ORA-358) ====================
+
+_NEIGHBORHOOD_MAX_NODES = 300
+
+# Edge types representing internal graph structure — excluded from UI responses.
+_NEIGHBORHOOD_EXCLUDED_EDGE_TYPES: frozenset[str] = frozenset(
+    {"FROM_CHUNK", "IN_COMMUNITY", "PARENT_COMMUNITY"}
+)
+
+# Reserved labels — skipped when picking a node's display label.
+_NEIGHBORHOOD_RESERVED_LABELS: frozenset[str] = frozenset(
+    {
+        "__Entity__",
+        "__KGBuilder__",
+        "__Platform__",
+        "__Chat__",
+        "__Community__",
+        "__Rebac__",
+        "__System__",
+    }
+)
+
+# Node properties never emitted to the browser.
+_NEIGHBORHOOD_DROPPED_PROPS: frozenset[str] = frozenset({"embedding", "graph_id", "id"})
+
+
+def _neighborhood_display_label(labels: list[str]) -> str:
+    """Pick the first non-reserved label; fall back to 'Entity'."""
+    for lbl in labels:
+        if lbl not in _NEIGHBORHOOD_RESERVED_LABELS:
+            return lbl
+    return "Entity"
+
+
+def _neighborhood_clean_props(props: dict[str, Any]) -> dict[str, Any]:
+    """Drop internal properties; coerce Neo4j temporal/spatial values."""
+
+    def _coerce(v: Any) -> Any:
+        if isinstance(v, DateTime | Date | Time | Duration):
+            return v.iso_format()
+        if isinstance(v, Point):
+            return list(v)
+        if isinstance(v, list | tuple):
+            return [_coerce(i) for i in v]
+        if isinstance(v, dict):
+            return {k2: _coerce(v2) for k2, v2 in v.items()}
+        return v
+
+    return {
+        k: _coerce(val)
+        for k, val in props.items()
+        if k not in _NEIGHBORHOOD_DROPPED_PROPS
+    }
+
+
+async def get_entity_neighborhood(
+    driver: AsyncDriver,
+    *,
+    graph_id: str,
+    entity_id: str,
+    hops: int = 2,
+    edge_types: list[str] | None = None,
+) -> dict:
+    """Return an N-hop entity neighborhood subgraph around a focal entity.
+
+    ``hops`` is validated server-side to {1, 2, 3} and embedded as a literal
+    integer in the Cypher path pattern — never interpolated from raw user input.
+    ``graph_id`` appears on every MATCH clause (multi-tenant safety).
+
+    Args:
+        driver: Async Neo4j driver (FastAPI context — use neo4j_client.async_driver).
+        graph_id: Tenant graph — scopes every Cypher MATCH clause.
+        entity_id: Focal entity's ``id`` property or elementId.
+        hops: Traversal depth; must be 1, 2, or 3.
+        edge_types: When provided, only edges of these relationship types are
+            returned in the response. All reachable entity nodes are still
+            included regardless of edge type.
+
+    Returns:
+        dict matching GraphDataResponse shape:
+        ``{"nodes": [...], "edges": [...], "truncated": bool}``
+    """
+    if hops not in (1, 2, 3):
+        raise ValueError(f"hops must be 1, 2, or 3; got {hops!r}")
+
+    # ---- Phase 0: resolve focal entity ---------------------------------
+    # If the entity does not exist in this graph, return an empty response.
+    focal_pre_query = """
+    MATCH (focal:__Entity__ {graph_id: $graph_id})
+    WHERE focal.id = $entity_id OR elementId(focal) = $entity_id
+    RETURN coalesce(focal.id, elementId(focal)) AS focal_id
+    LIMIT 1
+    """
+    async with driver.session() as session:
+        focal_result = await session.run(
+            focal_pre_query, {"graph_id": graph_id, "entity_id": entity_id}
+        )
+        focal_row = await focal_result.single()
+
+    if not focal_row:
+        return {"nodes": [], "edges": [], "truncated": False}
+
+    focal_id: str = focal_row["focal_id"]
+
+    # ---- Phase 1: focal entity + N-hop entity neighbors ----------------
+    # hops is a validated literal from {1,2,3} — safe to embed in Cypher.
+    # Neo4j does not support parameterized variable-length path bounds.
+    node_query = (
+        "MATCH (focal:__Entity__ {graph_id: $graph_id}) "
+        "WHERE focal.id = $entity_id OR elementId(focal) = $entity_id "
+        f"OPTIONAL MATCH (focal)-[*1..{hops}]-(neighbor:__Entity__ {{graph_id: $graph_id}}) "
+        "WITH focal, collect(DISTINCT neighbor) AS nbrs "
+        "WITH [focal] + [n IN nbrs WHERE n IS NOT NULL] AS all_nodes "
+        "UNWIND all_nodes AS n "
+        "WITH n, "
+        "     COUNT { "
+        "       MATCH (n)-[r {graph_id: $graph_id}]-(m:__Entity__ {graph_id: $graph_id}) "
+        "       RETURN DISTINCT r "
+        "     } AS degree "
+        "OPTIONAL MATCH (n)-[:IN_COMMUNITY {graph_id: $graph_id}]-> "
+        "               (c:__Community__ {graph_id: $graph_id, status: 'active'}) "
+        "WITH n, degree, c "
+        "ORDER BY coalesce(c.level, 2147483647) ASC "
+        "WITH n, degree, collect(c.id)[0] AS community_id "
+        "RETURN "
+        "  coalesce(n.id, elementId(n)) AS node_id, "
+        "  labels(n) AS node_labels, "
+        "  n.type AS node_type, "
+        "  degree, "
+        "  community_id, "
+        "  properties(n) AS node_props"
+    )
+    async with driver.session() as session:
+        node_result = await session.run(
+            node_query, {"graph_id": graph_id, "entity_id": entity_id}
+        )
+        node_rows = await node_result.data()
+
+    all_nodes: list[dict[str, Any]] = []
+    for nr in node_rows:
+        all_nodes.append(
+            {
+                "id": nr["node_id"],
+                "label": _neighborhood_display_label(nr["node_labels"] or []),
+                "type": nr.get("node_type"),
+                "community_id": nr.get("community_id"),
+                "degree": nr.get("degree") or 0,
+                "properties": _neighborhood_clean_props(nr.get("node_props") or {}),
+            }
+        )
+
+    # ---- Truncation: keep focal + highest-degree neighbors -------------
+    truncated = False
+    if len(all_nodes) > _NEIGHBORHOOD_MAX_NODES:
+        truncated = True
+        focal_nodes = [n for n in all_nodes if n["id"] == focal_id]
+        other_nodes = [n for n in all_nodes if n["id"] != focal_id]
+        other_nodes.sort(key=lambda n: n["degree"], reverse=True)
+        slots = _NEIGHBORHOOD_MAX_NODES - len(focal_nodes)
+        all_nodes = focal_nodes + other_nodes[:slots]
+
+    node_ids = [n["id"] for n in all_nodes]
+
+    # ---- Phase 2: induced edges among the node set ---------------------
+    # Exclude internal structural edge types; apply optional edge type filter.
+    # edge_types=None → $edge_types is null in Cypher → IS NULL check is true
+    # → all edge types pass the filter.
+    edges: list[dict[str, Any]] = []
+    if node_ids:
+        edge_query = """
+        MATCH (a:__Entity__ {graph_id: $graph_id})
+              -[r {graph_id: $graph_id}]->
+              (b:__Entity__ {graph_id: $graph_id})
+        WHERE coalesce(a.id, elementId(a)) IN $node_ids
+          AND coalesce(b.id, elementId(b)) IN $node_ids
+          AND NOT type(r) IN $excluded_types
+          AND ($edge_types IS NULL OR type(r) IN $edge_types)
+        RETURN elementId(r) AS id,
+               coalesce(a.id, elementId(a)) AS source,
+               coalesce(b.id, elementId(b)) AS target,
+               type(r) AS type,
+               toFloat(coalesce(r.weight, r.count, r.score, 1.0)) AS weight
+        """
+        async with driver.session() as session:
+            edge_result = await session.run(
+                edge_query,
+                {
+                    "graph_id": graph_id,
+                    "node_ids": node_ids,
+                    "excluded_types": list(_NEIGHBORHOOD_EXCLUDED_EDGE_TYPES),
+                    "edge_types": edge_types,
+                },
+            )
+            edge_rows = await edge_result.data()
+
+        for er in edge_rows:
+            edges.append(
+                {
+                    "id": er["id"],
+                    "source": er["source"],
+                    "target": er["target"],
+                    "type": er["type"],
+                    "weight": float(er["weight"]) if er["weight"] is not None else 1.0,
+                }
+            )
+
+    return {"nodes": all_nodes, "edges": edges, "truncated": truncated}

--- a/knowledge-graph-builder/tests/unit/test_entity_neighborhood.py
+++ b/knowledge-graph-builder/tests/unit/test_entity_neighborhood.py
@@ -1,0 +1,375 @@
+"""Unit tests for get_entity_neighborhood() (ORA-358 / ORA-378).
+
+Tests cover:
+- 1-hop, 2-hop, 3-hop traversal
+- edge_type filter
+- >300-node truncation (keep focal + highest-degree)
+- entity not found (returns empty response)
+- hops validation (out-of-range raises ValueError)
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.analytics_service import get_entity_neighborhood
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(rows: list[dict]) -> AsyncMock:
+    """Build a mock Neo4j result cursor."""
+    result = AsyncMock()
+    result.single = AsyncMock(return_value=rows[0] if rows else None)
+    result.data = AsyncMock(return_value=list(rows))
+    return result
+
+
+def _make_driver(*result_groups: list[dict]):
+    """Build a mock AsyncDriver whose session.run() returns each group in turn.
+
+    Each positional argument is a list[dict] returned for one session.run() call.
+    Calls beyond the supplied groups return an empty list.
+    """
+    results = [_make_result(g) for g in result_groups]
+    run_idx = [0]
+
+    async def fake_run(query, params=None):
+        idx = run_idx[0]
+        run_idx[0] += 1
+        return results[idx] if idx < len(results) else _make_result([])
+
+    mock_session = AsyncMock()
+    mock_session.run = fake_run
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_driver.session.return_value.__aexit__ = AsyncMock(return_value=None)
+    return mock_driver
+
+
+def _entity_row(
+    node_id: str,
+    name: str = "Entity",
+    degree: int = 1,
+    labels: list[str] | None = None,
+    node_type: str | None = None,
+    community_id: str | None = None,
+) -> dict:
+    return {
+        "node_id": node_id,
+        "node_labels": labels or ["__Entity__"],
+        "node_type": node_type,
+        "degree": degree,
+        "community_id": community_id,
+        "node_props": {"name": name},
+    }
+
+
+def _edge_row(
+    rel_id: str,
+    source: str,
+    target: str,
+    rel_type: str = "RELATES_TO",
+    weight: float = 1.0,
+) -> dict:
+    return {
+        "id": rel_id,
+        "source": source,
+        "target": target,
+        "type": rel_type,
+        "weight": weight,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHopsValidation:
+    @pytest.mark.unit
+    async def test_hops_0_raises(self):
+        driver = _make_driver()
+        with pytest.raises(ValueError, match="hops must be"):
+            await get_entity_neighborhood(driver, graph_id="g1", entity_id="e1", hops=0)
+
+    @pytest.mark.unit
+    async def test_hops_4_raises(self):
+        driver = _make_driver()
+        with pytest.raises(ValueError, match="hops must be"):
+            await get_entity_neighborhood(driver, graph_id="g1", entity_id="e1", hops=4)
+
+    @pytest.mark.unit
+    async def test_hops_negative_raises(self):
+        driver = _make_driver()
+        with pytest.raises(ValueError):
+            await get_entity_neighborhood(
+                driver, graph_id="g1", entity_id="e1", hops=-1
+            )
+
+
+class TestEntityNotFound:
+    @pytest.mark.unit
+    async def test_returns_empty_when_focal_not_found(self):
+        # Pre-query returns no rows → focal not in this graph
+        driver = _make_driver([])  # empty focal result
+
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="nonexistent"
+        )
+
+        assert result == {"nodes": [], "edges": [], "truncated": False}
+
+
+class TestOneHop:
+    @pytest.mark.unit
+    async def test_1_hop_returns_focal_and_direct_neighbors(self):
+        focal_row = {"focal_id": "e1"}
+        node_rows = [
+            _entity_row("e1", name="Focal", degree=2),
+            _entity_row("e2", name="Neighbor A", degree=1),
+            _entity_row("e3", name="Neighbor B", degree=1),
+        ]
+        edge_rows = [
+            _edge_row("r1", "e1", "e2"),
+            _edge_row("r2", "e1", "e3"),
+        ]
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="e1", hops=1
+        )
+
+        node_ids = {n["id"] for n in result["nodes"]}
+        assert node_ids == {"e1", "e2", "e3"}
+        assert len(result["edges"]) == 2
+        assert result["truncated"] is False
+
+    @pytest.mark.unit
+    async def test_1_hop_focal_only_when_no_neighbors(self):
+        focal_row = {"focal_id": "e1"}
+        node_rows = [_entity_row("e1", name="Isolated", degree=0)]
+        edge_rows: list[dict] = []
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="e1", hops=1
+        )
+
+        assert len(result["nodes"]) == 1
+        assert result["nodes"][0]["id"] == "e1"
+        assert result["edges"] == []
+        assert result["truncated"] is False
+
+
+class TestTwoHop:
+    @pytest.mark.unit
+    async def test_2_hop_default_includes_indirect_neighbors(self):
+        focal_row = {"focal_id": "e1"}
+        # e2 is direct neighbor; e3 is reached via e2 (2 hops)
+        node_rows = [
+            _entity_row("e1", name="Focal", degree=3),
+            _entity_row("e2", name="Direct", degree=2),
+            _entity_row("e3", name="Indirect", degree=1),
+        ]
+        edge_rows = [
+            _edge_row("r1", "e1", "e2"),
+            _edge_row("r2", "e2", "e3"),
+        ]
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(driver, graph_id="g1", entity_id="e1")
+
+        assert {n["id"] for n in result["nodes"]} == {"e1", "e2", "e3"}
+        assert result["truncated"] is False
+
+
+class TestThreeHop:
+    @pytest.mark.unit
+    async def test_3_hop_traversal(self):
+        focal_row = {"focal_id": "e1"}
+        node_rows = [
+            _entity_row("e1", degree=1),
+            _entity_row("e2", degree=2),
+            _entity_row("e3", degree=2),
+            _entity_row("e4", degree=1),
+        ]
+        edge_rows = [
+            _edge_row("r1", "e1", "e2"),
+            _edge_row("r2", "e2", "e3"),
+            _edge_row("r3", "e3", "e4"),
+        ]
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="e1", hops=3
+        )
+
+        assert {n["id"] for n in result["nodes"]} == {"e1", "e2", "e3", "e4"}
+        assert len(result["edges"]) == 3
+
+
+class TestEdgeTypeFilter:
+    @pytest.mark.unit
+    async def test_edge_type_filter_limits_returned_edges(self):
+        focal_row = {"focal_id": "e1"}
+        node_rows = [
+            _entity_row("e1", degree=2),
+            _entity_row("e2", degree=1),
+            _entity_row("e3", degree=1),
+        ]
+        # Only RELATES_TO edges survive the filter; HAS_PART is excluded
+        edge_rows = [
+            _edge_row("r1", "e1", "e2", rel_type="RELATES_TO"),
+        ]
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver,
+            graph_id="g1",
+            entity_id="e1",
+            edge_types=["RELATES_TO"],
+        )
+
+        # All nodes are returned; only RELATES_TO edges are in the response
+        assert {n["id"] for n in result["nodes"]} == {"e1", "e2", "e3"}
+        assert len(result["edges"]) == 1
+        assert result["edges"][0]["type"] == "RELATES_TO"
+
+    @pytest.mark.unit
+    async def test_no_edge_type_filter_returns_all_edges(self):
+        focal_row = {"focal_id": "e1"}
+        node_rows = [_entity_row("e1", degree=2), _entity_row("e2", degree=1)]
+        edge_rows = [_edge_row("r1", "e1", "e2", rel_type="OWNS")]
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="e1", edge_types=None
+        )
+
+        assert len(result["edges"]) == 1
+
+
+class TestTruncation:
+    @pytest.mark.unit
+    async def test_over_300_nodes_is_truncated(self):
+        focal_row = {"focal_id": "focal"}
+        # 301 nodes: focal + 300 neighbors, all with degree 1 except focal
+        node_rows = [_entity_row("focal", degree=300)]
+        node_rows += [_entity_row(f"e{i}", degree=i % 10 + 1) for i in range(300)]
+        edge_rows: list[dict] = []
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="focal", hops=1
+        )
+
+        assert result["truncated"] is True
+        assert len(result["nodes"]) == 300
+
+    @pytest.mark.unit
+    async def test_truncation_keeps_focal_node(self):
+        focal_row = {"focal_id": "focal"}
+        node_rows = [_entity_row("focal", degree=1)]
+        node_rows += [_entity_row(f"e{i}", degree=i) for i in range(300)]
+        edge_rows: list[dict] = []
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="focal", hops=2
+        )
+
+        assert result["truncated"] is True
+        focal_ids = [n["id"] for n in result["nodes"] if n["id"] == "focal"]
+        assert len(focal_ids) == 1, "focal node must always be present after truncation"
+
+    @pytest.mark.unit
+    async def test_truncation_keeps_highest_degree_neighbors(self):
+        focal_row = {"focal_id": "focal"}
+        # 301 nodes total; neighbors have degrees 1..300
+        node_rows = [_entity_row("focal", degree=300)]
+        node_rows += [_entity_row(f"e{i}", degree=i + 1) for i in range(300)]
+        edge_rows: list[dict] = []
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="focal", hops=1
+        )
+
+        # The 299 highest-degree neighbors should be e1..e299 (degree 300..2)
+        # e0 (degree 1) should be dropped
+        non_focal = [n for n in result["nodes"] if n["id"] != "focal"]
+        degrees = [n["degree"] for n in non_focal]
+        # All retained neighbors should have degree >= 2
+        assert min(degrees) >= 2
+
+    @pytest.mark.unit
+    async def test_exactly_300_nodes_not_truncated(self):
+        focal_row = {"focal_id": "focal"}
+        node_rows = [_entity_row("focal", degree=299)]
+        node_rows += [_entity_row(f"e{i}", degree=1) for i in range(299)]
+        edge_rows: list[dict] = []
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="focal", hops=2
+        )
+
+        assert result["truncated"] is False
+        assert len(result["nodes"]) == 300
+
+
+class TestResponseShape:
+    @pytest.mark.unit
+    async def test_node_shape_matches_graph_data_response(self):
+        focal_row = {"focal_id": "e1"}
+        node_rows = [
+            {
+                "node_id": "e1",
+                "node_labels": ["__Entity__", "Person"],
+                "node_type": "Person",
+                "degree": 3,
+                "community_id": "c-1",
+                "node_props": {"name": "Alice", "age": 30},
+            }
+        ]
+        edge_rows: list[dict] = []
+
+        driver = _make_driver([focal_row], node_rows, edge_rows)
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="e1", hops=1
+        )
+
+        node = result["nodes"][0]
+        assert node["id"] == "e1"
+        assert node["label"] == "Person"  # first non-reserved label
+        assert node["type"] == "Person"
+        assert node["community_id"] == "c-1"
+        assert node["degree"] == 3
+        assert "age" in node["properties"]
+
+    @pytest.mark.unit
+    async def test_embedding_dropped_from_properties(self):
+        focal_row = {"focal_id": "e1"}
+        node_rows = [
+            {
+                "node_id": "e1",
+                "node_labels": ["__Entity__"],
+                "node_type": None,
+                "degree": 0,
+                "community_id": None,
+                "node_props": {"name": "X", "embedding": [0.1, 0.2], "graph_id": "g1"},
+            }
+        ]
+        driver = _make_driver([focal_row], node_rows, [])
+        result = await get_entity_neighborhood(
+            driver, graph_id="g1", entity_id="e1", hops=1
+        )
+
+        props = result["nodes"][0]["properties"]
+        assert "embedding" not in props
+        assert "graph_id" not in props
+        assert "id" not in props


### PR DESCRIPTION
## Summary

- Adds `get_entity_neighborhood(driver, *, graph_id, entity_id, hops, edge_types)` to `analytics_service.py` as a standalone async function
- Returns `{nodes, edges, truncated}` matching the `GraphDataResponse` shape required by the Analytics Dashboard Relationship Browser (Panel 3, Gap #3)
- Follows the same driver-parameter pattern as `graph_data_service.get_graph_data()`

## Key Design Decisions

**Hops validation**: Validated server-side to `{1, 2, 3}` before any Cypher execution. The validated integer is embedded as a literal in the variable-length path pattern — Neo4j does not support parameterized path bounds, and user input never reaches Cypher.

**Multi-tenancy**: `graph_id` filter on every MATCH clause — focal entity pre-query, neighborhood traversal, induced edges query. No cross-tenant access possible.

**Focal always included**: Uses `OPTIONAL MATCH` for neighbors; focal entity is built into `[focal] + [n IN nbrs WHERE n IS NOT NULL]`. Isolated entities return as single-node responses.

**Truncation**: When the neighborhood exceeds 300 nodes, keeps focal + highest-degree neighbors first; `truncated: true` is set.

**Edge type filter**: Fully parameterized via `$edge_types IS NULL OR type(r) IN $edge_types` — no Cypher interpolation. Internal edges (`FROM_CHUNK`, `IN_COMMUNITY`, `PARENT_COMMUNITY`) excluded via `$excluded_types` parameter.

## Security Checklist

- [x] All Cypher queries parameterized
- [x] `graph_id` filter on every MATCH clause
- [x] Hops validated to `{1, 2, 3}` before embedding in Cypher (not raw user input)
- [x] No info leakage in error responses

## Test Plan

16 unit tests (all passing) covering:
- [ ] 1-hop traversal returns focal + direct neighbors
- [ ] 1-hop isolated entity returns focal-only
- [ ] 2-hop traversal includes indirect neighbors (default)
- [ ] 3-hop traversal
- [ ] `edge_types` filter restricts returned edges (nodes still included)
- [ ] No filter returns all edge types
- [ ] >300 nodes → truncated=true, 300 nodes returned, focal preserved
- [ ] Focal always kept after truncation
- [ ] Highest-degree neighbors prioritized in truncation
- [ ] Exactly 300 nodes → not truncated
- [ ] Entity not found → `{nodes: [], edges: [], truncated: false}`
- [ ] `hops=0`, `hops=4`, `hops=-1` all raise `ValueError`
- [ ] Node shape matches `GraphDataResponse` (label, type, degree, community_id, properties)
- [ ] `embedding`, `graph_id`, `id` dropped from node properties

## Files Changed

| File | Change |
|---|---|
| `knowledge-graph-builder/app/services/analytics_service.py` | Added neo4j imports + `_NEIGHBORHOOD_*` constants + helpers + `get_entity_neighborhood()` |
| `knowledge-graph-builder/tests/unit/test_entity_neighborhood.py` | New — 16 unit tests |

**Parent issue:** ORA-358 (entity neighborhood endpoint)
**Task:** ORA-378