### PR TITLE
feat(entities): GET /graphs/{graph_id}/entities endpoint (ORA-372)

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/entities.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/entities.py
@@ -1,6 +1,6 @@
 """GET /graphs/{graph_id}/entities — entity explorer endpoint (ORA-372)."""
 
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -12,8 +12,6 @@ from app.services.analytics_service import GraphAnalyticsService
 
 router = APIRouter()
 logger = get_logger(__name__)
-
-_VALID_SORT = {"confidence_desc", "name_asc", "degree_desc"}
 
 
 def _get_analytics_service() -> GraphAnalyticsService:
@@ -30,15 +28,15 @@ async def list_entities(
     q: Annotated[
         str | None, Query(description="Full-text search on name and aliases")
     ] = None,
-    type: Annotated[
+    type_: Annotated[
         list[str] | None,
-        Query(description="Filter by entity type (multi-value)"),
+        Query(alias="type", description="Filter by entity type (multi-value)"),
     ] = None,
     community_id: Annotated[
         str | None, Query(description="Filter by community id")
     ] = None,
     sort: Annotated[
-        str,
+        Literal["confidence_desc", "name_asc", "degree_desc"],
         Query(description="Sort order: confidence_desc | name_asc | degree_desc"),
     ] = "confidence_desc",
     page: Annotated[int, Query(ge=1, description="Page number (1-based)")] = 1,
@@ -55,17 +53,11 @@ async def list_entities(
     """
     await verify_graph_access(str(graph_id), "read", user_id)
 
-    if sort not in _VALID_SORT:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"sort must be one of {sorted(_VALID_SORT)}",
-        )
-
     try:
         result = await analytics.list_entities(
             graph_id=str(graph_id),
             q=q,
-            types=type,
+            types=type_,
             community_id=community_id,
             sort=sort,
             page=page,

--- a/knowledge-graph-builder/app/api/v1/endpoints/entities.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/entities.py
@@ -1,0 +1,86 @@
+"""GET /graphs/{graph_id}/entities — entity explorer endpoint (ORA-372)."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.api.dependencies import get_current_user_id, verify_graph_access
+from app.core.logging import get_logger
+from app.schemas.entity_schemas import EntityItem, EntityListResponse
+from app.services.analytics_service import GraphAnalyticsService
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+_VALID_SORT = {"confidence_desc", "name_asc", "degree_desc"}
+
+
+def _get_analytics_service() -> GraphAnalyticsService:
+    return GraphAnalyticsService()
+
+
+@router.get(
+    "/graphs/{graph_id}/entities",
+    response_model=EntityListResponse,
+    summary="List entities in a graph",
+)
+async def list_entities(
+    graph_id: UUID,
+    q: Annotated[
+        str | None, Query(description="Full-text search on name and aliases")
+    ] = None,
+    type: Annotated[
+        list[str] | None,
+        Query(description="Filter by entity type (multi-value)"),
+    ] = None,
+    community_id: Annotated[
+        str | None, Query(description="Filter by community id")
+    ] = None,
+    sort: Annotated[
+        str,
+        Query(description="Sort order: confidence_desc | name_asc | degree_desc"),
+    ] = "confidence_desc",
+    page: Annotated[int, Query(ge=1, description="Page number (1-based)")] = 1,
+    page_size: Annotated[int, Query(ge=1, le=200, description="Items per page")] = 50,
+    user_id: str = Depends(get_current_user_id),
+    analytics: GraphAnalyticsService = Depends(_get_analytics_service),
+) -> EntityListResponse:
+    """Return a paginated, filterable list of entities for a knowledge graph.
+
+    Supports full-text search on entity name and aliases, optional type and
+    community filters, three sort variants, and page-based pagination.
+
+    Auth: caller must have at least `read` access to the graph.
+    """
+    await verify_graph_access(str(graph_id), "read", user_id)
+
+    if sort not in _VALID_SORT:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"sort must be one of {sorted(_VALID_SORT)}",
+        )
+
+    try:
+        result = await analytics.list_entities(
+            graph_id=str(graph_id),
+            q=q,
+            types=type,
+            community_id=community_id,
+            sort=sort,
+            page=page,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        logger.error(f"list_entities failed for graph {graph_id}: {exc}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve entities",
+        ) from exc
+
+    return EntityListResponse(
+        items=[EntityItem(**item) for item in result["items"]],
+        total=result["total"],
+        page=result["page"],
+        page_size=result["page_size"],
+    )

--- a/knowledge-graph-builder/app/api/v1/router.py
+++ b/knowledge-graph-builder/app/api/v1/router.py
@@ -8,6 +8,7 @@ from app.api.v1.endpoints import (
     code_graphs,
     communities,
     connectors,
+    entities,
     evaluation,
     federation,
     graphs,
@@ -34,6 +35,7 @@ api_router = APIRouter()
 api_router.include_router(health.router, tags=["health"])
 api_router.include_router(graphs.router, tags=["graphs"])
 api_router.include_router(communities.router, tags=["communities"])
+api_router.include_router(entities.router, tags=["entities"])
 api_router.include_router(agents.router, tags=["agents"])
 api_router.include_router(llm_configs.router, tags=["llm-configs"])
 api_router.include_router(integration.router, tags=["integration"])

--- a/knowledge-graph-builder/app/schemas/entity_schemas.py
+++ b/knowledge-graph-builder/app/schemas/entity_schemas.py
@@ -1,0 +1,19 @@
+"""Pydantic schemas for the entity listing API (ORA-372)."""
+
+from pydantic import BaseModel
+
+
+class EntityItem(BaseModel):
+    id: str
+    name: str | None
+    type: str | None
+    confidence: float
+    community_id: str | None
+    degree: int
+
+
+class EntityListResponse(BaseModel):
+    items: list[EntityItem]
+    total: int
+    page: int
+    page_size: int

--- a/knowledge-graph-builder/tests/integration/test_entities_api.py
+++ b/knowledge-graph-builder/tests/integration/test_entities_api.py
@@ -134,6 +134,28 @@ class TestListEntitiesEndpoint:
 
     @pytest.mark.integration
     @pytest.mark.api
+    async def test_unknown_graph_returns_404(self, async_client):
+        """verify_graph_access raises HTTPException 404 for unknown graph → propagated."""
+        from fastapi import HTTPException
+
+        auth_patch = _patch_auth()
+        try:
+            with patch(
+                "app.api.v1.endpoints.entities.verify_graph_access",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=404, detail="Graph not found"),
+            ):
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 404
+
+    @pytest.mark.integration
+    @pytest.mark.api
     async def test_q_parameter_forwarded_to_service(self, async_client):
         """?q=alice is passed as q= to list_entities()."""
         service_result = _list_result([_entity_item("e-3", "Alice", "Person")])

--- a/knowledge-graph-builder/tests/integration/test_entities_api.py
+++ b/knowledge-graph-builder/tests/integration/test_entities_api.py
@@ -1,0 +1,265 @@
+"""Integration tests for GET /api/v1/graphs/{graph_id}/entities (ORA-372)."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+USER_ID = str(uuid.uuid4())
+GRAPH_ID = str(uuid.uuid4())
+FAKE_USER = {"id": USER_ID, "email": "test@example.com"}
+
+
+def _patch_auth():
+    p = patch("app.api.dependencies.auth_service")
+    mock_auth = p.start()
+    mock_auth.verify_token = AsyncMock(return_value=FAKE_USER)
+    return p
+
+
+def _auth_headers() -> dict:
+    return {"Authorization": "Bearer fake-token"}
+
+
+def _entity_item(
+    id: str = "e-1",
+    name: str = "Acme Corp",
+    type: str = "Organization",
+    confidence: float = 0.9,
+    community_id: str | None = "c-1",
+    degree: int = 5,
+) -> dict:
+    return {
+        "id": id,
+        "name": name,
+        "type": type,
+        "confidence": confidence,
+        "community_id": community_id,
+        "degree": degree,
+    }
+
+
+def _list_result(
+    items: list[dict], total: int = -1, page: int = 1, page_size: int = 50
+) -> dict:
+    return {
+        "items": items,
+        "total": total if total >= 0 else len(items),
+        "page": page,
+        "page_size": page_size,
+    }
+
+
+class TestListEntitiesEndpoint:
+    """GET /api/v1/graphs/{graph_id}/entities"""
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_happy_path_returns_entity_list_response(self, async_client):
+        """200 with items matching EntityListResponse schema."""
+        items = [
+            _entity_item("e-1", "Acme Corp", "Organization"),
+            _entity_item("e-2", "Alice", "Person", community_id=None, degree=2),
+        ]
+        service_result = _list_result(items, total=42)
+
+        auth_patch = _patch_auth()
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.entities.verify_graph_access",
+                    new_callable=AsyncMock,
+                ) as mock_vga,
+                patch("app.api.v1.endpoints.entities.GraphAnalyticsService") as MockSvc,
+            ):
+                mock_vga.return_value = GRAPH_ID
+                MockSvc.return_value.list_entities = AsyncMock(
+                    return_value=service_result
+                )
+
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 42
+        assert data["page"] == 1
+        assert data["page_size"] == 50
+        assert len(data["items"]) == 2
+
+        first = data["items"][0]
+        assert first["id"] == "e-1"
+        assert first["name"] == "Acme Corp"
+        assert first["type"] == "Organization"
+        assert first["confidence"] == 0.9
+        assert first["community_id"] == "c-1"
+        assert first["degree"] == 5
+
+        # community_id may be None
+        second = data["items"][1]
+        assert second["community_id"] is None
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_unauthenticated_returns_401(self, async_client):
+        """No token → 401 Unauthorized."""
+        response = await async_client.get(f"/api/v1/graphs/{GRAPH_ID}/entities")
+        assert response.status_code == 401
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_forbidden_graph_returns_403(self, async_client):
+        """verify_graph_access raises HTTPException 403 → propagated."""
+        from fastapi import HTTPException
+
+        auth_patch = _patch_auth()
+        try:
+            with patch(
+                "app.api.v1.endpoints.entities.verify_graph_access",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=403, detail="Forbidden"),
+            ):
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 403
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_q_parameter_forwarded_to_service(self, async_client):
+        """?q=alice is passed as q= to list_entities()."""
+        service_result = _list_result([_entity_item("e-3", "Alice", "Person")])
+
+        auth_patch = _patch_auth()
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.entities.verify_graph_access",
+                    new_callable=AsyncMock,
+                ) as mock_vga,
+                patch("app.api.v1.endpoints.entities.GraphAnalyticsService") as MockSvc,
+            ):
+                mock_vga.return_value = GRAPH_ID
+                mock_list = AsyncMock(return_value=service_result)
+                MockSvc.return_value.list_entities = mock_list
+
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities?q=alice",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 200
+        _call_kwargs = mock_list.call_args.kwargs
+        assert _call_kwargs["q"] == "alice"
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_multi_value_type_filter_forwarded(self, async_client):
+        """?type=concept&type=entity → types=["concept", "entity"]."""
+        service_result = _list_result([])
+
+        auth_patch = _patch_auth()
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.entities.verify_graph_access",
+                    new_callable=AsyncMock,
+                ) as mock_vga,
+                patch("app.api.v1.endpoints.entities.GraphAnalyticsService") as MockSvc,
+            ):
+                mock_vga.return_value = GRAPH_ID
+                mock_list = AsyncMock(return_value=service_result)
+                MockSvc.return_value.list_entities = mock_list
+
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities?type=concept&type=entity",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 200
+        _call_kwargs = mock_list.call_args.kwargs
+        assert sorted(_call_kwargs["types"]) == ["concept", "entity"]
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_invalid_sort_returns_422(self, async_client):
+        """An unrecognised sort value → 422 Unprocessable Entity."""
+        auth_patch = _patch_auth()
+        try:
+            with patch(
+                "app.api.v1.endpoints.entities.verify_graph_access",
+                new_callable=AsyncMock,
+                return_value=GRAPH_ID,
+            ):
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities?sort=bad_sort",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 422
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_page_size_clamped_at_200(self, async_client):
+        """page_size > 200 → 422 (FastAPI ge/le validation)."""
+        auth_patch = _patch_auth()
+        try:
+            with patch(
+                "app.api.v1.endpoints.entities.verify_graph_access",
+                new_callable=AsyncMock,
+                return_value=GRAPH_ID,
+            ):
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities?page_size=201",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 422
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    async def test_empty_result_returns_zero_total(self, async_client):
+        """Empty graph returns items=[], total=0."""
+        service_result = _list_result([], total=0)
+
+        auth_patch = _patch_auth()
+        try:
+            with (
+                patch(
+                    "app.api.v1.endpoints.entities.verify_graph_access",
+                    new_callable=AsyncMock,
+                ) as mock_vga,
+                patch("app.api.v1.endpoints.entities.GraphAnalyticsService") as MockSvc,
+            ):
+                mock_vga.return_value = GRAPH_ID
+                MockSvc.return_value.list_entities = AsyncMock(
+                    return_value=service_result
+                )
+
+                response = await async_client.get(
+                    f"/api/v1/graphs/{GRAPH_ID}/entities",
+                    headers=_auth_headers(),
+                )
+        finally:
+            auth_patch.stop()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"] == []
+        assert data["total"] == 0


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/graphs/{graph_id}/entities` FastAPI endpoint (entity explorer for the analytics dashboard).
- Implements `EntityItem` + `EntityListResponse` Pydantic schemas.
- Registers `entities` router in `router.py`.
- 7 integration tests covering auth (401/403), happy path, q search, multi-value type filter, invalid sort 422, page_size clamp 422.

**Stacked on PR #101** (`feature/ora-355/graph-dev/entity-list-service`) — merge #101 first, then rebase this onto `develop`.

## Acceptance criteria coverage

- [x] `verify_graph_access()` called before data access — no bypass
- [x] Multi-value `type` param: `?type=concept&type=entity` → `types=["concept","entity"]`
- [x] `page_size` clamped: ge=1, le=200 (FastAPI `Query` annotation)
- [x] Response matches `EntityListResponse` schema exactly
- [x] Router registered in `router.py` — endpoint visible in `/docs`
- [x] Integration tests: 401/403, happy path, q search, multi-value type, invalid sort 422, page_size > 200 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)