### PR TITLE
fix(tests): SA integration test assertions for KGB error format + URL prefix (ORA-426)

### DIFF
--- a/knowledge-graph-builder/tests/integration/test_service_accounts_api.py
+++ b/knowledge-graph-builder/tests/integration/test_service_accounts_api.py
@@ -154,7 +154,7 @@ class TestServiceAccountFullLifecycle:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.post(
-                    f"/api/v1/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
+                    f"/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
                     json={
                         "name": "integration-test-sa",
                         "description": "created in integration tests",
@@ -193,7 +193,7 @@ class TestServiceAccountFullLifecycle:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -226,7 +226,7 @@ class TestServiceAccountFullLifecycle:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.post(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/rotate-key",
+                    f"/api/v1/service-accounts/{SA_ID}/rotate-key",
                     headers=_auth_headers(),
                 )
         finally:
@@ -261,7 +261,7 @@ class TestServiceAccountFullLifecycle:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.delete(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -302,7 +302,7 @@ class TestServiceAccountJWTAuthPath:
                 mock_dep_svc.check_sa_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -335,7 +335,7 @@ class TestServiceAccountJWTAuthPath:
                 mock_dep_svc.check_sa_graph_permission = AsyncMock(return_value=False)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -344,7 +344,7 @@ class TestServiceAccountJWTAuthPath:
             deps_p.stop()
 
         assert response.status_code == 403
-        assert response.json()["detail"] == "Access denied"
+        assert response.json()["message"] == "Permission denied"
 
     @pytest.mark.integration
     @pytest.mark.api
@@ -360,7 +360,7 @@ class TestServiceAccountJWTAuthPath:
                 mock_svc.get_service_account = AsyncMock(return_value=_SA_RECORD)
 
                 response = await async_client.post(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/graph-grants",
+                    f"/api/v1/service-accounts/{SA_ID}/graph-grants",
                     json={"graph_id": TARGET_GRAPH_ID, "level": "reader"},
                     headers=_auth_headers(),
                 )
@@ -370,7 +370,7 @@ class TestServiceAccountJWTAuthPath:
             deps_p.stop()
 
         assert response.status_code == 403
-        assert "cannot grant" in response.json()["detail"].lower()
+        assert response.json()["message"] == "Permission denied"
 
 
 # ---------------------------------------------------------------------------
@@ -400,7 +400,7 @@ class TestCrossGraphGrant:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.post(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/graph-grants",
+                    f"/api/v1/service-accounts/{SA_ID}/graph-grants",
                     json={"graph_id": TARGET_GRAPH_ID, "level": "reader"},
                     headers=_auth_headers(),
                 )
@@ -444,7 +444,7 @@ class TestCrossGraphGrant:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/graph-grants",
+                    f"/api/v1/service-accounts/{SA_ID}/graph-grants",
                     headers=_auth_headers(),
                 )
         finally:
@@ -478,7 +478,7 @@ class TestCrossGraphGrant:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.delete(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/graph-grants/{TARGET_GRAPH_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}/graph-grants/{TARGET_GRAPH_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -510,7 +510,7 @@ class TestCrossGraphGrant:
                 mock_dep_svc.check_sa_graph_permission = AsyncMock(return_value=False)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -548,7 +548,7 @@ class TestListRequiresAdmin:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
+                    f"/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
                     headers=_auth_headers(),
                 )
         finally:
@@ -572,7 +572,7 @@ class TestListRequiresAdmin:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=False)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
+                    f"/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
                     headers=_auth_headers(),
                 )
         finally:
@@ -581,7 +581,7 @@ class TestListRequiresAdmin:
             deps_p.stop()
 
         assert response.status_code == 403
-        assert response.json()["detail"] == "Access denied"
+        assert response.json()["message"] == "Permission denied"
 
     @pytest.mark.integration
     @pytest.mark.api
@@ -595,7 +595,7 @@ class TestListRequiresAdmin:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=False)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
+                    f"/api/v1/graphs/{HOME_GRAPH_ID}/service-accounts",
                     headers=_auth_headers(),
                 )
         finally:
@@ -604,8 +604,8 @@ class TestListRequiresAdmin:
             deps_p.stop()
 
         assert response.status_code == 403
-        detail = response.json()["detail"]
-        # Error detail must not leak graph_id or internal paths
+        detail = response.json()["message"]
+        # Error message must not leak graph_id or internal paths
         assert HOME_GRAPH_ID not in detail
         assert "/" not in detail
 
@@ -632,7 +632,7 @@ class TestCrossTenantIsolation:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=False)
 
                 response = await async_client.post(
-                    f"/api/v1/api/v1/graphs/{TARGET_GRAPH_ID}/service-accounts",
+                    f"/api/v1/graphs/{TARGET_GRAPH_ID}/service-accounts",
                     json={"name": "hijack-sa", "level": "reader"},
                     headers=_auth_headers(),
                 )
