### PR TITLE
refactor(instructions): migrate InstructionsService to async_driver DI (ORA-441)

### DIFF
--- a/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
+++ b/knowledge-graph-builder/app/api/v1/endpoints/graphs.py
@@ -88,6 +88,7 @@ from app.services.background_job_service import background_job_service
 
 # Neo4j Services
 from app.services.graph_node_service import GraphNodeService
+from app.services.instructions_service import InstructionsService
 from app.services.llm_config_service import LLMConfigService
 from app.services.rollback_service import rollback_service
 from app.services.snapshot_service import snapshot_service
@@ -815,7 +816,7 @@ async def set_graph_instructions(
     graph_id: UUID,
     instructions: GraphInstructions,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Set or replace graph-level extraction instructions.
@@ -831,9 +832,9 @@ async def set_graph_instructions(
     # ReBAC check — write level required to set instructions
     await verify_graph_access(str(graph_id), "write", user_id)
 
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
-    return await instructions_service.set_instructions(str(graph_id), instructions)
+    return await svc.set_instructions(str(graph_id), instructions)
 
 
 @router.get(
@@ -848,7 +849,7 @@ async def set_graph_instructions(
 async def get_graph_instructions(
     graph_id: UUID,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Retrieve the current graph-level extraction instructions.
@@ -859,9 +860,9 @@ async def get_graph_instructions(
     # ReBAC check — read level required to view instructions
     await verify_graph_access(str(graph_id), "read", user_id)
 
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
-    result = await instructions_service.get_instructions(str(graph_id))
+    result = await svc.get_instructions(str(graph_id))
     if result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -883,7 +884,7 @@ async def get_graph_instructions(
 async def delete_graph_instructions(
     graph_id: UUID,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Delete graph-level extraction instructions and revert to free-form extraction.
@@ -895,9 +896,9 @@ async def delete_graph_instructions(
     # ReBAC check — admin level required to delete instructions
     await verify_graph_access(str(graph_id), "admin", user_id)
 
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
-    await instructions_service.delete_instructions(str(graph_id))
+    await svc.delete_instructions(str(graph_id))
 
 
 # ==================== MIGRATION ENDPOINT ====================
@@ -1034,7 +1035,7 @@ async def set_graph_ontology(
     graph_id: UUID,
     request: OntologySetRequest,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Replace the ontology on a graph — entity types, relationship types, and enforcement mode.
@@ -1043,10 +1044,10 @@ async def set_graph_ontology(
     Existing graph data is NOT modified; use the retroactive-apply endpoint for that.
     Invalidates the schema cache.
     """
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
     await _verify_graph_ownership(graph_id, user_id)
-    return await instructions_service.set_ontology(str(graph_id), request)
+    return await svc.set_ontology(str(graph_id), request)
 
 
 @router.get(
@@ -1061,17 +1062,17 @@ async def set_graph_ontology(
 async def get_graph_ontology(
     graph_id: UUID,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Retrieve the current ontology configuration for a graph.
 
     Returns `404` if no ontology has been configured. Free-form graphs have no ontology.
     """
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
     await _verify_graph_ownership(graph_id, user_id)
-    result = await instructions_service.get_ontology(str(graph_id))
+    result = await svc.get_ontology(str(graph_id))
     if result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1093,7 +1094,7 @@ async def patch_graph_ontology(
     graph_id: UUID,
     patch: OntologyPatchRequest,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Merge-update the graph ontology: add/remove individual type definitions or change the mode.
@@ -1101,10 +1102,10 @@ async def patch_graph_ontology(
     Types are matched by name. Adding a type that already exists replaces it.
     Invalidates the schema cache.
     """
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
     await _verify_graph_ownership(graph_id, user_id)
-    return await instructions_service.patch_ontology(str(graph_id), patch)
+    return await svc.patch_ontology(str(graph_id), patch)
 
 
 @router.delete(
@@ -1120,7 +1121,7 @@ async def patch_graph_ontology(
 async def delete_graph_ontology(
     graph_id: UUID,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Remove the ontology from a graph, reverting it to free-form extraction.
@@ -1129,10 +1130,10 @@ async def delete_graph_ontology(
     Previously extracted entities are NOT removed.
     Invalidates the schema cache.
     """
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
     await _verify_graph_ownership(graph_id, user_id)
-    await instructions_service.delete_ontology(str(graph_id))
+    await svc.delete_ontology(str(graph_id))
 
 
 @router.post(
@@ -1147,7 +1148,7 @@ async def delete_graph_ontology(
 async def validate_graph_ontology(
     graph_id: UUID,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Scan existing entities in the graph against the current ontology — no modifications.
@@ -1155,10 +1156,10 @@ async def validate_graph_ontology(
     Returns violation counts and a sample of offending entities. Use this to assess
     the impact before running retroactive-apply.
     """
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
     await _verify_graph_ownership(graph_id, user_id)
-    ontology = await instructions_service.get_ontology(str(graph_id))
+    ontology = await svc.get_ontology(str(graph_id))
     if ontology is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1243,7 +1244,7 @@ async def retroactive_apply_ontology(
     graph_id: UUID,
     request: RetroactiveApplyRequest,
     user_id: str = Depends(get_current_user_id),
-    _: AsyncDriver = Depends(get_neo4j_async_driver),  # 503 if Neo4j unavailable
+    driver: AsyncDriver = Depends(get_neo4j_async_driver),
 ):
     """
     Apply the current ontology enforcement to entities already in the graph.
@@ -1253,10 +1254,10 @@ async def retroactive_apply_ontology(
     - `dry_run=false, >10k entities`: dispatches a Celery background task and returns
       `celery_task_id`. Poll job status separately.
     """
-    from app.services.instructions_service import instructions_service
+    svc = InstructionsService(driver)
 
     await _verify_graph_ownership(graph_id, user_id)
-    ontology = await instructions_service.get_ontology(str(graph_id))
+    ontology = await svc.get_ontology(str(graph_id))
     if ontology is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/knowledge-graph-builder/app/services/instructions_service.py
+++ b/knowledge-graph-builder/app/services/instructions_service.py
@@ -11,8 +11,9 @@ import json
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from neo4j import AsyncDriver
+
 from app.core.logging import get_logger
-from app.core.neo4j_client import neo4j_client
 from app.schemas.graph_schemas import (
     EntityTypeDefinition,
     ExtractionDensity,
@@ -64,6 +65,9 @@ class InstructionsResolver:
     - overrides.extra_entity_types → appended to entity_types if any
     - overrides.schema_evolution_hint → appended to custom_prompt_suffix
     """
+
+    def __init__(self, driver: AsyncDriver) -> None:
+        self._driver = driver
 
     async def resolve(
         self,
@@ -147,10 +151,10 @@ class InstructionsResolver:
         RETURN g.instructions_config AS instructions_config
         """
         try:
-            records = await neo4j_client.execute_query(query, {"graph_id": graph_id})
-            if not records:
+            result = await self._driver.execute_query(query, {"graph_id": graph_id})
+            if not result.records:
                 return None
-            raw = records[0].get("instructions_config")
+            raw = result.records[0].get("instructions_config")
             if not raw:
                 return None
             data = json.loads(raw) if isinstance(raw, str) else raw
@@ -279,6 +283,9 @@ class InstructionsService:
     Stores on the Neo4j Graph node (authoritative) and in PostgreSQL schema_config (cache).
     """
 
+    def __init__(self, driver: AsyncDriver) -> None:
+        self._driver = driver
+
     async def set_instructions(
         self, graph_id: str, instructions: GraphInstructions
     ) -> GraphInstructionsResponse:
@@ -293,7 +300,7 @@ class InstructionsService:
             g.instructions_updated_at = datetime($updated_at)
         RETURN g.instructions_version AS version
         """
-        records = await neo4j_client.execute_query(
+        result = await self._driver.execute_query(
             query,
             {
                 "graph_id": graph_id,
@@ -302,7 +309,7 @@ class InstructionsService:
             },
         )
 
-        version = records[0]["version"] if records else 1
+        version = result.records[0]["version"] if result.records else 1
         logger.info(f"Set instructions v{version} for graph {graph_id}")
 
         return GraphInstructionsResponse(
@@ -320,11 +327,11 @@ class InstructionsService:
                g.instructions_version AS version,
                g.instructions_updated_at AS updated_at
         """
-        records = await neo4j_client.execute_query(query, {"graph_id": graph_id})
-        if not records:
+        result = await self._driver.execute_query(query, {"graph_id": graph_id})
+        if not result.records:
             return None
 
-        row = records[0]
+        row = result.records[0]
         raw_config = row.get("config")
         if not raw_config:
             return None
@@ -359,7 +366,7 @@ class InstructionsService:
         MATCH (g:Graph:__Platform__ {graph_id: $graph_id})
         REMOVE g.instructions_config, g.instructions_version, g.instructions_updated_at
         """
-        await neo4j_client.execute_query(query, {"graph_id": graph_id})
+        await self._driver.execute_query(query, {"graph_id": graph_id})
         logger.info(f"Deleted instructions for graph {graph_id}")
 
     # ==================== ONTOLOGY CRUD ====================
@@ -517,6 +524,4 @@ class InstructionsService:
 
 # ==================== GLOBAL INSTANCES ====================
 
-instructions_resolver = InstructionsResolver()
 instructions_compiler = InstructionsCompiler()
-instructions_service = InstructionsService()

--- a/knowledge-graph-builder/app/services/pipeline_service.py
+++ b/knowledge-graph-builder/app/services/pipeline_service.py
@@ -65,9 +65,9 @@ from app.schemas.graph_schemas import (
     TemporalFilter,
 )
 from app.services.instructions_service import (
+    InstructionsResolver,
     ResolvedInstructions,
     instructions_compiler,
-    instructions_resolver,
 )
 
 logger = get_logger(__name__)
@@ -450,7 +450,8 @@ class MultiTenantGraphRAGPipeline:
             start_time = datetime.now()
 
             # Resolve instructions once for all documents in this call
-            resolved = await instructions_resolver.resolve(self.graph_id, overrides)
+            resolver = InstructionsResolver(neo4j_client.async_driver)
+            resolved = await resolver.resolve(self.graph_id, overrides)
 
             # For large document sets, use background processing
             if len(documents) > 10 or background_tasks:

--- a/knowledge-graph-builder/tests/unit/test_instructions_service.py
+++ b/knowledge-graph-builder/tests/unit/test_instructions_service.py
@@ -9,7 +9,7 @@ Tests:
 """
 
 import warnings
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import ValidationError
@@ -25,6 +25,7 @@ from app.schemas.graph_schemas import (
 from app.services.instructions_service import (
     InstructionsCompiler,
     InstructionsResolver,
+    InstructionsService,
     ResolvedInstructions,
 )
 
@@ -33,8 +34,15 @@ from app.services.instructions_service import (
 # ---------------------------------------------------------------------------
 
 
+def _mock_driver():
+    """Return a minimal AsyncDriver mock."""
+    driver = MagicMock()
+    driver.execute_query = AsyncMock()
+    return driver
+
+
 def _make_resolver(instructions_json=None) -> InstructionsResolver:
-    resolver = InstructionsResolver()
+    resolver = InstructionsResolver(_mock_driver())
     resolver._load_from_neo4j = AsyncMock(
         return_value=(
             GraphInstructions(**instructions_json) if instructions_json else None
@@ -234,7 +242,7 @@ class TestInstructionsResolver:
 
     @pytest.mark.unit
     async def test_graph_id_passed_to_neo4j_loader(self):
-        resolver = InstructionsResolver()
+        resolver = InstructionsResolver(_mock_driver())
         resolver._load_from_neo4j = AsyncMock(return_value=None)
         await resolver.resolve("specific-graph-id")
         resolver._load_from_neo4j.assert_awaited_once_with("specific-graph-id")
@@ -331,3 +339,109 @@ class TestInstructionsCompiler:
     def test_language_included_in_rules(self):
         result = self._compile(language="fr")
         assert "fr" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: InstructionsService — CRUD with mock AsyncDriver
+# ---------------------------------------------------------------------------
+
+
+def _eager_result(records):
+    """Build a minimal EagerResult-like mock."""
+    mock = MagicMock()
+    mock.records = records
+    return mock
+
+
+def _record(**kwargs):
+    """Build a dict-like Record mock."""
+    r = MagicMock()
+    r.__getitem__ = lambda self, k: kwargs[k]
+    r.get = lambda k, default=None: kwargs.get(k, default)
+    return r
+
+
+_GID = "00000000-0000-0000-0000-000000000001"
+_GID2 = "00000000-0000-0000-0000-000000000002"
+
+
+class TestInstructionsService:
+    @pytest.mark.unit
+    async def test_set_instructions_uses_driver_and_returns_response(self):
+        driver = _mock_driver()
+        driver.execute_query.return_value = _eager_result([_record(version=3)])
+        svc = InstructionsService(driver)
+        inst = GraphInstructions(domain="finance")
+
+        resp = await svc.set_instructions(_GID, inst)
+
+        driver.execute_query.assert_awaited_once()
+        # graph_id must appear in parameters to satisfy multi-tenancy
+        assert driver.execute_query.call_args.args[1]["graph_id"] == _GID
+        assert resp.version == 3
+        assert resp.instructions.domain == "finance"
+
+    @pytest.mark.unit
+    async def test_set_instructions_version_defaults_to_1_when_no_records(self):
+        driver = _mock_driver()
+        driver.execute_query.return_value = _eager_result([])
+        svc = InstructionsService(driver)
+
+        resp = await svc.set_instructions(_GID, GraphInstructions())
+        assert resp.version == 1
+
+    @pytest.mark.unit
+    async def test_get_instructions_returns_none_when_no_records(self):
+        driver = _mock_driver()
+        driver.execute_query.return_value = _eager_result([])
+        svc = InstructionsService(driver)
+
+        result = await svc.get_instructions(_GID)
+        assert result is None
+
+    @pytest.mark.unit
+    async def test_get_instructions_returns_none_when_config_empty(self):
+        driver = _mock_driver()
+        driver.execute_query.return_value = _eager_result(
+            [_record(config=None, version=1, updated_at=None)]
+        )
+        svc = InstructionsService(driver)
+
+        result = await svc.get_instructions(_GID)
+        assert result is None
+
+    @pytest.mark.unit
+    async def test_get_instructions_deserializes_stored_json(self):
+        driver = _mock_driver()
+        inst = GraphInstructions(domain="legal")
+        driver.execute_query.return_value = _eager_result(
+            [_record(config=inst.model_dump_json(), version=2, updated_at=None)]
+        )
+        svc = InstructionsService(driver)
+
+        result = await svc.get_instructions(_GID)
+        assert result is not None
+        assert result.instructions.domain == "legal"
+        assert result.version == 2
+
+    @pytest.mark.unit
+    async def test_get_instructions_passes_graph_id(self):
+        driver = _mock_driver()
+        driver.execute_query.return_value = _eager_result([])
+        svc = InstructionsService(driver)
+
+        await svc.get_instructions(_GID2)
+        params = driver.execute_query.call_args.args[1]
+        assert params["graph_id"] == _GID2
+
+    @pytest.mark.unit
+    async def test_delete_instructions_calls_driver(self):
+        driver = _mock_driver()
+        driver.execute_query.return_value = _eager_result([])
+        svc = InstructionsService(driver)
+
+        await svc.delete_instructions(_GID)
+
+        driver.execute_query.assert_awaited_once()
+        params = driver.execute_query.call_args.args[1]
+        assert params["graph_id"] == _GID


### PR DESCRIPTION
## Summary

- `InstructionsResolver` and `InstructionsService` now accept `AsyncDriver` via `__init__` instead of calling the `neo4j_client` module-level singleton directly (copies the `LLMConfigService` pattern exactly)
- All 4 `execute_query` call sites updated to `self._driver.execute_query()` with `EagerResult.records` access
- `neo4j_client` import removed from `instructions_service.py`; module-level `instructions_resolver` and `instructions_service` singletons removed
- `graphs.py`: all 9 dead `_: AsyncDriver` params renamed to `driver`; `InstructionsService(driver)` instantiated per request
- `pipeline_service.py`: `InstructionsResolver(neo4j_client.async_driver)` constructed at call site
- Unit tests: existing `InstructionsResolver` tests updated to pass mock driver; 7 new `InstructionsService` tests added covering `set_instructions`, `get_instructions`, `delete_instructions`

Closes ORA-441 / ORA-448.
Based on `feature/phase1/sr-backend/ora-428-async-driver-di-graphs` (not yet merged to develop).

## Test plan

- [x] `uv run pytest tests/unit/test_instructions_service.py` — 41 passed
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — all files formatted
- [x] All pre-commit hooks passed
- [ ] CI: Unit Tests, Lint & Format, Docker Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)