### PR TITLE
fix(auth): HTTPBearer auto_error=False — return 401 for missing auth (ORA-395)

### DIFF
--- a/knowledge-graph-builder/app/api/dependencies.py
+++ b/knowledge-graph-builder/app/api/dependencies.py
@@ -12,7 +12,7 @@ from app.core.database import async_session_maker, get_db
 from app.services.auth_service import auth_service
 from app.services.rebac_service import rebac_service
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 # Stores the resolved principal dict for the current request (set in get_current_user).
 # Enables verify_graph_access to route SA vs user permission checks without
@@ -23,9 +23,15 @@ _current_principal: contextvars.ContextVar[dict[str, Any] | None] = (
 
 
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict[str, Any]:
     """Dependency to get current authenticated user or service account principal."""
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     token = credentials.credentials
     user = await auth_service.verify_token(token)
     # Store principal in contextvar so verify_graph_access can branch on principal_type


### PR DESCRIPTION
## Summary

Single-file fix for ORA-395 / ORA-392: `HTTPBearer()` returns 403 by default for missing `Authorization` header. RFC 7235 requires 401 with `WWW-Authenticate: Bearer`.

**Change:** `app/api/dependencies.py` only (8 lines)
- `HTTPBearer(auto_error=False)` — disables default 403
- `credentials is None` guard in `get_current_user` raises `HTTP 401` with `WWW-Authenticate: Bearer`

## Security Checklist
- [x] No info leakage in error responses — 401 returns only "Not authenticated"
- [x] `WWW-Authenticate: Bearer` header present per RFC 7235
- [x] No changes to queries, graph_id filtering, or access control logic

## Test plan
- [x] `test_entities_api.py::TestListEntitiesEndpoint::test_unauthenticated_returns_401` passes (via PR #106)
- [x] All existing auth tests still pass
- [x] CI: Unit Tests, Lint & Format, Docker Build — awaiting results

Closes ORA-395 / ORA-392

🤖 Generated with [Claude Code](https://claude.com/claude-code)