@@ -658,7 +658,7 @@ class TestCrossTenantIsolation:
                 mock_svc.get_service_account = AsyncMock(return_value=None)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -668,7 +668,7 @@ class TestCrossTenantIsolation:
 
         # Must return 403, not 404 — never reveal SA existence
         assert response.status_code == 403
-        assert response.json()["detail"] == "Access denied"
+        assert response.json()["message"] == "Permission denied"
 
     @pytest.mark.integration
     @pytest.mark.api
@@ -685,7 +685,7 @@ class TestCrossTenantIsolation:
                 mock_svc.get_service_account = AsyncMock(return_value=None)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{unknown_sa_id}",
+                    f"/api/v1/service-accounts/{unknown_sa_id}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -715,7 +715,7 @@ class TestCrossTenantIsolation:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=False)
 
                 response = await async_client.patch(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     json={"name": "updated-name"},
                     headers=_auth_headers(),
                 )
@@ -753,7 +753,7 @@ class TestRevokedSAToken:
         )
         try:
             response = await async_client.get(
-                f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                f"/api/v1/service-accounts/{SA_ID}",
                 headers=_auth_headers(),
             )
         finally:
@@ -763,11 +763,11 @@ class TestRevokedSAToken:
 
     @pytest.mark.integration
     @pytest.mark.api
-    async def test_missing_auth_header_returns_403(self, async_client):
-        """Request with no Authorization header → 403 (HTTPBearer rejects it)."""
-        response = await async_client.get(f"/api/v1/api/v1/service-accounts/{SA_ID}")
-        # HTTPBearer returns 403 when no credentials provided
-        assert response.status_code == 403
+    async def test_missing_auth_header_returns_401(self, async_client):
+        """Request with no Authorization header → 401 (HTTPBearer rejects it)."""
+        response = await async_client.get(f"/api/v1/service-accounts/{SA_ID}")
+        # HTTPBearer returns 401 when no credentials provided
+        assert response.status_code == 401
 
     @pytest.mark.integration
     @pytest.mark.api
@@ -789,7 +789,7 @@ class TestRevokedSAToken:
                 mock_dep_svc.check_sa_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}",
+                    f"/api/v1/service-accounts/{SA_ID}",
                     headers=_auth_headers(),
                 )
         finally:
@@ -862,7 +862,7 @@ class TestAuditLogEndpoint:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    f"/api/v1/service-accounts/{SA_ID}/audit-log",
                     headers=_auth_headers(),
                 )
         finally:
@@ -903,7 +903,7 @@ class TestAuditLogEndpoint:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    f"/api/v1/service-accounts/{SA_ID}/audit-log",
                     headers=_auth_headers(),
                 )
         finally:
@@ -942,7 +942,7 @@ class TestAuditLogEndpoint:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    f"/api/v1/service-accounts/{SA_ID}/audit-log",
                     params={"before": _T2},
                     headers=_auth_headers(),
                 )
@@ -965,7 +965,7 @@ class TestAuditLogEndpoint:
         auth_p = _patch_auth(FAKE_SA_PRINCIPAL)
         try:
             response = await async_client.get(
-                f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                f"/api/v1/service-accounts/{SA_ID}/audit-log",
                 headers=_auth_headers(),
             )
         finally:
@@ -993,7 +993,7 @@ class TestAuditLogEndpoint:
                 mock_rebac.check_graph_permission = AsyncMock(return_value=True)
 
                 response = await async_client.get(
-                    f"/api/v1/api/v1/service-accounts/{SA_ID}/audit-log",
+                    f"/api/v1/service-accounts/{SA_ID}/audit-log",
                     params={"before": "not-a-date"},
                     headers=_auth_headers(),
                 )


### PR DESCRIPTION
## Summary

- Fix 5× `response.json()["detail"]` → `["message"]` with value updated to `"Permission denied"`
- Fix 1× 403 → 401 with test renamed to `test_missing_auth_header_returns_401`
- Fix 26 URL prefix regressions: `/api/v1/api/v1/` → `/api/v1/` (TASK-090 regression)

## Context

This is a clean replacement for PR #115 which was rejected due to a branch scope violation (ORA-352 pipeline template code was included). This branch was created fresh from `origin/develop` and contains only commit `4c4c6fd6` (cherry-picked from the original fix branch).

## Related Issues
- Fixes: ORA-426
- Replaces: PR #115 (closed without merging)

## Test plan
- [ ] All 26 SA integration test URL prefix fixes verified
- [ ] 5 `["detail"]` → `["message"]` assertion corrections verified
- [ ] `test_missing_auth_header_returns_401` correctly expects 401
- [ ] CI passes: Lint, Docker Build, Unit Tests (1342/1342)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Agent: Backend Developer Senior
Task: ORA-433 / ORA-426